### PR TITLE
🎨 Palette: Add interactive dashboard to maintenance script

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-05-24 - CLI Output Scanability
 **Learning:** For long-running maintenance scripts, users scan summary tables for failures and outliers (long durations). Standardizing column widths and using semantic colors (Red/Green) significantly reduces cognitive load.
 **Action:** Implement fixed-width summary tables with ANSI colors and duration tracking for all batch processing scripts.
+
+## 2026-02-18 - Interactive Dashboards for Maintenance Scripts
+**Learning:** For complex maintenance scripts with multiple modes (weekly, monthly, specific tasks), users often forget the specific CLI arguments. An interactive dashboard (menu) when no arguments are provided reduces cognitive load and makes the tool more discoverable.
+**Action:** When no arguments are provided to a multi-mode script, present an interactive menu (using `read` and `case`) instead of showing an error or a silent default, unless running in a non-interactive environment (check `[[ -t 0 ]]`).

--- a/maintenance/bin/run_all_maintenance.sh
+++ b/maintenance/bin/run_all_maintenance.sh
@@ -374,6 +374,31 @@ print_summary() {
     echo "└────────────────────────────────────────────────────────────────────────┘" | tee -a "$MASTER_LOG"
 }
 
+# --- Interactive Menu ---
+
+interactive_menu() {
+    echo -e "\n${BOLD}${CYAN}🛠️  Maintenance System Control${NC}"
+    echo -e "${CYAN}   Select a maintenance task to run:${NC}\n"
+
+    echo -e "   1) ${GREEN}Weekly Maintenance${NC} (Health + Cleanup + Updates)"
+    echo -e "   2) ${YELLOW}Monthly Maintenance${NC} (Weekly + Deep Analysis)"
+    echo -e "   3) ${CYAN}Health Check Only${NC}"
+    echo -e "   4) ${CYAN}Quick Cleanup Only${NC}"
+    echo -e "   0) 🚪 Exit"
+
+    echo -ne "\n${BOLD}Select an option [1-4]: ${NC}"
+    read -r choice
+
+    case "$choice" in
+        1) run_weekly_maintenance ;;
+        2) export FORCE_RUN=1; run_monthly_maintenance ;;
+        3) run_script "health_check.sh" "critical" ;;
+        4) run_script "quick_cleanup.sh" "cleanup" ;;
+        0) echo "Exiting..."; exit 0 ;;
+        *) echo -e "${RED}Invalid option.${NC}"; exit 1 ;;
+    esac
+}
+
 # --- Execution Entry Point ---
 
 if [[ $# -eq 1 ]]; then
@@ -388,8 +413,13 @@ if [[ $# -eq 1 ]]; then
             ;;
     esac
 else
-    # Default
-    run_weekly_maintenance
+    # Interactive Menu if running in a terminal
+    if [[ -t 0 ]]; then
+        interactive_menu
+    else
+        # Default for non-interactive (cron/scripts)
+        run_weekly_maintenance
+    fi
 fi
 
 # Generate error summary if script exists


### PR DESCRIPTION
Added an interactive menu to `maintenance/bin/run_all_maintenance.sh` that appears when the script is run without arguments in a terminal. This improves discoverability of maintenance tasks (Weekly, Monthly, Health Check, Quick Cleanup) while preserving backward compatibility for automated cron jobs. Also updated `.Jules/palette.md` with relevant UX learnings.

---
*PR created automatically by Jules for task [15223838811589577227](https://jules.google.com/task/15223838811589577227) started by @abhimehro*