### PR TITLE
Fix fish PATH export syntax

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -16,4 +16,4 @@ end
 # Added by LM Studio CLI (lms)
 set -gx PATH $PATH /Users/abhimehrotra/.cache/lm-studio/bin
 
-export PATH="$PATH:$HOME/.local/bin"
+set -gx PATH $PATH $HOME/.local/bin


### PR DESCRIPTION
## Summary
- fix the PATH export syntax in fish config

## Testing
- `ls tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684240226214832092454fb1b79cd77b