### PR TITLE
🎨 Palette: [UX improvement] Replace subprocess polling in spinner with iteration counter

### DIFF
--- a/scripts/bootstrap_fish_plugins.sh
+++ b/scripts/bootstrap_fish_plugins.sh
@@ -44,8 +44,6 @@ spinner() {
     local pid
     local delay=0.1
     local spinstr='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
-    local start_time
-    start_time=$(date +%s)
     local temp_log
 
     temp_log=$(mktemp -t 'fish_bootstrap.XXXXXX')
@@ -58,14 +56,14 @@ spinner() {
     tput civis 2>/dev/null || true
 
     local elapsed=0
+    local count=0
     while kill -0 $pid 2>/dev/null; do
-        local current_time
-        current_time=$(date +%s)
-        elapsed=$((current_time - start_time))
+        elapsed=$((count / 10))
         local temp=${spinstr#?}
         printf "\r${BLUE}%c${NC} %s (${elapsed}s)..." "$spinstr" "$message"
         local spinstr=$temp${spinstr%"$temp"}
         sleep $delay
+        count=$((count + 1))
     done
 
     wait $pid


### PR DESCRIPTION
💡 What: Modified the `spinner` function in `scripts/bootstrap_fish_plugins.sh` to use a loop iteration counter instead of spawning a `date +%s` subprocess every 0.1 seconds.
🎯 Why: To provide a smoother and more efficient command-line animation (spinner) by eliminating the performance and UX overhead of repeatedly spawning system processes.
📸 Before/After: Not applicable (shell animation).
♿ Accessibility: Ensures consistent visual feedback without potential system jank or unresponsiveness caused by subprocess spam.

---
*PR created automatically by Jules for task [9215902205217469729](https://jules.google.com/task/9215902205217469729) started by @abhimehro*