### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credentials leak in process list

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-01-24 - Credentials in Process List
+**Vulnerability:** Information Disclosure (CWE-214) in `media-streaming/scripts/final-media-server.sh`. The script passed sensitive credentials (`--user`, `--pass`) as command-line arguments to `rclone serve webdav`, exposing them to any local user via `ps`.
+**Learning:** Command-line arguments are visible to all users on the system via the process table.
+**Prevention:** Use environment variables (e.g., `RCLONE_USER`, `RCLONE_PASS`) or file-based configuration to pass secrets to subprocesses.

--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -117,10 +117,12 @@ echo "   Mode: $INFO_MESSAGE"
 echo "   Bind Address: $BIND_ADDR:$AVAILABLE_PORT"
 
 # Start Rclone WebDAV (Performance Tuned)
+# 🛡️ Sentinel: Pass credentials via env vars to prevent leak in process list (CWE-214)
+export RCLONE_USER="$WEB_USER"
+export RCLONE_PASS="$WEB_PASS"
+
 nohup rclone serve webdav "media:" \
     --addr "$BIND_ADDR:$AVAILABLE_PORT" \
-    --user "$WEB_USER" \
-    --pass "$WEB_PASS" \
     --vfs-cache-mode full \
     --vfs-read-chunk-size 32M \
     --vfs-read-chunk-size-limit 2G \


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Vulnerability:** Information Disclosure (CWE-214)
**Impact:** HIGH. Any local user could view the WebDAV password by listing running processes.
**Fix:** Switched from CLI flags (`--user`, `--pass`) to environment variables (`RCLONE_USER`, `RCLONE_PASS`), which are hidden from other users.

Verified syntax with `bash -n`. This follows standard `rclone` security best practices.

---
*PR created automatically by Jules for task [4573352824312365028](https://jules.google.com/task/4573352824312365028) started by @abhimehro*