### PR TITLE
Add test for fish config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ git clone https://github.com/yourusername/personal-config.git
 # or symbolic link them from your home directory
 ```
 
+## Tests
+
+To verify that the Fish shell configuration is valid, run:
+
+```bash
+./tests/test_config_fish.sh
+```
+
 ## License
 
 These configurations and scripts are for personal use, but feel free to use or adapt them if you find them helpful.

--- a/tests/test_config_fish.sh
+++ b/tests/test_config_fish.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Simple syntax check for config.fish
+set -euo pipefail
+
+# Determine repository root and config path
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_FILE="$REPO_ROOT/.config/fish/config.fish"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Config file not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+fish --no-execute "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- add a shell script that runs `fish --no-execute` against `.config/fish/config.fish`
- document how to run the test in the README

## Testing
- `./tests/test_config_fish.sh && echo "test ok"`

------
https://chatgpt.com/codex/tasks/task_e_6842408a39948320a5f479e55c70ae08