### PR TITLE
⚡ Bolt: Optimize network verification performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-02-15 - Minimizing Service Downtime during Handover
 **Learning:** When stopping a critical network service (like a DNS proxy) that the OS depends on, the order of operations matters significantly for perceived downtime. Stopping the service first leaves the OS querying a dead port until the fallback configuration is applied.
 **Action:** Always restore the fallback network configuration (e.g., reset DNS to DHCP) *before* stopping the service that was handling the traffic. This ensures continuity of service during the shutdown process.
+
+## 2026-05-23 - Service Verification Performance Trade-offs
+**Learning:** `lsof` on macOS is extremely slow (seconds) for checking port bindings. For high-frequency verification scripts, combining `pgrep` (process exists) with functional tests (e.g., `dig`) is a valid performance optimization, even if it theoretically sacrifices the strict "process owns port" check.
+**Action:** When optimizing service verifiers, replace `lsof` with `pgrep` + functional checks, documenting the "hijack" risk trade-off.


### PR DESCRIPTION
⚡ Bolt: Optimize network verification performance

💡 What:
- Replaced `sudo launchctl list | grep ...` with `pgrep -x "ctrld"`.
- Removed `sudo lsof -nPi :53` checks.
- Optimized `scutil --dns` parsing.

🎯 Why:
- `lsof` on macOS can take seconds to run, slowing down verification.
- `launchctl list` is heavier than `pgrep`.
- "Verify" scripts are often run in hot paths or loops, so speed matters.

📊 Impact:
- Reduces verification time by ~1-2 seconds per run (depending on `lsof` speed).

🔬 Measurement:
- `time ./scripts/network-mode-verify.sh controld` should show reduced execution time (excluding `dig` timeouts if offline).
- `dig` functional tests ensure the service is actually working, mitigating the removal of strict port binding checks.

---
*PR created automatically by Jules for task [9885104625875968774](https://jules.google.com/task/9885104625875968774) started by @abhimehro*