### PR TITLE
🛡️ Sentinel: Fix insecure default binding in media server scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-05-22 - Daemon Scripts Bypassing Secure Defaults
+**Vulnerability:** `media-server-daemon.sh` was hardcoded to bind to `0.0.0.0`, bypassing the secure options available in the interactive `final-media-server.sh`.
+**Learning:** Background/Daemon scripts often get less security scrutiny than interactive ones and may hardcode insecure conveniences.
+**Prevention:** Ensure daemon/service scripts inherit or duplicate the secure defaults of their interactive counterparts.

--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -28,6 +28,10 @@ DEFAULT_INTERFACE=$(route get default 2>/dev/null | grep interface | awk '{print
 echo "   Default Interface: $DEFAULT_INTERFACE"
 
 PRIMARY_IP=$(ifconfig | grep "inet " | grep -v 127.0.0.1 | head -1 | awk '{print $2}')
+if [[ -z "$PRIMARY_IP" ]]; then
+    PRIMARY_IP="127.0.0.1"
+    echo "   ⚠️  Could not detect LAN IP, defaulting to 127.0.0.1"
+fi
 echo "   🎯 Local IP: $PRIMARY_IP"
 
 # Check if connected via VPN (Windscribe)
@@ -107,8 +111,8 @@ case "$MODE" in
         INFO_MESSAGE="EXTERNAL Mode: Server listening on all interfaces (VPN: $VPN_CONNECTED)"
         ;;
     *)
-        BIND_ADDR="0.0.0.0"
-        INFO_MESSAGE="AUTO Mode: Server listening on all interfaces"
+        BIND_ADDR="$PRIMARY_IP"
+        INFO_MESSAGE="AUTO Mode: Server bound to $PRIMARY_IP"
         ;;
 esac
 

--- a/media-streaming/scripts/media-server-daemon.sh
+++ b/media-streaming/scripts/media-server-daemon.sh
@@ -21,6 +21,10 @@ sleep 2
 
 # Get network info
 PRIMARY_IP=$(ifconfig | grep "inet " | grep -v 127.0.0.1 | head -1 | awk '{print $2}')
+if [[ -z "$PRIMARY_IP" ]]; then
+    PRIMARY_IP="127.0.0.1"
+    log "WARNING: Could not detect LAN IP, defaulting to 127.0.0.1"
+fi
 PUBLIC_IP=$(curl -s --max-time 5 ifconfig.me 2>/dev/null || echo "unknown")
 
 log "Network: LAN=$PRIMARY_IP, Public=$PUBLIC_IP"
@@ -60,14 +64,14 @@ if [[ -z "$WEB_USER" || -z "$WEB_PASS" ]]; then
 fi
 
 log "✅ Credentials loaded"
-log "🚀 Starting rclone WebDAV server on 0.0.0.0:$AVAILABLE_PORT"
+log "🚀 Starting rclone WebDAV server on $PRIMARY_IP:$AVAILABLE_PORT"
 log "   User: $WEB_USER"
 log "   LAN Address: $PRIMARY_IP:$AVAILABLE_PORT"
 
 # Start rclone in FOREGROUND (no nohup, no &)
 # This keeps the script running so LaunchAgent can monitor it
 exec rclone serve webdav "media:" \
-    --addr "0.0.0.0:$AVAILABLE_PORT" \
+    --addr "$PRIMARY_IP:$AVAILABLE_PORT" \
     --user "$WEB_USER" \
     --pass "$WEB_PASS" \
     --vfs-cache-mode full \

--- a/tests/test_media_server_binding.sh
+++ b/tests/test_media_server_binding.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Setup Mock Bin
+MOCK_BIN=$(mktemp -d)
+export PATH="$MOCK_BIN:$PATH"
+
+# Setup Logs directory
+mkdir -p "$HOME/Library/Logs"
+
+# Mock utilities
+cat > "$MOCK_BIN/rclone" << 'EOF'
+#!/bin/bash
+if [[ "$1" == "listremotes" ]]; then
+    echo "media:"
+    exit 0
+fi
+if [[ "$1" == "serve" ]]; then
+    # Print arguments for verification
+    echo "MOCK_RCLONE_CMD: $@"
+    # Sleep to simulate running server
+    sleep 2
+    exit 0
+fi
+EOF
+
+cat > "$MOCK_BIN/op" << 'EOF'
+#!/bin/bash
+if [[ "$1" == "read" ]]; then
+    echo "mock-secret"
+    exit 0
+fi
+exit 1
+EOF
+
+cat > "$MOCK_BIN/lsof" << 'EOF'
+#!/bin/bash
+exit 1 # No ports listening
+EOF
+
+cat > "$MOCK_BIN/route" << 'EOF'
+#!/bin/bash
+echo "interface: en0"
+EOF
+
+cat > "$MOCK_BIN/curl" << 'EOF'
+#!/bin/bash
+echo "unknown"
+EOF
+
+cat > "$MOCK_BIN/pkill" << 'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+chmod +x "$MOCK_BIN/"*
+
+# Test media-server-daemon.sh
+echo "Testing media-server-daemon.sh..."
+OUTPUT=$(bash media-streaming/scripts/media-server-daemon.sh 2>&1)
+echo "$OUTPUT"
+
+if echo "$OUTPUT" | grep -q "MOCK_RCLONE_CMD:.*--addr 0.0.0.0"; then
+    echo "FAIL: media-server-daemon.sh still binding to 0.0.0.0"
+    exit 1
+elif echo "$OUTPUT" | grep -q "MOCK_RCLONE_CMD:.*--addr"; then
+     echo "PASS: media-server-daemon.sh bound to specific IP (not 0.0.0.0)"
+else
+     echo "FAIL: usage of --addr not found in output"
+     exit 1
+fi
+
+# Test final-media-server.sh (Auto mode)
+echo "Testing final-media-server.sh (Auto)..."
+# Reduce sleep in script to speed up test? The script sleeps 5.
+# We can just run it. The mock sleeps 2. script sleeps 5. process will be dead by check.
+# But we care about the LOG content.
+bash media-streaming/scripts/final-media-server.sh >/dev/null 2>&1
+
+LOG_CONTENT=$(cat "$HOME/Library/Logs/media-server.log")
+echo "LOG CONTENT:"
+echo "$LOG_CONTENT"
+
+if echo "$LOG_CONTENT" | grep -q "MOCK_RCLONE_CMD:.*--addr 0.0.0.0"; then
+    echo "FAIL: final-media-server.sh (Auto) still binding to 0.0.0.0"
+    exit 1
+elif echo "$LOG_CONTENT" | grep -q "MOCK_RCLONE_CMD:.*--addr"; then
+     echo "PASS: final-media-server.sh bound to specific IP (not 0.0.0.0)"
+else
+     echo "FAIL: usage of --addr not found in log"
+     exit 1
+fi
+
+# Clean up
+rm -rf "$MOCK_BIN"
+rm -f "$HOME/Library/Logs/media-server.log"
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
**Vulnerability Fix:** Insecure Default Binding (0.0.0.0)

**Impact:** The media server was listening on all interfaces by default, potentially exposing files to untrusted networks if the device roams or is connected to a VPN.

**Fix:** Changed default binding to the primary LAN IP. Added a fallback to localhost (127.0.0.1) if no LAN IP is found.

**Verification:** Added a regression test `tests/test_media_server_binding.sh` that mocks `rclone` and verifies the `--addr` argument.

---
*PR created automatically by Jules for task [13293653919583392074](https://jules.google.com/task/13293653919583392074) started by @abhimehro*