### PR TITLE
🎨 Palette: Instant CLI Menu for Network Manager

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-02-19 - Instant Menus in CLI
+**Learning:** Removing the need to press "Enter" for single-digit menu selections makes CLI tools feel significantly more responsive and modern.
+**Action:** Use `read -n 1` for numbered menus where choices are single digits.
+
 ## 2026-02-18 - Smart Defaults in CLI Tools
 **Learning:** Users often run task-based scripts (like downloaders) with the intent already in their clipboard. Detecting this intent reduces friction.
 **Action:** When creating CLI tools that take a single primary input, check if the input can be safely inferred from the clipboard (e.g. `pbpaste`) when running interactively.

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -289,8 +289,9 @@ interactive_menu() {
   echo -e "   5) ${E_INFO} Show Status"
   echo -e "   0) 🚪 Exit"
 
-  echo -ne "\n${BOLD}Select an option [1-5]: ${NC}"
-  read -r choice
+  echo -ne "\n${BOLD}Select an option [1-5, 0]: ${NC}"
+  read -n 1 -r choice
+  echo "" # Newline
 
   case "$choice" in
     1)    main "controld" "privacy" ;;


### PR DESCRIPTION
🎨 Palette: Instant CLI Menu for Network Manager

💡 **What:** Modified the interactive menu in `scripts/network-mode-manager.sh` to accept single-keypress input.
🎯 **Why:** To make the CLI tool feel snappier and more responsive by removing the need to press Enter after selecting an option.
📸 **Before:** Type `1`, press `Enter`.
📸 **After:** Type `1`, action starts immediately.
📚 **Journal:** Added entry about "Instant Menus in CLI".

---
*PR created automatically by Jules for task [4667923288855574559](https://jules.google.com/task/4667923288855574559) started by @abhimehro*