### PR TITLE
🛡️ Sentinel: Fix lock file vulnerability in run_all_maintenance.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** `scripts/network-mode-manager.sh` (which requests `sudo`) executed a script from the local repository path relative to itself, rather than the installed system binary.
 **Learning:** If a script prompts for `sudo` to run another script, using a relative path to a user-writable file (like a local repo clone) creates a privilege escalation path. A malicious actor (or the user themselves) could modify the target script and then run the wrapper, unknowingly executing the modified code as root.
 **Prevention:** Helper scripts that escalate privileges should prefer executing installed, root-owned binaries (e.g., in `/usr/local/bin`) over local/relative paths.
+
+## 2026-05-22 - Logic Flaw in Lock File Mechanism
+**Vulnerability:** A logic flaw in `maintenance/bin/run_all_maintenance.sh` where the script checked if a directory existed but failed to handle the case where a file existed at the lock path, allowing bypass of the locking mechanism.
+**Learning:** Checking for directory existence (`[[ -d ... ]]`) after `mkdir` failure is insufficient if `mkdir` fails due to a file blocking the path. The script proceeded execution, defeating the lock.
+**Prevention:** Always handle the failure case explicitly. If a resource creation fails, verify *why* or exit securely. Use `mkdir` atomic creation as the primary check and ensure failure paths are handled securely (exit by default).


### PR DESCRIPTION
This PR fixes a critical logic flaw in `maintenance/bin/run_all_maintenance.sh` where the script would proceed execution even if it failed to acquire the lock file, provided the blocking entity was a regular file and not a directory. This allowed bypassing the concurrency protection.

Additionally, the lock file location was moved from `/tmp` to `LOG_DIR` (relative to the script) to prevent potential symlink or DoS attacks from other users on the system.

A Sentinel journal entry was added to document this learning.

---
*PR created automatically by Jules for task [2579721311775656430](https://jules.google.com/task/2579721311775656430) started by @abhimehro*