### PR TITLE
🎨 Palette: Add active state indicators to network menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - CLI Output Scanability
 **Learning:** For long-running maintenance scripts, users scan summary tables for failures and outliers (long durations). Standardizing column widths and using semantic colors (Red/Green) significantly reduces cognitive load.
 **Action:** Implement fixed-width summary tables with ANSI colors and duration tracking for all batch processing scripts.
+
+## 2026-02-18 - Contextual Menus in CLI
+**Learning:** Static menus force users to remember their current state. Dynamic menus that highlight the active configuration (e.g., via checkmarks) transform a tool from a "switcher" to a "dashboard".
+**Action:** When building selection menus for toggleable states, always compute and display the current active state inline.


### PR DESCRIPTION
💡 What: The UX enhancement added
- Added visual indicators (✅) to the interactive menu in `scripts/network-mode-manager.sh` to show the currently active network mode.

🎯 Why: The user problem it solves
- Users previously had to remember their current network state or run a separate `status` command. Now the menu acts as a dashboard, showing the active configuration at a glance.

📸 Before/After:
Before:
```
   1) 🛡️ Control D (Privacy)
   2) 🌐 Control D (Browsing) [Default]
   3) 🎮 Control D (Gaming)
   4) 🔐 Windscribe (VPN)
```

After (if Browsing is active):
```
   1) 🛡️ Control D (Privacy)
   2) 🌐 Control D (Browsing) ✅ [Default]
   3) 🎮 Control D (Gaming)
   4) 🔐 Windscribe (VPN)
```

♿ Accessibility:
- Improves cognitive accessibility by reducing memory load.
- Uses standard emojis which are screen-reader friendly (though visual placement is primary benefit).

---
*PR created automatically by Jules for task [1393297139014731718](https://jules.google.com/task/1393297139014731718) started by @abhimehro*