### PR TITLE
⚡ Bolt: Optimize VPN status check in network-mode-manager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-02-15 - Minimizing Service Downtime during Handover
 **Learning:** When stopping a critical network service (like a DNS proxy) that the OS depends on, the order of operations matters significantly for perceived downtime. Stopping the service first leaves the OS querying a dead port until the fallback configuration is applied.
 **Action:** Always restore the fallback network configuration (e.g., reset DNS to DHCP) *before* stopping the service that was handling the traffic. This ensures continuity of service during the shutdown process.
+
+## 2026-03-05 - Efficient Interface Enumeration
+**Learning:** Parsing full `ifconfig` output is inefficient and brittle. `ifconfig -l` provides a list of interface names instantly, allowing for targeted queries on specific interfaces (e.g., VPN tunnels) which is orders of magnitude faster and less error-prone than grepping massive text blobs.
+**Action:** Use `ifconfig -l` to iterate over interfaces when checking status, instead of piping full `ifconfig` output.


### PR DESCRIPTION
💡 **What:** Optimized the VPN status check in `scripts/network-mode-manager.sh` by replacing a full `ifconfig` dump and multiple `grep` pipes with a targeted loop using `ifconfig -l`.

🎯 **Why:** The original approach parsed the entire output of `ifconfig` (which can be very large on dev machines with many interfaces) to find a single VPN interface. This was inefficient and relied on brittle output formatting (assuming IP lines follow within 5 lines).

📊 **Impact:** 
- Faster execution of the `status` command.
- Reduced CPU overhead (avoiding process creation for multiple greps and massive text processing).
- More robust detection of VPN interfaces.

🔬 **Measurement:** 
- Verify `status` command output remains correct.
- Compare execution time (e.g. `time ./scripts/network-mode-manager.sh status`) before and after (expected to be faster on machines with many interfaces).

---
*PR created automatically by Jules for task [16736550757260846771](https://jules.google.com/task/16736550757260846771) started by @abhimehro*