### PR TITLE
🛡️ Sentinel: Harden permissions for Control D configs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-02-04 - Insecure Permissions on Configuration Files
+**Vulnerability:** World-readable configuration files in `/etc/controld/profiles/` containing sensitive Profile IDs.
+**Learning:** Sensitive identifiers should be treated as secrets on disk to prevent unauthorized access by other local users. Inconsistency between log redaction and file permissions weakens defense in depth.
+**Prevention:** Explicitly set `chmod 600` on generated configuration files and `chmod 700` on their directories immediately after creation.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -143,6 +143,8 @@ check_root() {
 setup_directories() {
     log "Setting up directory structure..."
     mkdir -p "$PROFILES_DIR" "$BACKUP_DIR"
+    # 🛡️ Sentinel: Restrict permissions to root-only
+    chmod 700 "$PROFILES_DIR" "$BACKUP_DIR"
     touch "$LOG_FILE" 2>/dev/null || true
     # Restrict log file to root-only (600) to protect sensitive profile IDs
     chmod 600 "$LOG_FILE" 2>/dev/null || true
@@ -283,6 +285,8 @@ generate_profile_config() {
     if [[ -f "$TEMP_CONFIG" ]]; then
         # Copy and customize the generated config
         cp "$TEMP_CONFIG" "$config_file"
+        # 🛡️ Sentinel: Restrict permissions to root-only
+        chmod 600 "$config_file"
         # Cleanup handled by trap, but explicit remove doesn't hurt
         rm -f "$TEMP_CONFIG"
 

--- a/scripts/setup-controld.sh
+++ b/scripts/setup-controld.sh
@@ -68,6 +68,8 @@ log "Setting up configuration file..."
 # Ensure /etc/controld exists (controld-manager creates it usually, but we should ensure it here for the config)
 if [[ ! -d "/etc/controld" ]]; then
     sudo mkdir -p "/etc/controld"
+    # 🛡️ Sentinel: Restrict permissions to root-only
+    sudo chmod 700 "/etc/controld"
 fi
 
 if [[ ! -f "$ENV_DEST" ]]; then


### PR DESCRIPTION
🛡️ Sentinel Security Enhancement

**Vulnerability:** World-readable configuration files in `/etc/controld/profiles/` exposed sensitive Profile IDs to all local users.
**Fix:** Explicitly set `chmod 700` on configuration directories and `chmod 600` on generated config files immediately after creation.
**Impact:** Ensures that only the root user (or the user running the manager) can read sensitive configuration data, adhering to the principle of least privilege.

Changes:
- Modified `scripts/setup-controld.sh` to secure `/etc/controld` on creation.
- Modified `controld-system/scripts/controld-manager` to secure `$PROFILES_DIR` and `$config_file`.
- Added Sentinel Journal entry.

---
*PR created automatically by Jules for task [10251453984605307378](https://jules.google.com/task/10251453984605307378) started by @abhimehro*