### PR TITLE
Add MacOS Resource Monitor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ personal-config/
 
 The [VPN Switching Guide](docs/vpn_switching_guide.md) documents the workflow for switching between Cloudflare WARP+Control D DNS and ProtonVPN configurations for different use cases. It includes step-by-step instructions, troubleshooting steps, and technical details.
 
+### MacOS Resource Monitor MCP Server
+
+The [MacOS Resource Monitor guide](docs/mac_resource_monitor_mcp.md) explains how to run the lightweight MCP server that exposes CPU, memory, and network usage on macOS. It covers installation, usage, integration with LLM clients, and troubleshooting tips.
+
 ## Future Additions
 
 This repository will grow to include:

--- a/docs/mac_resource_monitor_mcp.md
+++ b/docs/mac_resource_monitor_mcp.md
@@ -1,0 +1,63 @@
+# MacOS Resource Monitor MCP Server
+
+This document summarizes how to run and extend the MacOS Resource Monitor MCP server. The server exposes real‑time CPU, memory and network usage through the Model Context Protocol (MCP).
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Pratyay/mac-monitor-mcp.git
+   cd mac-monitor-mcp
+   ```
+2. (Optional) Create a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+3. Install the dependencies:
+   ```bash
+   pip install mcp
+   ```
+
+## Running the Server
+
+Start the MCP server with:
+```bash
+python src/monitor.py
+```
+You should see output similar to:
+```text
+Simple MacOS Resource Monitor MCP server starting...
+Monitoring CPU, Memory, and Network resource usage...
+```
+
+## Using `get_resource_intensive_processes()`
+
+The server exposes a single tool that returns JSON describing the most CPU, memory, and network intensive processes. Each entry contains fields such as `pid`, `cpu_percent`, `memory_percent`, and `network_connections`.
+
+## Integration with LLM Clients
+
+Add a server block to clients such as Cursor or Claude Desktop so they can call the MCP tool. After restarting the client, LLMs will prompt before invoking `get_resource_intensive_processes`.
+
+## Potential Enhancements
+
+- **Disk I/O Monitoring** – use `iostat` for device statistics or tools like `iosnoop`, `fs_usage`, or `iotop` for per‑process monitoring.
+- **Network Bandwidth** – leverage `psutil.net_io_counters(pernic=True)` to compute throughput per interface.
+- **Visualization Dashboard** – build a small Flask app with Chart.js or create plots with Matplotlib to visualize resource usage over time.
+- **Cross‑Platform Support** – replace direct `ps`/`lsof` calls with `psutil` to support Linux and Windows.
+
+## Troubleshooting
+
+- **Virtual Environment Problems** – confirm that Python 3.10+ is available and the virtual environment is activated before installing `mcp`.
+- **`lsof` Permissions** – run the server with elevated privileges or configure a sudoers rule to list all network connections.
+- **Missing Utilities** – if tools like `iostat` or `lsof` are missing, install Xcode command‑line tools using:
+  ```bash
+  xcode-select --install
+  ```
+
+## Resources
+
+- [MCP Python SDK](https://pypi.org/project/mcp/)
+- [MacOS Resource Monitor repository](https://github.com/Pratyay/mac-monitor-mcp)
+- [psutil documentation](https://psutil.readthedocs.io/en/latest/)
+


### PR DESCRIPTION
## Summary
- document how to run the MacOS Resource Monitor MCP server
- link the new guide from the README

## Testing
- `./tests/test_config_fish.sh` *(fails: Fish shell is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a4108b7a883209fc4687139d51f5f