### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-377 in Morning Brief LaunchAgent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -195,3 +195,9 @@
 **Vulnerability:** Command Injection ([CWE-78](https://cwe.mitre.org/data/definitions/78.html)) risk existed in `maintenance/bin/system_cleanup.sh`, `configs/.config/mole/lib/core/base.sh`, and `configs/.config/mole/lib/core/app_protection.sh`. Functions used `eval` to assign variables dynamically based on function arguments (e.g. `eval "$var_name=\"\$value\""`). If an attacker could control the variable name passed to these functions, they could inject arbitrary bash commands.
 **Learning:** Using `eval` to mimic pass-by-reference variable assignment in shell scripts exposes the script to command injection vulnerabilities if the variable name is not strictly validated.
 **Prevention:** Strictly validate the dynamically passed variable name against `^[a-zA-Z_][a-zA-Z0-9_]*$` before evaluation to prevent Command Injection (CWE-78).
+
+## 2024-03-24 - Insecure Temporary File Creation in macOS LaunchAgents
+
+**Vulnerability:** Insecure Temporary File Creation ([CWE-377](https://cwe.mitre.org/data/definitions/377.html)) in `launch-agents/com.speedybee.morningbrief.plist`. The LaunchAgent configured `StandardOutPath` and `StandardErrorPath` to use predictable filenames (`/tmp/morning-brief.out` and `/tmp/morning-brief.err`) in the shared, world-writable `/tmp` directory.
+**Learning:** Configuring macOS LaunchAgents to output logs to predictable filenames in shared directories like `/tmp` exposes the system to symlink attacks. A malicious local user could pre-create these files as symlinks pointing to critical system files or user data. When the LaunchAgent executes (potentially with higher privileges or as the target user), it would overwrite the target of the symlink with its log output, leading to denial of service or data corruption.
+**Prevention:** Always route LaunchAgent logs to secure, user-owned directories such as `~/Library/Logs/` (e.g., `/Users/username/Library/Logs/app-name.log`) rather than world-writable shared directories.

--- a/launch-agents/com.speedybee.morningbrief.plist
+++ b/launch-agents/com.speedybee.morningbrief.plist
@@ -20,9 +20,9 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>/tmp/morning-brief.out</string>
+    <string>/Users/speedybee/Library/Logs/morning-brief.out</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/morning-brief.err</string>
+    <string>/Users/speedybee/Library/Logs/morning-brief.err</string>
 </dict>
 </plist>
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Temporary File Creation (CWE-377) in macOS LaunchAgent. The `com.speedybee.morningbrief.plist` file outputted logs to predictable paths in the world-writable `/tmp` directory.
🎯 **Impact:** Local users could exploit this via symlink attacks. By pre-creating symlinks at `/tmp/morning-brief.out` pointing to critical files, an attacker could trick the LaunchAgent into overwriting those files when it executes, leading to potential data corruption, denial of service, or privilege escalation.
🔧 **Fix:** Changed `StandardOutPath` and `StandardErrorPath` to point to the secure, user-owned `~/Library/Logs/` directory (`/Users/speedybee/Library/Logs/`).
✅ **Verification:** Verified via `make test` and `trunk check launch-agents/com.speedybee.morningbrief.plist`. The paths have been validated in the plist.
📝 **Documentation:** Added a new critical learning entry to `.jules/sentinel.md` outlining this specific LaunchAgent vulnerability pattern.

═════ ELIR ═════
PURPOSE: Changes LaunchAgent log output destinations from a shared directory to a secure user directory.
SECURITY: Prevents CWE-377 (Insecure Temporary File Creation) and associated symlink attacks by avoiding world-writable paths.
FAILS IF: The `/Users/speedybee/Library/Logs/` directory is somehow inaccessible or unwritable by the user running the LaunchAgent.
VERIFY: Check that `launch-agents/com.speedybee.morningbrief.plist` now uses the new secure paths.
MAINTAIN: Never use `/tmp/` for fixed or predictable file paths in automated scripts or LaunchAgents.

---
*PR created automatically by Jules for task [15405625143032664706](https://jules.google.com/task/15405625143032664706) started by @abhimehro*