### PR TITLE
🛡️ Sentinel: Fix insecure permissions on ControlD config files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-01-28 - Insecure File Permissions on Generated Configs
+**Vulnerability:** Information Disclosure (CWE-276) in `controld-manager`. The script generated configuration files containing sensitive Profile IDs in a directory created with default permissions (likely world-readable), and did not restrict the file permissions.
+**Learning:** `mkdir -p` and `cp` typically respect the umask or default to 755/644, which leaves files readable by all users on the system. Security-critical files must have explicit permission hardening.
+**Prevention:** Explicitly use `chmod 700` on directories and `chmod 600` on files containing sensitive information immediately after creation.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -143,6 +143,9 @@ check_root() {
 setup_directories() {
     log "Setting up directory structure..."
     mkdir -p "$PROFILES_DIR" "$BACKUP_DIR"
+    # 🛡️ Sentinel: Enforce strict permissions on directories containing sensitive configs
+    chmod 700 "$PROFILES_DIR" "$BACKUP_DIR" 2>/dev/null || true
+
     touch "$LOG_FILE" 2>/dev/null || true
     # Restrict log file to root-only (600) to protect sensitive profile IDs
     chmod 600 "$LOG_FILE" 2>/dev/null || true
@@ -283,6 +286,10 @@ generate_profile_config() {
     if [[ -f "$TEMP_CONFIG" ]]; then
         # Copy and customize the generated config
         cp "$TEMP_CONFIG" "$config_file"
+
+        # 🛡️ Sentinel: Enforce strict permissions on the config file (contains Profile ID)
+        chmod 600 "$config_file"
+
         # Cleanup handled by trap, but explicit remove doesn't hurt
         rm -f "$TEMP_CONFIG"
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Information Disclosure (CWE-276)

🚨 Severity: HIGH
💡 Vulnerability: ControlD profile configuration files containing sensitive Profile IDs were generated in directories with default permissions (likely world-readable), potentially allowing other local users to read the Profile IDs.
🎯 Impact: An attacker with local access could read the Profile ID and hijack the DNS configuration or use the paid DNS profile.
🔧 Fix: Explicitly enforced `chmod 700` on configuration directories and `chmod 600` on generated configuration files in `controld-system/scripts/controld-manager`.
✅ Verification: Code review and syntax check.


---
*PR created automatically by Jules for task [3297388024252597812](https://jules.google.com/task/3297388024252597812) started by @abhimehro*