### PR TITLE
🛡️ Sentinel: Fix Privilege Escalation in network-mode-manager

### DIFF
--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -83,11 +83,9 @@ start_controld() {
 
   local controld_manager="/usr/local/bin/controld-manager"
   if [[ ! -x "$controld_manager" ]]; then
-    controld_manager="$REPO_ROOT/controld-system/scripts/controld-manager"
-    if [[ ! -x "$controld_manager" ]]; then
-      error "controld-manager script not found in /usr/local/bin or at $controld_manager"
-    fi
-    log "Using local controld-manager: $controld_manager"
+    # SECURITY: Do NOT fall back to local script. Privileged execution must be from a trusted system path.
+    # See .jules/sentinel.md (2026-01-23 - Privilege Escalation in Helper Scripts)
+    error "controld-manager script not found at $controld_manager. Please install it first (see setup.sh)."
   fi
 
   # Call switch with profile and optional protocol override


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Privilege Escalation in Helper Scripts

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** `scripts/network-mode-manager.sh` contained a fallback mechanism that executed `controld-manager` from the local repository if the system-wide installation was missing. This created a privilege escalation vector where a user with write access to the repository could modify the local script and have it executed with elevated privileges (sudo) by the wrapper.
🎯 **Impact:** A local attacker could gain root privileges by tampering with the repository script and waiting for an administrator to run the network manager.
🔧 **Fix:** The fallback logic has been removed. The script now strictly enforces execution from `/usr/local/bin/controld-manager`, a trusted system path.
✅ **Verification:** Updated `tests/test_network_mode_manager.sh` to verify the script functions correctly when the binary exists in the expected system location (mocked) and fails safely otherwise.

**Testing:**
- Run `bash tests/test_network_mode_manager.sh` to verify the fix and ensure no regressions.

---
*PR created automatically by Jules for task [15522359496519907309](https://jules.google.com/task/15522359496519907309) started by @abhimehro*