### PR TITLE
🎨 Palette: Add active state indicators to Network Mode Manager

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-05-24 - CLI Output Scanability
 **Learning:** For long-running maintenance scripts, users scan summary tables for failures and outliers (long durations). Standardizing column widths and using semantic colors (Red/Green) significantly reduces cognitive load.
 **Action:** Implement fixed-width summary tables with ANSI colors and duration tracking for all batch processing scripts.
+
+## 2026-02-19 - Active State Indicators in Menus
+**Learning:** Users often forget the current system state when opening a configuration menu. Displaying the active state directly alongside menu options eliminates the need to run a separate "status" command.
+**Action:** In interactive selection menus, always highlight the currently active option (e.g., with a checkmark or "Active" label).

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -278,14 +278,64 @@ print_help() {
   echo -e ""
 }
 
+detect_active_state() {
+  IS_VPN_ACTIVE=false
+  IS_CTRLD_ACTIVE=false
+  CTRLD_PROFILE=""
+
+  # Check Windscribe (VPN)
+  # Look for utun interface excluding localhost
+  if ifconfig | grep -A5 "utun" | grep "inet " | grep -v "127.0.0.1" >/dev/null 2>&1; then
+    IS_VPN_ACTIVE=true
+  fi
+
+  # Check Control D
+  if pgrep -x "ctrld" >/dev/null 2>&1; then
+    IS_CTRLD_ACTIVE=true
+
+    # Try to detect profile (best effort without sudo)
+    local config_link="/etc/controld/ctrld.toml"
+    local target=""
+
+    if [[ -L "$config_link" ]]; then
+       target=$(readlink "$config_link" 2>/dev/null || echo "")
+    fi
+
+    if [[ -n "$target" ]]; then
+      local extracted_name
+      extracted_name=$(basename "$target")
+      extracted_name="${extracted_name#ctrld.}"
+      extracted_name="${extracted_name%.toml}"
+      CTRLD_PROFILE="$extracted_name"
+    fi
+  fi
+}
+
 interactive_menu() {
+  detect_active_state
+
+  local M_PRIV=""
+  local M_BROW=""
+  local M_GAME=""
+  local M_WIND=""
+
+  if $IS_CTRLD_ACTIVE; then
+    if [[ "$CTRLD_PROFILE" == "privacy" ]]; then M_PRIV=" ${GREEN}● (Active)${NC}"; fi
+    if [[ "$CTRLD_PROFILE" == "browsing" ]]; then M_BROW=" ${GREEN}● (Active)${NC}"; fi
+    if [[ "$CTRLD_PROFILE" == "gaming" ]]; then M_GAME=" ${GREEN}● (Active)${NC}"; fi
+  fi
+
+  if $IS_VPN_ACTIVE; then
+    M_WIND=" ${GREEN}● (Active)${NC}"
+  fi
+
   echo -e "\n${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
   echo -e "${BLUE}   Select a mode to apply:${NC}\n"
 
-  echo -e "   1) ${E_PRIVACY} Control D (Privacy)"
-  echo -e "   2) ${E_BROWSING} Control D (Browsing) ${YELLOW}[Default]${NC}"
-  echo -e "   3) ${E_GAMING} Control D (Gaming)"
-  echo -e "   4) ${E_VPN} Windscribe (VPN)"
+  echo -e "   1) ${E_PRIVACY} Control D (Privacy)${M_PRIV}"
+  echo -e "   2) ${E_BROWSING} Control D (Browsing) ${YELLOW}[Default]${NC}${M_BROW}"
+  echo -e "   3) ${E_GAMING} Control D (Gaming)${M_GAME}"
+  echo -e "   4) ${E_VPN} Windscribe (VPN)${M_WIND}"
   echo -e "   5) ${E_INFO} Show Status"
   echo -e "   0) 🚪 Exit"
 


### PR DESCRIPTION
💡 What: Added visual indicators (e.g., `● (Active)`) to the interactive menu in `scripts/network-mode-manager.sh` to show the currently active network mode and Control D profile.
🎯 Why: Users often forget which mode they are in. Seeing it in the menu prevents redundant switching and provides reassurance (Journal: "Visibility of Invisible States").

📸 Before:
```
   1) 🛡️ Control D (Privacy)
   2) 🌐 Control D (Browsing) [Default]
```

📸 After:
```
   1) 🛡️ Control D (Privacy)  ● (Active)
   2) 🌐 Control D (Browsing) [Default]
```

♿ Accessibility: Uses color and text ("Active") to denote state, improving scanability.

---
*PR created automatically by Jules for task [13134460049874570757](https://jules.google.com/task/13134460049874570757) started by @abhimehro*