### PR TITLE
Fix macOS typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal System Configuration
 
-A repository for personal system configurations, scripts, and documentation to make my MacOS setup reproducible and backed up.
+A repository for personal system configurations, scripts, and documentation to make my macOS setup reproducible and backed up.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- fix macOS spelling in documentation

## Testing
- `grep -n macOS -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6842400ec61483208e310a29901099aa