### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in health_check.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -76,3 +76,9 @@
 [CWE-59]: https://cwe.mitre.org/data/definitions/59.html
 [CWE-88]: https://cwe.mitre.org/data/definitions/88.html
 [CWE-732]: https://cwe.mitre.org/data/definitions/732.html
+
+## 2026-02-10 - Command Injection in Health Check
+**Vulnerability:** Command Injection ([CWE-78][]) in `maintenance/bin/health_check.sh`. The script interpolated the `HEALTH_LOG_LOOKBACK_HOURS` variable directly into a command string passed to `bash -c`, allowing arbitrary code execution if the variable contained malicious input.
+**Learning:** Shell scripts that construct commands from variables are inherently risky. Sourcing configuration files (`source config.env`) without validation assumes the file is trustworthy, but environment variables can override defaults or be set maliciously if the config is missing.
+**Prevention:** Always sanitize variables used in command construction. Ensure numeric values are actually integers using regex validation (`[[ "$VAR" =~ ^[0-9]+$ ]]`) before using them.
+[CWE-78]: https://cwe.mitre.org/data/definitions/78.html


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection in `maintenance/bin/health_check.sh`. The script interpolated the `HEALTH_LOG_LOOKBACK_HOURS` variable directly into a command string passed to `bash -c`, allowing arbitrary code execution if the variable contained malicious input (e.g. from a compromised environment or missing config).
🎯 Impact: Attackers controlling environment variables could execute arbitrary commands as the user running the script.
🔧 Fix: Sanitized `HEALTH_LOG_LOOKBACK_HOURS`, `DISK_WARN_PCT`, and `DISK_CRIT_PCT` using regex `^[0-9]+$` to ensure they are integers.
✅ Verification: Verified with a test script that attempts command injection; the script now safely logs a warning and defaults to safe values.

---
*PR created automatically by Jules for task [16609040271059522980](https://jules.google.com/task/16609040271059522980) started by @abhimehro*