### PR TITLE
🎨 Palette: Improve interactive menu prompt in network manager

### DIFF
--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -289,7 +289,7 @@ interactive_menu() {
   echo -e "   5) ${E_INFO} Show Status"
   echo -e "   0) 🚪 Exit"
 
-  echo -ne "\n${BOLD}Select an option [1-5]: ${NC}"
+  echo -ne "\n${BOLD}Select an option [0-5] (Enter for Default): ${NC}"
   read -r choice
 
   case "$choice" in


### PR DESCRIPTION
💡 **What**: Updated the interactive prompt in `scripts/network-mode-manager.sh`.
🎯 **Why**: The prompt incorrectly requested input in range `[1-5]` while option `0` was available. It also lacked explicit instruction for the default behavior (Enter key).
📸 **Change**: `Select an option [1-5]:` -> `Select an option [0-5] (Enter for Default):`

---
*PR created automatically by Jules for task [2614494606950923300](https://jules.google.com/task/2614494606950923300) started by @abhimehro*