### PR TITLE
🛡️ Sentinel: [HIGH] Fix privilege escalation in network-mode-manager.sh

### DIFF
--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -83,11 +83,7 @@ start_controld() {
 
   local controld_manager="/usr/local/bin/controld-manager"
   if [[ ! -x "$controld_manager" ]]; then
-    controld_manager="$REPO_ROOT/controld-system/scripts/controld-manager"
-    if [[ ! -x "$controld_manager" ]]; then
-      error "controld-manager script not found in /usr/local/bin or at $controld_manager"
-    fi
-    log "Using local controld-manager: $controld_manager"
+    error "controld-manager script not found in /usr/local/bin. Please run 'scripts/setup-controld.sh' to install it securely."
   fi
 
   # Call switch with profile and optional protocol override


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Privilege Escalation
The `scripts/network-mode-manager.sh` script, which often runs with elevated privileges (sudo), contained a fallback mechanism that executed `controld-manager` from the local repository (`$REPO_ROOT`) if the system-wide installation (`/usr/local/bin/controld-manager`) was missing. Since the local repository is typically writable by the user, this allowed a local attacker (or the user themselves) to modify the local script and have it executed as root by the wrapper.

🎯 Impact:
A malicious user or process could gain root privileges by modifying the local `controld-manager` script and triggering `network-mode-manager.sh`.

🔧 Fix:
Removed the fallback logic. The script now enforces execution from `/usr/local/bin/controld-manager` (a root-owned, protected location). If the binary is missing, the script fails securely and instructs the user to run the installation script.

✅ Verification:
Verified that the script fails with a descriptive error message when `/usr/local/bin/controld-manager` is missing, and succeeds when it is present (simulated). Existing tests in `tests/test_network_mode_manager.sh` also pass.

---
*PR created automatically by Jules for task [10217624978862984915](https://jules.google.com/task/10217624978862984915) started by @abhimehro*