### PR TITLE
⚡ Bolt: Optimize VPN status check in network-mode-manager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-02-15 - Minimizing Service Downtime during Handover
 **Learning:** When stopping a critical network service (like a DNS proxy) that the OS depends on, the order of operations matters significantly for perceived downtime. Stopping the service first leaves the OS querying a dead port until the fallback configuration is applied.
 **Action:** Always restore the fallback network configuration (e.g., reset DNS to DHCP) *before* stopping the service that was handling the traffic. This ensures continuity of service during the shutdown process.
+
+## 2026-05-25 - Robust parsing of network interface blocks
+**Learning:** Using `grep -A` to parse network interface blocks (like `ifconfig`) is fragile because the number of lines per interface varies. It can also lead to false positives if it bleeds into the next interface definition.
+**Action:** Use state-machine logic in `awk` (e.g. `/^iface/ {s=1} s && /prop/ {match} /^[a-z]/ {s=0}`) to reliably parse blocks and avoid process overhead from multiple pipes.

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -200,7 +200,8 @@ print_status() {
   # --- VPN Status ---
   local vpn_status
   # Check for utun interface with an IP address (standard for VPNs on macOS)
-  if ifconfig | grep -A5 "utun" | grep "inet " | grep -v "127.0.0.1" >/dev/null 2>&1; then
+  # ⚡ Bolt Optimization: Use single-pass awk to parse ifconfig instead of multiple grep pipes.
+  if ifconfig | awk '/^utun/ {s=1; next} s && /inet / && !/127\.0\.0\.1/ {f=1; exit} s && /^[a-z]/ {s=0} END {exit !f}' >/dev/null 2>&1; then
     vpn_status="${GREEN}CONNECTED${NC}"
   else
     vpn_status="${RED}DISCONNECTED${NC}"


### PR DESCRIPTION
💡 What: Replaced `ifconfig | grep -A5 "utun" | grep "inet " | grep -v "127.0.0.1"` with a state-aware `awk` command.
🎯 Why: The original check was inefficient (3 forks) and fragile (assumed fixed line count).
📊 Impact: Reduced process overhead and eliminated potential false positives from interface bleeding.
🔬 Measurement: Verified with a reproduction script covering various interface scenarios.

---
*PR created automatically by Jules for task [5540085483240857705](https://jules.google.com/task/5540085483240857705) started by @abhimehro*