### PR TITLE
🎨 Palette: Make youtube-download.sh interactive

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-02-18 - Smart Defaults in CLI Tools
+**Learning:** Users often run task-based scripts (like downloaders) with the intent already in their clipboard. Detecting this intent reduces friction.
+**Action:** When creating CLI tools that take a single primary input, check if the input can be safely inferred from the clipboard (e.g. `pbpaste`) when running interactively.
+
 ## 2026-01-20 - Visibility of Invisible States
 **Learning:** Users managing network privacy tools (VPN, DNS) need explicit confirmation of connection states. Assuming "configuration applied" equals "connected" leads to false security.
 **Action:** When reporting status for connectivity tools, always verify the actual interface state (e.g., `utun` existence) rather than just the configuration intent.

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -46,14 +46,37 @@ print_usage() {
 
 URL="${1:-}"
 
-if [[ -z "$URL" ]] || [[ "$URL" == "-h" ]] || [[ "$URL" == "--help" ]]; then
+if [[ "$URL" == "-h" ]] || [[ "$URL" == "--help" ]]; then
   print_usage
-  # Exit successfully if help was explicitly requested
-  if [[ "$URL" == "-h" ]] || [[ "$URL" == "--help" ]]; then
-    exit 0
-  else
-    exit 1
+  exit 0
+fi
+
+# Interactive mode if no URL provided and running in terminal
+if [[ -z "$URL" ]] && [[ -t 0 ]]; then
+  # Try to detect from clipboard (macOS)
+  if command -v pbpaste >/dev/null 2>&1; then
+    CLIP_CONTENT=$(pbpaste)
+    # Simple heuristic for YouTube URLs
+    if [[ "$CLIP_CONTENT" =~ ^https?://(www\.)?(youtube\.com|youtu\.be)/ ]]; then
+      echo -e "${YELLOW}${E_SEARCH} Found in clipboard: ${BOLD}$CLIP_CONTENT${NC}"
+      read -p "Use this URL? [Y/n] " -n 1 -r REPLY
+      echo "" # Newline
+      if [[ -z "$REPLY" ]] || [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        URL="$CLIP_CONTENT"
+      fi
+    fi
   fi
+
+  # Prompt if still empty
+  if [[ -z "$URL" ]]; then
+    echo -e "${BLUE}${E_SEARCH} Please enter the YouTube URL:${NC}"
+    read -r URL
+  fi
+fi
+
+if [[ -z "$URL" ]]; then
+  print_usage
+  exit 1
 fi
 
 header "${E_VIDEO} YouTube Downloader"


### PR DESCRIPTION
Improved UX for scripts/youtube-download.sh by adding an interactive mode.
- Detects if running in a terminal.
- Checks clipboard for YouTube URLs (using `pbpaste`).
- Prompts user for input if no argument provided.
- Preserves existing automation behavior (exit 1 on error) for non-interactive shells.

---
*PR created automatically by Jules for task [15158033243860920300](https://jules.google.com/task/15158033243860920300) started by @abhimehro*