### PR TITLE
🎨 Palette: Add 'Reveal in Finder' and audio feedback to downloader

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-05-24 - CLI Output Scanability
 **Learning:** For long-running maintenance scripts, users scan summary tables for failures and outliers (long durations). Standardizing column widths and using semantic colors (Red/Green) significantly reduces cognitive load.
 **Action:** Implement fixed-width summary tables with ANSI colors and duration tracking for all batch processing scripts.
+
+## 2026-02-26 - Post-Task Delight in CLI Tools
+**Learning:** Users feel a sense of completion and reduced friction when CLI tools automate the "next step" (e.g., revealing a downloaded file) or provide subtle confirmation (e.g., sound) for long-running tasks.
+**Action:** For file-producing CLI tools, add an option or default behavior to reveal the output location (e.g., `open -R`) and consider non-blocking audio cues for success.

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -68,10 +68,14 @@ if [[ -z "$URL" ]] && [[ -t 0 ]]; then
   fi
 
   # Prompt if still empty
-  if [[ -z "$URL" ]]; then
-    echo -e "${BLUE}${E_SEARCH} Please enter the YouTube URL:${NC}"
+  while [[ -z "$URL" ]]; do
+    echo -e "${BLUE}${E_SEARCH} Please enter the YouTube URL (or 'q' to quit):${NC}"
     read -r URL
-  fi
+    if [[ "$URL" == "q" ]]; then
+      echo "Exiting."
+      exit 0
+    fi
+  done
 fi
 
 if [[ -z "$URL" ]]; then
@@ -124,8 +128,14 @@ header "${E_DOWN} Starting Download"
 info "Target: $URL"
 info "Output: ~/Downloads"
 
+# 🎨 Palette: Reveal in Finder (macOS)
+REVEAL_ARGS=()
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  REVEAL_ARGS=(--exec "open -R {}")
+fi
+
 # Use -- to prevent argument injection
-"$YTDLP_CMD" "${EXTERNAL_DOWNLOADER_ARGS[@]}" -o "$HOME/Downloads/%(title)s.%(ext)s" -- "$URL"
+"$YTDLP_CMD" "${EXTERNAL_DOWNLOADER_ARGS[@]}" "${REVEAL_ARGS[@]}" -o "$HOME/Downloads/%(title)s.%(ext)s" -- "$URL"
 YTDLP_EXIT_CODE=$?
 
 if [[ $YTDLP_EXIT_CODE -ne 0 ]]; then
@@ -141,4 +151,9 @@ info "Video saved to ~/Downloads"
 # Optional: Notification
 if command -v terminal-notifier >/dev/null 2>&1; then
   terminal-notifier -title "Download Complete" -message "Video saved to Downloads"
+fi
+
+# 🎨 Palette: Audio feedback
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  afplay /System/Library/Sounds/Glass.aiff >/dev/null 2>&1 &
 fi


### PR DESCRIPTION
Improved the UX of `scripts/youtube-download.sh` by adding "delight" features and reducing friction.

Details:
- **Input Loop**: Replaced the single-pass input prompt with a `while` loop that robustly handles empty input and offers a clear 'q' to quit option.
- **Reveal in Finder**: On macOS, the script now automatically highlights the downloaded file in Finder using `open -R`, saving the user a navigation step.
- **Audio Feedback**: On macOS, a subtle system sound (`Glass.aiff`) is played upon successful completion, providing non-blocking feedback for this potentially long-running task.
- **Safety**: All new features are platform-gated (`$OSTYPE`) and use safe argument passing.

---
*PR created automatically by Jules for task [5499888140330439457](https://jules.google.com/task/5499888140330439457) started by @abhimehro*