### PR TITLE
🛡️ Sentinel: Fix TOCTOU vulnerability in setup script via atomic `install`

### DIFF
--- a/scripts/setup-controld.sh
+++ b/scripts/setup-controld.sh
@@ -51,15 +51,11 @@ if [[ -f "$CONTROLD_MANAGER_DEST" ]]; then
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         log "Skipping controld-manager installation"
     else
-        sudo cp "$CONTROLD_MANAGER_SRC" "$CONTROLD_MANAGER_DEST"
-        sudo chmod +x "$CONTROLD_MANAGER_DEST"
-        sudo chown root:wheel "$CONTROLD_MANAGER_DEST"
+        sudo install -m 755 -o root -g wheel "$CONTROLD_MANAGER_SRC" "$CONTROLD_MANAGER_DEST"
         success "controld-manager installed"
     fi
 else
-    sudo cp "$CONTROLD_MANAGER_SRC" "$CONTROLD_MANAGER_DEST"
-    sudo chmod +x "$CONTROLD_MANAGER_DEST"
-    sudo chown root:wheel "$CONTROLD_MANAGER_DEST"
+    sudo install -m 755 -o root -g wheel "$CONTROLD_MANAGER_SRC" "$CONTROLD_MANAGER_DEST"
     success "controld-manager installed"
 fi
 
@@ -81,12 +77,10 @@ if [[ -e "/etc/controld" && ! -d "/etc/controld" ]]; then
     error "/etc/controld exists but is not a directory. Please fix this and rerun the script."
 fi
 
-if [[ ! -d "/etc/controld" ]]; then
-    sudo mkdir -p "/etc/controld"
-fi
-# 🛡️ Sentinel: Restrict permissions and ownership to root-only
-sudo chmod 700 "/etc/controld"
-sudo chown root:wheel "/etc/controld"
+# 🛡️ Sentinel: Use atomic directory creation to prevent TOCTOU race conditions
+# install -d sets permissions/owner atomically upon creation
+sudo install -d -m 700 -o root -g wheel "/etc/controld"
+
 # 🛡️ Sentinel: Post-creation verification to catch TOCTOU symlink swaps
 if [[ -L "/etc/controld" ]]; then
     error "Security Alert: /etc/controld became a symlink after creation. Aborting to prevent hijack."
@@ -99,9 +93,7 @@ fi
 
 if [[ ! -f "$ENV_DEST" ]]; then
     if [[ -f "$ENV_EXAMPLE_SRC" ]]; then
-        sudo cp "$ENV_EXAMPLE_SRC" "$ENV_DEST"
-        sudo chown root:wheel "$ENV_DEST"
-        sudo chmod 600 "$ENV_DEST"
+        sudo install -m 600 -o root -g wheel "$ENV_EXAMPLE_SRC" "$ENV_DEST"
         log "Created $ENV_DEST"
         warn "You must edit $ENV_DEST and add your Control D Profile IDs!"
     else


### PR DESCRIPTION
This PR addresses a Time-of-Check Time-of-Use (TOCTOU) vulnerability in `scripts/setup-controld.sh`. The script previously used a sequence of `cp`, `chmod`, and `chown` commands to install files and create directories. This created a race condition window where a malicious actor could replace the target file with a symbolic link after creation but before permissions were set, potentially leading to privilege escalation or file overwrite as the script runs with `sudo`.

Changes:
- Replaced `sudo cp` + `sudo chmod` + `sudo chown` with `sudo install -m <mode> -o <owner> -g <group>` for atomic file installation.
- Replaced `sudo mkdir -p` + `sudo chmod` + `sudo chown` with `sudo install -d -m <mode> -o <owner> -g <group>` for atomic directory creation.
- Removed redundant file existence checks where `install` handles idempotency correctly.
- Kept existing symlink checks as a defense-in-depth measure.

This aligns with security best practices for script-based installers.

---
*PR created automatically by Jules for task [17096581476335882309](https://jules.google.com/task/17096581476335882309) started by @abhimehro*