### PR TITLE
🎨 Palette: Improve Network Mode Manager Menu UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,6 +41,11 @@
 ## 2025-02-17 - Delightful Data Visualization in CLI
 **Learning:** In text-based interfaces, mapping abstract data (like weather conditions or time) to relevant emojis provides immediate visual recognition and delight, acting as a "micro-UX" improvement.
 **Action:** When displaying categorical data in CLI tools, consider using emoji mappings to enhance scanability and user experience.
+
 ## 2025-05-15 - CLI Micro-Interactions
 **Learning:** Even simple CLI tools benefit significantly from "web-like" UX patterns: clear headers, explicit loading states ("Thinking..."), and graceful exit handling (Ctrl+C). Users expect feedback for every action, including empty input.
 **Action:** Always add a SIGINT handler to CLI tools to restore cursor state and say goodbye. Use box-drawing characters for CLI headers to frame the experience.
+
+## 2026-05-23 - Micro-Copy in CLI Menus
+**Learning:** Users often hesitate at cryptic menu options like "Gaming Mode" vs "Privacy Mode". Adding a single line of descriptive micro-copy (e.g., "Max performance, min filtering") directly under the option significantly reduces decision fatigue and improves confidence.
+**Action:** When designing interactive CLI menus, use a subtle secondary color (Gray) to add concise, benefit-oriented descriptions for each choice.

--- a/scripts/lib/network-core.sh
+++ b/scripts/lib/network-core.sh
@@ -24,6 +24,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 BOLD='\033[1m'
+GRAY='\033[0;90m'
 NC='\033[0m'
 
 # --- Emojis ---
@@ -36,7 +37,7 @@ E_BROWSING="🌐"
 E_VPN="🔐"
 
 # Export for use in scripts that source this library
-export RED GREEN YELLOW BLUE BOLD NC
+export RED GREEN YELLOW BLUE BOLD GRAY NC
 export E_PASS E_FAIL E_INFO E_PRIVACY E_GAMING E_BROWSING E_VPN
 
 # --- Logging ---

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -201,11 +201,30 @@ interactive_menu() {
     vpn)      m_vpn="${GREEN}✅${NC}" ;;
   esac
 
+  local display_mode="None"
+  case "$active_mode" in
+    privacy)  display_mode="Privacy" ;;
+    browsing) display_mode="Browsing" ;;
+    gaming)   display_mode="Gaming" ;;
+    vpn)      display_mode="VPN" ;;
+  esac
+
   echo -e "\n${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
+  echo -e "   ${BOLD}Current Mode:${NC} ${GREEN}${display_mode}${NC}"
+  echo -e "${BLUE}   ─────────────────────${NC}"
+
   echo -e "   1) ${E_PRIVACY} Control D (Privacy)          $m_priv"
+  echo -e "      ${GRAY}Malware & tracking protection${NC}"
+
   echo -e "   2) ${E_BROWSING} Control D (Browsing)         $m_brow ${YELLOW}[Default]${NC}"
+  echo -e "      ${GRAY}Balanced protection${NC}"
+
   echo -e "   3) ${E_GAMING} Control D (Gaming)           $m_game"
+  echo -e "      ${GRAY}Max performance, min filtering${NC}"
+
   echo -e "   4) ${E_VPN} Windscribe (VPN)             $m_vpn"
+  echo -e "      ${GRAY}Full traffic encryption${NC}"
+
   echo -e "   5) ${E_INFO} Show Status"
   echo -e "   0) 🚪 Exit"
 


### PR DESCRIPTION
Improved the `network-mode-manager.sh` CLI menu by adding descriptive helper text and a clear status header. This helps users understand the difference between network modes (Privacy, Browsing, Gaming) without needing to consult documentation.

Changes:
- Defined `GRAY` color in `scripts/lib/network-core.sh`.
- Updated `interactive_menu` in `scripts/network-mode-manager.sh` with descriptions and status indicator.
- Verified the output with a test script.

---
*PR created automatically by Jules for task [7392327214014330471](https://jules.google.com/task/7392327214014330471) started by @abhimehro*