### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation in controld-manager

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-01-23 - Insecure File Creation in Root Scripts
+**Vulnerability:** Insecure file creation (CWE-732/CWE-59) in `controld-system/scripts/controld-manager`. The script used `touch` followed by `chmod 600` on a log file in `/var/log`.
+**Learning:** Checking existence and setting permissions in two steps creates a race condition. If the target is a symlink (CWE-59), `chmod` follows it and changes permissions of the target file. While `/var/log` is usually root-owned on macOS, this pattern is dangerous in any shared or user-writable directory.
+**Prevention:** Use `umask` in a subshell (e.g., `(umask 077 && touch file)`) to create files with secure permissions atomically. Verify files are not symlinks (`-L`) before performing operations that follow them.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -143,9 +143,19 @@ check_root() {
 setup_directories() {
     log "Setting up directory structure..."
     mkdir -p "$PROFILES_DIR" "$BACKUP_DIR"
-    touch "$LOG_FILE" 2>/dev/null || true
+
+    # Securely create log file if it doesn't exist (with 600 permissions)
+    if [[ ! -e "$LOG_FILE" ]]; then
+        (umask 077 && touch "$LOG_FILE") 2>/dev/null || true
+    fi
+
     # Restrict log file to root-only (600) to protect sensitive profile IDs
-    chmod 600 "$LOG_FILE" 2>/dev/null || true
+    # 🛡️ Sentinel: Check for symlinks to prevent permission hijacking
+    if [[ -L "$LOG_FILE" ]]; then
+        log_warning "Log file $LOG_FILE is a symlink. Skipping permission change to prevent symlink attack."
+    elif [[ -f "$LOG_FILE" ]]; then
+        chmod 600 "$LOG_FILE" 2>/dev/null || true
+    fi
 }
 
 # Backup current network settings


### PR DESCRIPTION
This PR fixes a security vulnerability in `controld-system/scripts/controld-manager` where the script insecurely created and set permissions on its log file.

Changes:
- Modified `setup_directories` to use `(umask 077 && touch "$LOG_FILE")` for atomic secure creation.
- Added explicit check `[[ -L "$LOG_FILE" ]]` to prevent `chmod` from following symlinks.
- Updated `.jules/sentinel.md` with the security learning.

---
*PR created automatically by Jules for task [14984493984856957239](https://jules.google.com/task/14984493984856957239) started by @abhimehro*