### PR TITLE
🛡️ Sentinel: Harden controld-manager against symlink attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -79,6 +79,7 @@
 
 [CWE-22]: https://cwe.mitre.org/data/definitions/22.html
 [CWE-59]: https://cwe.mitre.org/data/definitions/59.html
+[CWE-78]: https://cwe.mitre.org/data/definitions/78.html
 [CWE-88]: https://cwe.mitre.org/data/definitions/88.html
 [CWE-732]: https://cwe.mitre.org/data/definitions/732.html
 
@@ -86,4 +87,8 @@
 **Vulnerability:** Command Injection ([CWE-78][]) in `maintenance/bin/health_check.sh`. The script interpolated the `HEALTH_LOG_LOOKBACK_HOURS` variable directly into a command string passed to `bash -c`, allowing arbitrary code execution if the variable contained malicious input.
 **Learning:** Shell scripts that construct commands from variables are inherently risky. Sourcing configuration files (`source config.env`) without validation assumes the file is trustworthy, but environment variables can override defaults or be set maliciously if the config is missing.
 **Prevention:** Always sanitize variables used in command construction. Ensure numeric values are actually integers using regex validation (`[[ "$VAR" =~ ^[0-9]+$ ]]`) before using them.
-[CWE-78]: https://cwe.mitre.org/data/definitions/78.html
+
+## 2026-02-12 - Symlink Attack in Config Generation
+**Vulnerability:** Symlink following ([CWE-59][]) in `controld-system/scripts/controld-manager`. The script used `cp` to overwrite a configuration file without checking if the destination was a symlink.
+**Learning:** `cp` follows symlinks by default when the destination exists. If an attacker can create a symlink at the destination path, running `cp` as root will overwrite the symlink's target.
+**Prevention:** Remove the destination file (`rm -f`) before copying to ensure any existing symlinks are broken. Also, verify critical directories are not symlinks before use.

--- a/controld-system/scripts/controld-manager
+++ b/controld-system/scripts/controld-manager
@@ -142,6 +142,14 @@ check_root() {
 # Create directory structure
 setup_directories() {
     log "Setting up directory structure..."
+
+    # 🛡️ Sentinel: Security Hardening against Symlink Attacks
+    # Ensure PROFILES_DIR is not a symlink before creating/using it
+    if [[ -L "$PROFILES_DIR" ]]; then
+        log_error "Security Alert: $PROFILES_DIR is a symlink! Aborting to prevent hijack."
+        exit 1
+    fi
+
     mkdir -p "$PROFILES_DIR" "$BACKUP_DIR"
     # 🛡️ Sentinel: Restrict permissions to root-only
     chmod 700 "$PROFILES_DIR" "$BACKUP_DIR"
@@ -294,6 +302,9 @@ generate_profile_config() {
 
     if [[ -f "$TEMP_CONFIG" ]]; then
         # Copy and customize the generated config
+        # 🛡️ Sentinel: Security Hardening against Symlink Attacks
+        # Remove destination first to break any existing symlinks
+        rm -f "$config_file"
         cp "$TEMP_CONFIG" "$config_file"
         # 🛡️ Sentinel: Restrict permissions to root-only
         chmod 600 "$config_file"


### PR DESCRIPTION
🛡️ Sentinel: Harden controld-manager against symlink attacks

💡 **Vulnerability:** Symlink following in file operations ([CWE-59](https://cwe.mitre.org/data/definitions/59.html)). The `controld-manager` script, running as root, used `cp` to write configuration files to a predictable location. If an attacker could place a symlink at that location, the script would overwrite the symlink's target (e.g., a critical system file).

🎯 **Impact:** Potential arbitrary file overwrite or privilege escalation if permissions on the parent directory are compromised or if a race condition is exploited.

🔧 **Fix:**
- Explicitly check if the profiles directory is a symlink and abort if so.
- Use `rm -f` on the destination file path before copying. This removes the symlink itself (if one exists) instead of following it, ensuring the new content is written to a new, safe file.

✅ **Verification:**
- Verified with a reproduction script that `cp` overwrites symlink targets.
- Verified with a test script that `rm -f` before `cp` correctly replaces the symlink with a regular file.
- Confirmed script syntax is valid with `bash -n`.

---
*PR created automatically by Jules for task [16085860333870366163](https://jules.google.com/task/16085860333870366163) started by @abhimehro*