### PR TITLE
🧪 [testing improvement] Add unit tests for `load_json_file` in consolidate_adblock_lists.py

### DIFF
--- a/tests/test_consolidate_adblock_lists.py
+++ b/tests/test_consolidate_adblock_lists.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import patch, mock_open
+import sys
+import os
+
+# Add the script's directory to sys.path so we can import it
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../adguard/scripts')))
+
+from consolidate_adblock_lists import load_json_file
+
+class TestLoadJsonFile(unittest.TestCase):
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"key": "value"}')
+    def test_valid_json_happy_path(self, mock_file):
+        # 1. Valid JSON file (happy path, returns expected dict)
+        result = load_json_file('dummy_path.json')
+        self.assertEqual(result, {"key": "value"})
+        mock_file.assert_called_once_with('dummy_path.json', 'r', encoding='utf-8')
+
+    @patch('builtins.open')
+    def test_file_not_found_error(self, mock_file):
+        # 2. FileNotFoundError (file does not exist)
+        mock_file.side_effect = FileNotFoundError("No such file or directory")
+
+        # Suppress print output for clean test output
+        with patch('sys.stdout', new_callable=unittest.mock.MagicMock):
+            result = load_json_file('nonexistent_path.json')
+
+        self.assertIsNone(result)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{invalid_json: 123')
+    def test_json_decode_error(self, mock_file):
+        # 3. json.JSONDecodeError (malformed JSON)
+        with patch('sys.stdout', new_callable=unittest.mock.MagicMock):
+            result = load_json_file('malformed_path.json')
+
+        self.assertIsNone(result)
+
+    @patch('builtins.open')
+    def test_permission_error(self, mock_file):
+        # 4. PermissionError (file not readable)
+        mock_file.side_effect = PermissionError("Permission denied")
+
+        with patch('sys.stdout', new_callable=unittest.mock.MagicMock):
+            result = load_json_file('unreadable_path.json')
+
+        self.assertIsNone(result)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='')
+    def test_empty_file(self, mock_file):
+        # 5. Empty file (0 bytes)
+        with patch('sys.stdout', new_callable=unittest.mock.MagicMock):
+            result = load_json_file('empty_path.json')
+
+        self.assertIsNone(result)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='["item1", "item2"]')
+    def test_valid_json_unexpected_type(self, mock_file):
+        # 6. Valid JSON, unexpected type (array or primitive instead of dict)
+        result = load_json_file('array_path.json')
+
+        # The function should just parse whatever JSON returns, in this case a list
+        self.assertEqual(result, ["item1", "item2"])
+        self.assertIsInstance(result, list)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds comprehensive unit testing to the `load_json_file` function in `adguard/scripts/consolidate_adblock_lists.py`. Previously, this function was entirely untested, leading to potential unseen regressions when handling edge cases in file parsing and loading.

📊 **Coverage:** What scenarios are now tested
- Happy path (Valid JSON parsing resulting in a dictionary object).
- File does not exist (`FileNotFoundError`).
- Malformed JSON causing parsing errors (`json.JSONDecodeError`).
- File permissions restrict reading (`PermissionError`).
- File is completely empty (0 bytes).
- File contains valid JSON but not a dictionary structure (unexpected type, e.g., a list `[]`).

✨ **Result:** The improvement in test coverage
The `load_json_file` function is now thoroughly tested with deterministic and isolated execution, utilizing `unittest.mock.patch` and `mock_open`. Test performance remains blazingly fast while preventing regressions on edge case I/O handling errors.

═════ ELIR ═════
PURPOSE: Add unit tests for `load_json_file` to establish testing baseline and prevent regressions on file I/O operations.
SECURITY: Safely handles unreadable and empty files, ensuring failures do not result in unhandled application crashes or leak filesystem structure.
FAILS IF: Python's standard `open()` changes signature or `json.load()` behavior changes drastically.
VERIFY: All scenarios run cleanly without true disk I/O side effects.
MAINTAIN: New logic reading JSON must expand these mock test cases rather than creating actual temporary files on disk.

---
*PR created automatically by Jules for task [2966220056279361012](https://jules.google.com/task/2966220056279361012) started by @abhimehro*