### PR TITLE
🎨 Palette: Make interactive CLI menus forgiving

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2025-05-15 - CLI Micro-Interactions
 **Learning:** Even simple CLI tools benefit significantly from "web-like" UX patterns: clear headers, explicit loading states ("Thinking..."), and graceful exit handling (Ctrl+C). Users expect feedback for every action, including empty input.
 **Action:** Always add a SIGINT handler to CLI tools to restore cursor state and say goodbye. Use box-drawing characters for CLI headers to frame the experience.
+
+## 2026-03-05 - Forgiving Interactive CLI Menus
+**Learning:** Hard-exiting an interactive CLI menu when a user makes a typo or enters an invalid option creates a frustrating, unforgiving experience. Users expect a chance to correct their mistake without restarting the command.
+**Action:** Always wrap interactive menu inputs in a loop (`while true; do ... done`) and gracefully handle invalid inputs with a warning message, allowing the user to try again instead of forcefully exiting the script.

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -201,27 +201,29 @@ interactive_menu() {
     vpn)      m_vpn="${GREEN}✅${NC}" ;;
   esac
 
-  echo -e "\n${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
-  echo -e "   1) ${E_PRIVACY} Control D (Privacy)          $m_priv"
-  echo -e "   2) ${E_BROWSING} Control D (Browsing)         $m_brow ${YELLOW}[Default]${NC}"
-  echo -e "   3) ${E_GAMING} Control D (Gaming)           $m_game"
-  echo -e "   4) ${E_VPN} Windscribe (VPN)             $m_vpn"
-  echo -e "   5) ${E_INFO} Show Status"
-  echo -e "   0) 🚪 Exit"
+  while true; do
+    echo -e "\n${BOLD}${BLUE}🎨 Network Mode Manager${NC}"
+    echo -e "   1) ${E_PRIVACY} Control D (Privacy)          $m_priv"
+    echo -e "   2) ${E_BROWSING} Control D (Browsing)         $m_brow ${YELLOW}[Default]${NC}"
+    echo -e "   3) ${E_GAMING} Control D (Gaming)           $m_game"
+    echo -e "   4) ${E_VPN} Windscribe (VPN)             $m_vpn"
+    echo -e "   5) ${E_INFO} Show Status"
+    echo -e "   0) 🚪 Exit"
 
-  echo -ne "\n${BOLD}Select option [0-5]: ${NC}"
-  read -r choice
-  choice="${choice:-2}"
+    echo -ne "\n${BOLD}Select option [0-5]: ${NC}"
+    read -r choice
+    choice="${choice:-2}"
 
-  case "$choice" in
-    1) main "controld" "privacy" ;;
-    2) main "controld" "browsing" ;;
-    3) main "controld" "gaming" ;;
-    4) main "windscribe" ;;
-    5) main "status" ;;
-    0) exit 0 ;;
-    *) error "Invalid option" ;;
-  esac
+    case "$choice" in
+      1) main "controld" "privacy"; exit 0 ;;
+      2) main "controld" "browsing"; exit 0 ;;
+      3) main "controld" "gaming"; exit 0 ;;
+      4) main "windscribe"; exit 0 ;;
+      5) main "status"; exit 0 ;;
+      0) exit 0 ;;
+      *) echo -e "${YELLOW}⚠️ [WARN]${NC} Invalid option. Please try again." ;;
+    esac
+  done
 }
 
 main() {


### PR DESCRIPTION
💡 **What:** Added a `while true` loop around the interactive prompt in `scripts/network-mode-manager.sh` and changed the invalid option handler to display a warning instead of hard-exiting. Also appended an entry to `.Jules/palette.md` noting the pattern.

🎯 **Why:** Users expect a chance to correct their mistake without restarting the command. Hard-exiting an interactive CLI menu when a user makes a typo creates a frustrating, unforgiving experience.

📸 **Before/After:**
**Before:**
```
Select option [0-5]: x
❌ [ERR] Invalid option
(Script exits)
```

**After:**
```
Select option [0-5]: x
⚠️ [WARN] Invalid option. Please try again.

🎨 Network Mode Manager
   1) 🛡️ Control D (Privacy)          
...
```

♿ **Accessibility:** This makes the CLI much more forgiving for users prone to typos, improving overall usability and reducing cognitive load/frustration.

---
*PR created automatically by Jules for task [9470753233274533697](https://jules.google.com/task/9470753233274533697) started by @abhimehro*