### PR TITLE
🛡️ Sentinel: Fix potential path traversal vulnerability in backup restoration

### DIFF
--- a/maintenance/bin/security_manager.sh
+++ b/maintenance/bin/security_manager.sh
@@ -147,6 +147,22 @@ EOF
     fi
 }
 
+# Security check for backup contents
+check_backup_safety() {
+    local backup_file="$1"
+
+    log_security "INFO" "Verifying backup safety: $backup_file"
+
+    # Check for absolute paths or directory traversal
+    if tar -tf "$backup_file" 2>/dev/null | grep -qE '(^|/)\.\.(/|$)|^/'; then
+        log_security "ERROR" "Security check failed: Backup contains unsafe paths (absolute or relative path traversal)"
+        return 1
+    fi
+
+    log_security "INFO" "Backup safety check passed"
+    return 0
+}
+
 # Restore configuration from backup
 restore_config() {
     local backup_file="$1"
@@ -162,6 +178,13 @@ restore_config() {
     local temp_dir=$(mktemp -d)
     local backup_name=$(basename "$backup_file" .tar.gz)
     
+    # Verify backup safety before extraction
+    if ! check_backup_safety "$backup_file"; then
+        log_security "ERROR" "Backup verification failed - aborting restore"
+        rm -rf "$temp_dir"
+        return 1
+    fi
+
     # Extract backup
     cd "$temp_dir" && tar -xzf "$backup_file" 2>/dev/null
     
@@ -448,8 +471,12 @@ verify_recovery_readiness() {
     # Check backup integrity
     if [[ -n "$recent_backup" ]]; then
         if tar -tzf "$recent_backup" >/dev/null 2>&1; then
-            echo "✅ Recent backup integrity verified"
-            readiness_score=$((readiness_score + 20))
+            if check_backup_safety "$recent_backup" >/dev/null 2>&1; then
+                echo "✅ Recent backup integrity and safety verified"
+                readiness_score=$((readiness_score + 20))
+            else
+                echo "❌ Recent backup contains unsafe paths"
+            fi
         else
             echo "❌ Recent backup appears corrupted"
         fi


### PR DESCRIPTION
This change adds a security check to `maintenance/bin/security_manager.sh` to prevent path traversal (Zip Slip/Tar Slip) vulnerabilities when restoring backups.
It validates the contents of the tar archive before extraction, ensuring that no files contain absolute paths or relative path traversals (`..`).
If unsafe paths are detected, the restoration is aborted and an error is logged.
This protects the system from malicious or malformed backup files that could overwrite critical system files.

---
*PR created automatically by Jules for task [12936731552087854900](https://jules.google.com/task/12936731552087854900) started by @abhimehro*