### PR TITLE
🛡️ Sentinel: [HIGH] Fix privilege escalation in network-mode-manager

### DIFF
--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -83,11 +83,7 @@ start_controld() {
 
   local controld_manager="/usr/local/bin/controld-manager"
   if [[ ! -x "$controld_manager" ]]; then
-    controld_manager="$REPO_ROOT/controld-system/scripts/controld-manager"
-    if [[ ! -x "$controld_manager" ]]; then
-      error "controld-manager script not found in /usr/local/bin or at $controld_manager"
-    fi
-    log "Using local controld-manager: $controld_manager"
+    error "controld-manager script not found in /usr/local/bin. Please run './scripts/setup-controld.sh' to install it."
   fi
 
   # Call switch with profile and optional protocol override

--- a/tests/test_network_mode_security.sh
+++ b/tests/test_network_mode_security.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Security Test for network-mode-manager.sh
+# Verifies that the script fails securely when /usr/local/bin/controld-manager is missing.
+
+set -u
+
+# Setup
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Mock dependencies
+MOCK_BIN="$TEST_DIR/bin"
+mkdir -p "$MOCK_BIN"
+export PATH="$MOCK_BIN:$PATH"
+
+# Create minimal mocks to pass prereqs
+touch "$MOCK_BIN/ctrld" && chmod +x "$MOCK_BIN/ctrld"
+touch "$MOCK_BIN/networksetup" && chmod +x "$MOCK_BIN/networksetup"
+touch "$MOCK_BIN/scutil" && chmod +x "$MOCK_BIN/scutil"
+
+# Mock IPv6 Manager
+MOCK_IPV6="$TEST_DIR/ipv6-manager.sh"
+echo '#!/bin/bash' > "$MOCK_IPV6"
+chmod +x "$MOCK_IPV6"
+
+# Path to the real script
+REAL_MANAGER="./scripts/network-mode-manager.sh"
+
+# Create a test version of the manager
+TEST_MANAGER="$TEST_DIR/network-mode-manager.sh"
+cp "$REAL_MANAGER" "$TEST_MANAGER"
+
+# Copy library
+mkdir -p "$TEST_DIR/lib"
+cp scripts/lib/network-core.sh "$TEST_DIR/lib/"
+
+# Inject mock IPv6 manager location (same as original test)
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    sed -i '' "s|IPV6_MANAGER=\".*\"|IPV6_MANAGER=\"$MOCK_IPV6\"|" "$TEST_MANAGER"
+else
+    sed -i "s|IPV6_MANAGER=\".*\"|IPV6_MANAGER=\"$MOCK_IPV6\"|" "$TEST_MANAGER"
+fi
+
+# DO NOT inject a mock location for controld-manager.
+# This ensures the script looks for /usr/local/bin/controld-manager.
+# We assume /usr/local/bin/controld-manager does NOT exist in this environment.
+# If it does, this test might fail (false negative), but that's unlikely here.
+
+echo "Running security test: ensuring failure when system binary is missing..."
+
+# Run the script. It should fail.
+output=$("$TEST_MANAGER" controld browsing 2>&1)
+exit_code=$?
+
+echo "Exit code: $exit_code"
+echo "Output: $output"
+
+if [[ $exit_code -ne 0 ]]; then
+    if echo "$output" | grep -q "controld-manager script not found in /usr/local/bin"; then
+        echo "PASS: Script failed securely with correct error message."
+        exit 0
+    else
+        echo "FAIL: Script failed but with unexpected error message."
+        exit 1
+    fi
+else
+    echo "FAIL: Script succeeded but should have failed."
+    exit 1
+fi


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Privilege Escalation via Insecure Path Fallback
🎯 Impact: A malicious local user could modify the `controld-manager` script in the repository and wait for an administrator to run `network-mode-manager.sh` (which invokes it with sudo), thereby executing arbitrary code as root.
🔧 Fix: Removed the fallback logic in `scripts/network-mode-manager.sh`. The script now strictly enforces execution from `/usr/local/bin/controld-manager`. If the system binary is missing, it errors out with instructions to run the setup script.
✅ Verification:
  - Verified that `scripts/network-mode-manager.sh` no longer contains the fallback logic.
  - Ran existing tests (`tests/test_network_mode_manager.sh`) which passed.
  - Added a new regression test `tests/test_network_mode_security.sh` which confirms the script fails securely when the system binary is missing.

---
*PR created automatically by Jules for task [10153462690443250808](https://jules.google.com/task/10153462690443250808) started by @abhimehro*