### PR TITLE
⚡ Bolt: Optimize status check parsing in controld-manager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-02-15 - Minimizing Service Downtime during Handover
 **Learning:** When stopping a critical network service (like a DNS proxy) that the OS depends on, the order of operations matters significantly for perceived downtime. Stopping the service first leaves the OS querying a dead port until the fallback configuration is applied.
 **Action:** Always restore the fallback network configuration (e.g., reset DNS to DHCP) *before* stopping the service that was handling the traffic. This ensures continuity of service during the shutdown process.
+
+## 2026-02-18 - Small File Parsing with Bash vs Grep
+**Learning:** For small configuration files (like TOML/INI), a pure Bash `while read` loop with regex matching is faster than `grep | sed` pipelines because it avoids forking external processes. It also allows for more flexible parsing logic (e.g. handling mixed quote styles) without complex sed expressions.
+**Action:** Parse small, structured files using Bash loops and regex/parameter expansion instead of external tools when performance is a concern.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -480,8 +480,24 @@ show_status() {
         # Determine current profile and protocol
         if [[ -L "$CONTROLD_DIR/ctrld.toml" ]]; then
             local current_config=$(readlink "$CONTROLD_DIR/ctrld.toml")
-            local profile_name=$(basename "$current_config" | sed 's/ctrld\.\(.*\)\.toml/\1/')
-            local protocol=$(grep "type = " "$current_config" 2>/dev/null | sed "s/.*type = '\(.*\)'.*/\1/" || echo "unknown")
+
+            # ⚡ Bolt Optimization: Use Bash parameter expansion instead of sed
+            local profile_name=$(basename "$current_config")
+            profile_name="${profile_name#ctrld.}"
+            profile_name="${profile_name%.toml}"
+
+            # ⚡ Bolt Optimization: Use Bash built-in read loop instead of grep | sed pipeline
+            # This saves 2 process spawns and handles both single/double quotes.
+            local protocol="unknown"
+            if [[ -f "$current_config" ]]; then
+                while IFS= read -r line; do
+                    if [[ "$line" =~ type\ =\ [\'\"](.*)[\'\"] ]]; then
+                        protocol="${BASH_REMATCH[1]}"
+                        break
+                    fi
+                done < "$current_config"
+            fi
+
             local profile_id=$(get_profile_id "$profile_name")
             echo "Active Profile: $profile_name"
             echo "Profile ID: $(redact_profile_id "$profile_id")"


### PR DESCRIPTION
💡 **What:** Replaced `sed` based string extraction with Bash parameter expansion for profile names, and `grep | sed` pipeline with a Bash `while read` loop for protocol extraction in `controld-system/scripts/controld-manager`.
🎯 **Why:** To reduce the overhead of spawning external processes (`sed`, `grep`) in the status check function, which improves responsiveness. It also fixes a limitation where the original logic only supported single-quoted values.
📊 **Impact:** Reduces process forks by 3 calls per status check. Adds support for double-quoted configuration values.
🔬 **Measurement:** Verified with `tests/repro_parsing.sh` (created and deleted during verification) that the new logic produces identical results for legacy inputs and correctly handles double quotes. Existing tests `tests/test_controld_validation.sh` passed.

---
*PR created automatically by Jules for task [5638893552934211644](https://jules.google.com/task/5638893552934211644) started by @abhimehro*