### PR TITLE
🛡️ Sentinel: Fix silent failure of security hardening on Linux

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-02-05 - Silent Failure of Security Hardening
+**Vulnerability:** The security hardening logic in `controld-manager` relied on non-portable `sed -i ''` syntax, which would fail silently on Linux systems, leaving the configuration insecure (Open Resolver vulnerability).
+**Learning:** Shell commands like `sed` and `mktemp` have platform-specific variants. Security logic that depends on these must handle portability to ensure the hardening actually executes.
+**Prevention:** Use portable syntax (e.g., `sed -i.bak` followed by `rm`) or explicit OS detection when writing shell scripts that modify security configurations.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -243,7 +243,7 @@ generate_profile_config() {
     # Generate configuration using ctrld
     # 🛡️ Sentinel: Use local variable and ensure cleanup
     local TEMP_CONFIG
-    TEMP_CONFIG=$(mktemp /tmp/ctrld_temp.toml.XXXXXX)
+    TEMP_CONFIG=$(mktemp)
     trap 'rm -f "$TEMP_CONFIG"' RETURN
 
     # Start service temporarily to generate config
@@ -290,12 +290,15 @@ generate_profile_config() {
         # 1. Strictly enforce localhost binding to prevent Open Resolver vulnerability
         # 2. Remove IPv6 wildcards
         # 3. Optimize timeout
-        sed -i '' -e "s/ip = ['\"]0.0.0.0['\"]/ip = \"127.0.0.1\"/g" \
+        # Note: Using -i.bak for cross-platform compatibility (macOS/Linux)
+        sed -i.bak -e "s/ip = ['\"]0.0.0.0['\"]/ip = \"127.0.0.1\"/g" \
                   -e "s/ip = ['\"]::['\"]/ip = \"127.0.0.1\"/g" \
                   -e 's/, "::\/0"//g' \
                   -e 's/"::\/0", //g' \
                   -e "s/timeout = 5000/timeout = 3000/g" \
                   "$config_file" 2>/dev/null || true
+        # Remove backup file
+        rm -f "$config_file.bak" 2>/dev/null || true
 
         # 🛡️ Sentinel: Verification
         # Ensure no wildcard bindings remain in the config


### PR DESCRIPTION
Fixes a critical security vulnerability where the `controld-manager` script fails to apply security hardening on Linux systems due to non-portable `sed` syntax. This leaves the service binding to 0.0.0.0 (all interfaces) instead of 127.0.0.1 (localhost), creating an Open Resolver vulnerability.

Changes:
- Replaced `sed -i ''` with `sed -i.bak` and immediate cleanup.
- Improved `mktemp` usage for portability.
- Added Sentinel Journal entry.

---
*PR created automatically by Jules for task [891822583618688263](https://jules.google.com/task/891822583618688263) started by @abhimehro*