### PR TITLE
🛡️ Sentinel: Fix variable scope in security reporting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-02-03 - Variable Scope in Bash Loops
+**Vulnerability:** Inaccurate reporting in `maintenance/bin/security_manager.sh`. The script used a pipe (`find ... | while ...`) to iterate over files and increment a counter variable. In Bash, the pipe runs the loop in a subshell, so the counter updates were lost when the loop finished.
+**Learning:** Logic bugs in security tools can mask the very vulnerabilities they are meant to detect. Modifying variables inside a piped loop is a common pitfall that leads to silent failures.
+**Prevention:** Use process substitution (`while ... done < <(command)`) instead of pipes when you need to modify variables in the parent shell scope from within a loop.

--- a/maintenance/bin/security_manager.sh
+++ b/maintenance/bin/security_manager.sh
@@ -276,10 +276,10 @@ EOF
         echo "$ssh_perms" >> "$security_report"
         
         # Check for overly permissive SSH files
-        find "$HOME/.ssh" -type f \( -perm -044 -o -perm -004 \) 2>/dev/null | while read -r file; do
+        while read -r file; do
             echo "⚠️  SSH file has overly permissive permissions: $file" >> "$security_report"
             ((security_issues++))
-        done
+        done < <(find "$HOME/.ssh" -type f \( -perm -044 -o -perm -004 \) 2>/dev/null)
     fi
     echo "" >> "$security_report"
     
@@ -410,12 +410,12 @@ cleanup_old_backups() {
     
     if [[ -d "$BACKUP_DIR" ]]; then
         # Find and delete old backups
-        find "$BACKUP_DIR" -name "config_backup_*.tar.gz" -type f -mtime +$retention_days | while read -r old_backup; do
+        while read -r old_backup; do
             local backup_name=$(basename "$old_backup")
             log_security "INFO" "Deleting old backup: $backup_name"
             rm -f "$old_backup"
             ((deleted_count++))
-        done
+        done < <(find "$BACKUP_DIR" -name "config_backup_*.tar.gz" -type f -mtime +$retention_days)
         
         if [[ $deleted_count -gt 0 ]]; then
             log_security "INFO" "Deleted $deleted_count old backups"


### PR DESCRIPTION
- Modified `maintenance/bin/security_manager.sh` to use process substitution (`while ... done < <(find ...)`) instead of pipes.
- This fixes a bug where `security_issues` and `deleted_count` variables were modified in a subshell and thus not preserved, leading to incorrect reporting.
- Added entry to Sentinel's journal.

---
*PR created automatically by Jules for task [2411689369578210949](https://jules.google.com/task/2411689369578210949) started by @abhimehro*