### PR TITLE
⚡ Bolt: Optimize AdGuard list generation (Revised)

### DIFF
--- a/adguard/scripts/create_consolidated_lists.py
+++ b/adguard/scripts/create_consolidated_lists.py
@@ -30,7 +30,8 @@ def extract_domains_from_file(filepath, action_filter=None):
     return domains
 
 def main():
-    base_dir = Path("/Users/abhimehrotra/Downloads")
+    # Allow overriding base directory for testing/portability
+    base_dir = Path(os.environ.get("ADGUARD_LISTS_DIR", "/Users/abhimehrotra/Downloads"))
     
     print("🔍 Consolidating Ad-Blocking Lists...")
     print("=" * 50)
@@ -91,6 +92,10 @@ def main():
     
     print(f"\n✅ Allowlist total domains: {len(allowlist_domains)}")
     
+    # ⚡ Bolt Optimization: Sort once, reuse everywhere (O(N log N))
+    sorted_denylist = sorted(denylist_domains)
+    sorted_allowlist = sorted(allowlist_domains)
+
     # 3. CREATE CONSOLIDATED TEXT FILES
     print("\n💾 Creating consolidated text files...")
     
@@ -101,7 +106,7 @@ def main():
         f.write("# This file contains all domains from various tracker lists that should be blocked\n")
         f.write("# Generated from: Microsoft, No SafeSearch, OPPO/Realme, Roku, Samsung, TikTok, Vivo, Xiaomi, Amazon, Apple, Badware Hoster, LG webOS, Huawei Trackers\n")
         f.write(f"# Total domains: {len(denylist_domains):,}\n\n")
-        for domain in sorted(denylist_domains):
+        for domain in sorted_denylist:
             f.write(f"{domain}\n")
     
     # Create Allowlist text file (AdGuard allowlist syntax with @@ prefix)
@@ -111,7 +116,7 @@ def main():
         f.write("# This file contains domains that should NOT be blocked\n")
         f.write("# Generated from: CD-Control-D-Bypass and legitimate entries from CD-Most-Abused-TLDs\n")
         f.write(f"# Total domains: {len(allowlist_domains):,}\n\n")
-        for domain in sorted(allowlist_domains):
+        for domain in sorted_allowlist:
             f.write(f"@@{domain}\n")  # AdGuard allowlist syntax
     
     print(f"✅ Created: {denylist_txt_path}")
@@ -137,7 +142,7 @@ def main():
                     "status": 1
                 }
             }
-            for domain in sorted(denylist_domains)
+            for domain in sorted_denylist
         ]
     }
     
@@ -158,7 +163,7 @@ def main():
                     "status": 1
                 }
             }
-            for domain in sorted(allowlist_domains)
+            for domain in sorted_allowlist
         ]
     }
     
@@ -166,6 +171,8 @@ def main():
     denylist_json_path = base_dir / "Consolidated-Denylist.json"
     allowlist_json_path = base_dir / "Consolidated-Allowlist.json"
     
+    # ⚡ Bolt Optimization: Use cached sorted lists.
+    # Note: Indentation kept for readability as these are reference files.
     with open(denylist_json_path, 'w', encoding='utf-8') as f:
         json.dump(denylist_json, f, indent=2, ensure_ascii=False)
     


### PR DESCRIPTION
⚡ Bolt Optimization for `adguard/scripts/create_consolidated_lists.py`

**What:**
- **Cached Sorting:** The script was sorting the `denylist_domains` and `allowlist_domains` sets twice: once for the text file generation and again for the JSON file generation. I've refactored this to sort once and store the result in `sorted_denylist` and `sorted_allowlist`, reducing the computational complexity for this step by half.
- **Testability:** Added `ADGUARD_LISTS_DIR` environment variable support to allow running the script against test fixtures instead of hardcoded paths.

**Why:**
- **Performance:** Sorting is an expensive operation (O(N log N)). Doing it redundantly is wasteful, especially as the list size grows.
- **Robustness:** Hardcoded paths prevented the script from being tested or run in different environments (like CI).

**Impact:**
- Reduces sorting overhead by 50%.
- Enables automated testing of the script.

**Verification:**
- Verified by running the script with a custom `ADGUARD_LISTS_DIR` containing dummy JSON files.
- Confirmed output files are generated correctly and indentation is preserved for readability.
- Confirmed script handles missing files gracefully.

---
*PR created automatically by Jules for task [825337335000196232](https://jules.google.com/task/825337335000196232) started by @abhimehro*