### PR TITLE
🧪 testing: add tests for extract_allowlist_domains_from_file

### DIFF
--- a/adguard/scripts/import_fix_allowlist_format.py
+++ b/adguard/scripts/import_fix_allowlist_format.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+# Need to import a script with hyphens in the name
+import importlib.util
+
+# Get absolute path to fix-allowlist-format.py
+current_dir = Path(__file__).resolve().parent
+script_path = current_dir / "fix-allowlist-format.py"
+
+# Load the module dynamically
+spec = importlib.util.spec_from_file_location("fix_allowlist_format", script_path)
+fix_allowlist_format = importlib.util.module_from_spec(spec)
+sys.modules["fix_allowlist_format"] = fix_allowlist_format
+spec.loader.exec_module(fix_allowlist_format)
+
+extract_allowlist_domains_from_file = fix_allowlist_format.extract_allowlist_domains_from_file

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,18 @@
+# ELIR Handoff: `fix-allowlist-format.py` Testing Improvement
+
+📋 **Purpose:**
+Added comprehensive unit test coverage for the `extract_allowlist_domains_from_file` function in `adguard/scripts/fix-allowlist-format.py`. The tests document the function's existing behavior across 10+ edge cases including missing files, invalid JSON, and missing keys.
+
+🛡️ **Security:**
+The script currently parses files securely, though error swallowing could obscure failures. The tests mock the file system with `unittest.mock.mock_open` ensuring isolated test execution without actual side effects.
+
+⚠️ **Failure Modes:**
+- The function currently uses a generic `except Exception as e` to catch errors and returns an empty list. The test verifies this behavior explicitly. If we decide to tighten error propagation in the future (e.g. letting `json.JSONDecodeError` surface), these tests will intentionally fail to guide the refactoring.
+
+✅ **Review Checklist:**
+- [ ] Review `tests/test_fix_allowlist_format.py` to confirm the test matrix matches expectations.
+- [ ] Verify `adguard/scripts/import_fix_allowlist_format.py` acts as a safe dynamic import wrapper.
+- [ ] Ensure all 11 tests pass successfully locally (`python3 -m unittest tests/test_fix_allowlist_format.py`).
+
+🔧 **Maintenance:**
+The tests run efficiently and purely in memory without affecting the host filesystem, aligning with the project's testing practices. The integration test safely creates and deletes its temporary file.

--- a/tests/test_fix_allowlist_format.py
+++ b/tests/test_fix_allowlist_format.py
@@ -1,0 +1,133 @@
+import unittest
+import json
+from unittest.mock import patch, mock_open
+import tempfile
+import os
+
+# Adjust the import path since the script is in adguard/scripts/
+import sys
+from pathlib import Path
+
+# Add the project root to sys.path so we can import the script
+project_root = Path(__file__).resolve().parent.parent
+sys.path.append(str(project_root))
+
+from adguard.scripts.import_fix_allowlist_format import extract_allowlist_domains_from_file
+
+
+class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
+
+    def test_valid_json_multiple_entries_do_1(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "example.com", "action": {"do": 1}},
+                {"PK": "test.com", "action": {"do": 1}}
+            ]
+        })
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, ["example.com", "test.com"])
+
+    def test_valid_json_mix_do_values(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "allow.com", "action": {"do": 1}},
+                {"PK": "block.com", "action": {"do": 0}},
+                {"PK": "null-do.com", "action": {"do": None}}
+            ]
+        })
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, ["allow.com"])
+
+    def test_valid_json_empty_rules_list(self):
+        json_data = json.dumps({"rules": []})
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, [])
+
+    def test_valid_json_no_rules_key(self):
+        json_data = json.dumps({"other_key": "value"})
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, [])
+
+    def test_entry_missing_pk_key(self):
+        json_data = json.dumps({
+            "rules": [
+                {"action": {"do": 1}},  # Missing PK
+                {"PK": "valid.com", "action": {"do": 1}}
+            ]
+        })
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, ["valid.com"])
+
+    def test_entry_missing_action_key(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "no-action.com"},
+                {"PK": "valid.com", "action": {"do": 1}}
+            ]
+        })
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, ["valid.com"])
+
+    @patch('builtins.print')
+    def test_file_not_found(self, mock_print):
+        # We don't mock open here, so it actually raises FileNotFoundError
+        result = extract_allowlist_domains_from_file('nonexistent_file.json')
+        self.assertEqual(result, [])
+        mock_print.assert_called_once()
+        self.assertIn("Error reading nonexistent_file.json", mock_print.call_args[0][0])
+
+    @patch('builtins.print')
+    def test_invalid_json_content(self, mock_print):
+        invalid_json = "this is not json"
+        with patch('builtins.open', mock_open(read_data=invalid_json)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, [])
+        mock_print.assert_called_once()
+        self.assertIn("Error reading dummy.json", mock_print.call_args[0][0])
+
+    @patch('builtins.print')
+    def test_empty_file(self, mock_print):
+        with patch('builtins.open', mock_open(read_data="")):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, [])
+        mock_print.assert_called_once()
+        self.assertIn("Error reading dummy.json", mock_print.call_args[0][0])
+
+    def test_entry_where_do_is_not_1(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "zero.com", "action": {"do": 0}},
+                {"PK": "two.com", "action": {"do": 2}},
+                {"PK": "string.com", "action": {"do": "1"}}, # Assuming strict equality
+            ]
+        })
+        with patch('builtins.open', mock_open(read_data=json_data)):
+            result = extract_allowlist_domains_from_file('dummy.json')
+        self.assertEqual(result, [])
+
+    # Integration Test
+    def test_integration_with_tempfile(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "temp.com", "action": {"do": 1}}
+            ]
+        })
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as tf:
+            tf.write(json_data)
+            temp_path = tf.name
+
+        try:
+            result = extract_allowlist_domains_from_file(temp_path)
+            self.assertEqual(result, ["temp.com"])
+        finally:
+            os.remove(temp_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `extract_allowlist_domains_from_file` function in `adguard/scripts/fix-allowlist-format.py` lacked test coverage, creating uncertainty around its error handling and edge-case behavior.

📊 **Coverage:** Added 11 new tests covering:
- Valid JSON (multiple entries, mixed `do` values)
- Missing/empty `rules` lists
- Missing nested keys (`PK` or `action`)
- `FileNotFoundError` (returns `[]` and prints error)
- `json.JSONDecodeError` (returns `[]` and prints error)
- Edge cases where `do` != 1

✨ **Result:** Test coverage improved, giving us a safety net to refactor the error handling in a future PR without fear of regressions. The new tests use `unittest.mock.mock_open` for speed and isolation, plus one `tempfile` integration test.

---
*PR created automatically by Jules for task [1279563952241069114](https://jules.google.com/task/1279563952241069114) started by @abhimehro*