### PR TITLE
🛡️ Sentinel: Fix critical credential exposure in media server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-01-24 - Credentials in Process List (CWE-214)
+**Vulnerability:** `media-streaming/scripts/final-media-server.sh` passed passwords as command-line arguments (`--user`, `--pass`) to `rclone`.
+**Learning:** Command-line arguments are visible to all users on the system via `ps aux` or `/proc` filesystem. This turns a local file permission issue into a system-wide credential leak.
+**Prevention:** Pass sensitive data (passwords, tokens) via environment variables (e.g., `RCLONE_USER`, `RCLONE_PASS`) or configuration files with restricted permissions (0600). Most CLI tools support this pattern.

--- a/adguard/scripts/create_consolidated_lists.py
+++ b/adguard/scripts/create_consolidated_lists.py
@@ -31,7 +31,7 @@ def extract_domains_from_file(filepath, action_filter=None):
 
 def main():
     # Allow overriding base directory for testing/portability
-    base_dir = Path(os.environ.get("ADGUARD_LISTS_DIR", "/Users/abhimehrotra/Downloads"))
+    base_dir = Path(os.environ.get("ADGUARD_LISTS_DIR", os.path.expanduser("~/Downloads")))
     
     print("🔍 Consolidating Ad-Blocking Lists...")
     print("=" * 50)

--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -117,10 +117,9 @@ echo "   Mode: $INFO_MESSAGE"
 echo "   Bind Address: $BIND_ADDR:$AVAILABLE_PORT"
 
 # Start Rclone WebDAV (Performance Tuned)
-nohup rclone serve webdav "media:" \
+# 🛡️ Sentinel: Pass credentials via env vars to prevent exposure in process table (ps aux)
+RCLONE_USER="$WEB_USER" RCLONE_PASS="$WEB_PASS" nohup rclone serve webdav "media:" \
     --addr "$BIND_ADDR:$AVAILABLE_PORT" \
-    --user "$WEB_USER" \
-    --pass "$WEB_PASS" \
     --vfs-cache-mode full \
     --vfs-read-chunk-size 32M \
     --vfs-read-chunk-size-limit 2G \


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Vulnerability:** [CRITICAL] Credentials in Process List (CWE-214)
**Impact:** `media-streaming/scripts/final-media-server.sh` was passing WebDAV credentials as command-line arguments to `rclone`. This made the password visible to any user on the system via `ps aux`.
**Fix:** Modified the script to pass credentials via environment variables (`RCLONE_USER` and `RCLONE_PASS`) which are hidden from the process table.

**Additional Improvements:**
- Fixed hardcoded user path in `adguard/scripts/create_consolidated_lists.py` to prevent information leak and improve portability.

**Verification:**
- Verified script syntax with `bash -n` and `python3 -m py_compile`.
- Confirmed logic using Rclone documentation for environment variable usage.

---
*PR created automatically by Jules for task [9881772433040572380](https://jules.google.com/task/9881772433040572380) started by @abhimehro*