### PR TITLE
🎨 Palette: Add graceful exit handling for Ctrl+D (EOF)

### DIFF
--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -209,6 +209,18 @@ rl.on("SIGINT", async () => {
   process.exit(0);
 });
 
+// Graceful shutdown on EOF (Ctrl+D)
+rl.on("close", async () => {
+  stopSpinner();
+  console.log(`\n${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
+  try {
+    await client.stop();
+  } catch (e) {
+    // Ignore error
+  }
+  process.exit(0);
+});
+
 const prompt = () => {
   rl.question(`${COLORS.Cyan}You:${COLORS.Reset} `, async (input) => {
     if (input.trim() === "") {


### PR DESCRIPTION
💡 What: Added graceful exit handling for EOF (Ctrl+D) in the CLI via the `readline` `close` event.
🎯 Why: To ensure the application exits cleanly and provides a consistent goodbye message when the user sends an EOF signal, matching the existing `SIGINT` (Ctrl+C) behavior and preventing the terminal from appearing unresponsive.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [1115842317949013996](https://jules.google.com/task/1115842317949013996) started by @abhimehro*