### PR TITLE
🎨 Palette: Improve interactive menu in network-mode-manager

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-02-18 - Discoverability of Hybrid Modes
+**Learning:**  Users often miss powerful "hybrid" configurations (like VPN + DNS) when they are only documented as CLI arguments. Exposing these combinations in the interactive menu significantly improves feature adoption.
+**Action:**  When designing interactive menus, group related options (e.g., "VPN Only" vs "Hybrid Mode") to guide users toward advanced configurations without overwhelming them.
+
 ## 2026-02-18 - Smart Defaults in CLI Tools
 **Learning:** Users often run task-based scripts (like downloaders) with the intent already in their clipboard. Detecting this intent reduces friction.
 **Action:** When creating CLI tools that take a single primary input, check if the input can be safely inferred from the clipboard (e.g. `pbpaste`) when running interactively.

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -279,27 +279,53 @@ print_help() {
 }
 
 interactive_menu() {
-  echo -e "\n${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
+  # Ensure we are in a terminal (unless testing)
+  if [[ ! -t 0 && -z "$TEST_MODE" ]]; then
+    error "Interactive mode requires a terminal."
+  fi
+
+  clear
+  echo -e "${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
   echo -e "${BLUE}   Select a mode to apply:${NC}\n"
 
-  echo -e "   1) ${E_PRIVACY} Control D (Privacy)"
-  echo -e "   2) ${E_BROWSING} Control D (Browsing) ${YELLOW}[Default]${NC}"
-  echo -e "   3) ${E_GAMING} Control D (Gaming)"
-  echo -e "   4) ${E_VPN} Windscribe (VPN)"
-  echo -e "   5) ${E_INFO} Show Status"
+  echo -e "   ${BOLD}Control D (DNS Only)${NC}"
+  echo -e "   1) ${E_PRIVACY} Privacy"
+  echo -e "   2) ${E_BROWSING} Browsing"
+  echo -e "   3) ${E_GAMING} Gaming"
+  echo -e ""
+  echo -e "   ${BOLD}Windscribe (VPN Only)${NC}"
+  echo -e "   4) ${E_VPN} Standalone"
+  echo -e ""
+  echo -e "   ${BOLD}Windscribe + Control D (Hybrid)${NC}"
+  echo -e "   5) ${E_VPN} + ${E_PRIVACY} Privacy"
+  echo -e "   6) ${E_VPN} + ${E_BROWSING} Browsing"
+  echo -e "   7) ${E_VPN} + ${E_GAMING} Gaming"
+  echo -e ""
+  echo -e "   ${BOLD}Other${NC}"
+  echo -e "   8) ${E_INFO} Show Status"
   echo -e "   0) 🚪 Exit"
 
-  echo -ne "\n${BOLD}Select an option [1-5]: ${NC}"
-  read -r choice
+  echo -ne "\n${BOLD}Select an option [0-8]: ${NC}"
+
+  # Read one character, silent (-s)
+  read -n 1 -s -r choice
+  echo "$choice" # Echo the choice so user sees what they typed
 
   case "$choice" in
     1)    main "controld" "privacy" ;;
-    2|"") main "controld" "browsing" ;;
+    2)    main "controld" "browsing" ;;
     3)    main "controld" "gaming" ;;
     4)    main "windscribe" ;;
-    5)    main "status" ;;
+    5)    main "windscribe" "privacy" ;;
+    6)    main "windscribe" "browsing" ;;
+    7)    main "windscribe" "gaming" ;;
+    8)    main "status" ;;
     0)    echo -e "${BLUE}Exiting...${NC}"; exit 0 ;;
-    *)    error "Invalid option" ;;
+    *)
+          echo -e "\n${RED}Invalid option '${choice}'${NC}"
+          sleep 1
+          interactive_menu
+          ;;
   esac
 }
 
@@ -376,4 +402,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/test_interactive_menu.sh
+++ b/tests/test_interactive_menu.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Test script for scripts/network-mode-manager.sh interactive menu
+
+# Enable TEST_MODE to skip TTY check
+export TEST_MODE=1
+
+# Mock dependencies
+# EUID=1000 # Read-only, rely on current user not being root
+sudo() { echo "sudo $@"; }
+command() { echo "mock command"; return 0; }
+clear() { echo "[CLEAR SCREEN]"; }
+error() { echo "ERROR: $@"; exit 1; }
+
+# Source the script (assuming it's modified to allow sourcing)
+# We use a trick to prevent the original main from running if it's not wrapped yet
+# but since we are modifying the script in the next step, this test might fail initially if run against unmodified script.
+# However, the plan says "Modify scripts/network-mode-manager.sh" in this step too.
+
+source scripts/network-mode-manager.sh
+
+# Mock main function to intercept calls
+main() {
+  echo "MOCK_MAIN_CALLED: $1 ${2:-}"
+}
+
+# Function to run a test case
+run_test() {
+  local input="$1"
+  local expected="$2"
+  local desc="$3"
+
+  echo "---------------------------------------------------"
+  echo "TEST: $desc"
+  echo "INPUT: '$input'"
+
+  # Pipe input to interactive_menu and capture output
+  # We use -n to avoid sending newline if read expects just 1 char
+  output=$(echo -n "$input" | interactive_menu)
+
+  # Check if mock main was called correctly
+  if echo "$output" | grep -q "$expected"; then
+    echo "PASS: Found expected call '$expected'"
+  else
+    echo "FAIL: Did not find '$expected'"
+    echo "OUTPUT WAS:"
+    echo "$output"
+    exit 1
+  fi
+}
+
+# Run tests
+run_test "1" "MOCK_MAIN_CALLED: controld privacy" "Option 1: Privacy"
+run_test "2" "MOCK_MAIN_CALLED: controld browsing" "Option 2: Browsing"
+run_test "3" "MOCK_MAIN_CALLED: controld gaming" "Option 3: Gaming"
+run_test "4" "MOCK_MAIN_CALLED: windscribe " "Option 4: Windscribe Standalone"
+run_test "5" "MOCK_MAIN_CALLED: windscribe privacy" "Option 5: Windscribe + Privacy"
+run_test "6" "MOCK_MAIN_CALLED: windscribe browsing" "Option 6: Windscribe + Browsing"
+run_test "7" "MOCK_MAIN_CALLED: windscribe gaming" "Option 7: Windscribe + Gaming"
+run_test "8" "MOCK_MAIN_CALLED: status " "Option 8: Status"
+run_test "0" "Exiting..." "Option 0: Exit"
+
+echo "---------------------------------------------------"
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
💡 What:
- Updated `scripts/network-mode-manager.sh` to use a cleaner, single-key interactive menu.
- Added options for "Windscribe + Control D" hybrid modes which were previously hidden.
- Wrapped `main` execution to allow sourcing for testing.
- Added `tests/test_interactive_menu.sh` to verify menu logic.

🎯 Why:
- Users were missing the powerful hybrid configurations because they were only available via CLI arguments.
- The previous menu required typing a number and pressing Enter, which felt clunky.
- Testing the menu logic was difficult without mocking `main`.

♿ Accessibility:
- Grouped options logically for easier scanning.
- Clearer visual hierarchy with bold headers.

---
*PR created automatically by Jules for task [2842463884870617975](https://jules.google.com/task/2842463884870617975) started by @abhimehro*