### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Remove hardcoded user paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-01-23 - Hardcoded PII and Absolute Paths
+**Vulnerability:** Hardcoded absolute paths containing usernames (PII) in Python utility scripts (`adguard/scripts/*.py`).
+**Learning:** Developer convenience (copy-pasting working paths) often leads to non-portable and privacy-leaking code. Scripts intended for personal use often end up in shared repos without cleanup.
+**Prevention:** Use `Path.home()` (pathlib) or `os.path.expanduser("~")` to reference user directories dynamically. This ensures portability and protects developer identity.

--- a/adguard/scripts/consolidate_adblock_lists.py
+++ b/adguard/scripts/consolidate_adblock_lists.py
@@ -162,7 +162,7 @@ def print_summary(denylist_domains, allowlist_domains):
 
 def main():
     """Main consolidation workflow."""
-    base_dir = Path("/Users/abhimehrotra/Downloads")
+    base_dir = Path.home() / "Downloads"
     
     tracker_files = [
         "CD-Microsoft-Tracker.json",

--- a/adguard/scripts/create_consolidated_lists.py
+++ b/adguard/scripts/create_consolidated_lists.py
@@ -31,7 +31,11 @@ def extract_domains_from_file(filepath, action_filter=None):
 
 def main():
     # Allow overriding base directory for testing/portability
-    base_dir = Path(os.environ.get("ADGUARD_LISTS_DIR", "/Users/abhimehrotra/Downloads"))
+    base_dir_env = os.environ.get("ADGUARD_LISTS_DIR")
+    if base_dir_env:
+        base_dir = Path(base_dir_env)
+    else:
+        base_dir = Path.home() / "Downloads"
     
     print("🔍 Consolidating Ad-Blocking Lists...")
     print("=" * 50)

--- a/adguard/scripts/extract_domains.py
+++ b/adguard/scripts/extract_domains.py
@@ -30,7 +30,7 @@ def extract_allowlist_domains_from_file(filepath):
     return domains
 
 # Base directory
-base_dir = "/Users/abhimehrotra/Downloads"
+base_dir = os.path.join(os.path.expanduser("~"), "Downloads")
 
 # Tracker files for denylist
 tracker_files = [

--- a/adguard/scripts/fix-allowlist-format.py
+++ b/adguard/scripts/fix-allowlist-format.py
@@ -27,7 +27,7 @@ def extract_allowlist_domains_from_file(filepath):
     return domains
 
 def main():
-    base_dir = Path("/Users/abhimehrotra/Downloads")
+    base_dir = Path.home() / "Downloads"
     
     print("🔧 Fixing Allowlist Format for AdGuard")
     print("=" * 50)

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -3,12 +3,12 @@ import sys
 import os
 
 # Add the script directory to path to import the module
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../media-streaming/scripts')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../media-streaming/archive/scripts')))
 
 # Import the module
 import importlib.util
 spec = importlib.util.spec_from_file_location("infuse_media_server",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), '../media-streaming/scripts/infuse-media-server.py')))
+    os.path.abspath(os.path.join(os.path.dirname(__file__), '../media-streaming/archive/scripts/infuse-media-server.py')))
 infuse_media_server = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(infuse_media_server)
 


### PR DESCRIPTION
🛡️ Sentinel Security Fix

🚨 Severity: MEDIUM (Privacy/Portability)
💡 Vulnerability: Hardcoded absolute paths containing developer username in AdGuard Python scripts.
🎯 Impact: Exposes PII (username) and prevents scripts from working on other users' machines.
🔧 Fix: Replaced absolute paths with dynamic `Path.home()` resolution.
✅ Verification: Scripts now use `~/Downloads` regardless of the user. Syntax check passed.

---
*PR created automatically by Jules for task [12771850971742957063](https://jules.google.com/task/12771850971742957063) started by @abhimehro*