### PR TITLE
fix(config): Remove inline comments from inside double quotes in maintenance/conf/config.env

### DIFF
--- a/maintenance/conf/config.env
+++ b/maintenance/conf/config.env
@@ -15,7 +15,8 @@ DEBUG=0
 
 # Notification settings
 NOTIFY_MODE="auto"
-# SLACK_WEBHOOK_URL=  # Optional Slack webhook for notifications
+# Optional Slack webhook for notifications
+# SLACK_WEBHOOK_URL=""
 
 # =============================================================================
 # SYSTEM HEALTH THRESHOLDS

--- a/maintenance/conf/config.env
+++ b/maintenance/conf/config.env
@@ -14,40 +14,40 @@ DRY_RUN=0
 DEBUG=0
 
 # Notification settings
-NOTIFY_MODE="auto  # auto|none"
+NOTIFY_MODE="auto"
 # SLACK_WEBHOOK_URL=  # Optional Slack webhook for notifications
 
 # =============================================================================
 # SYSTEM HEALTH THRESHOLDS
 # =============================================================================
 
-DISK_CRIT_PCT="90           # Critical threshold (percentage)"
+DISK_CRIT_PCT="90"
 # Disk space warnings
-DISK_WARN_PCT="80           # Warning threshold (percentage)"
-HEALTHCHECK_AUTO_REMEDIATE="1  # Auto-cleanup on critical disk usage"
+DISK_WARN_PCT="80"
+HEALTHCHECK_AUTO_REMEDIATE="1"
 
 # Memory pressure monitoring
-MEMORY_PRESSURE_WARN="80    # Memory pressure warning threshold"
+MEMORY_PRESSURE_WARN="80"
 
-HEALTH_LOG_LOOKBACK_HOURS="24  # Check system logs for last 24 hours"
+HEALTH_LOG_LOOKBACK_HOURS="24"
 # Log retention and system monitoring
-LOG_RETENTION_DAYS="60      # Keep logs for 60 days"
+LOG_RETENTION_DAYS="60"
 
 # =============================================================================
 # CLEANUP SETTINGS
 # =============================================================================
 
 # Cache and temporary file cleanup
-CLEANUP_CACHE_DAYS="30      # Clean caches older than 30 days"
-TMP_CLEAN_DAYS="7           # Clean temp files older than 7 days"
-XCODE_DERIVEDDATA_KEEP_DAYS="30  # Keep Xcode derived data for 30 days"
+CLEANUP_CACHE_DAYS="30"
+TMP_CLEAN_DAYS="7"
+XCODE_DERIVEDDATA_KEEP_DAYS="30"
 
 # Homebrew cleanup settings
-BREW_CLEAN_PRUNE_DAYS="30   # Prune Homebrew cache older than 30 days"
+BREW_CLEAN_PRUNE_DAYS="30"
 
 # Editor cache cleanup
-EDITOR_CACHE_AGE_DAYS="14   # Clean editor caches older than 14 days"
-EDITOR_CACHE_MAX_GB="2      # Clean if cache exceeds 2GB"
+EDITOR_CACHE_AGE_DAYS="14"
+EDITOR_CACHE_MAX_GB="2"
 
 # =============================================================================
 # DEVELOPMENT ENVIRONMENT SETTINGS
@@ -57,16 +57,16 @@ EDITOR_CACHE_MAX_GB="2      # Clean if cache exceeds 2GB"
 REPO_SEARCH_PATHS="$HOME/Documents/dev $HOME/RProjects"
 
 # Git maintenance settings
-GIT_SKIP_PATTERNS=node_modules|.venv|venv|.tox|.pytest_cache
+GIT_SKIP_PATTERNS="node_modules|.venv|venv|.tox|.pytest_cache"
 
-NODE_MODULES_MAX_AGE_DAYS="90  # and older than 90 days"
+NODE_MODULES_MAX_AGE_DAYS="90"
 # Node.js cleanup settings
-NODE_MODULES_MAX_GB="5      # Clean node_modules if larger than 5GB"
+NODE_MODULES_MAX_GB="5"
 
-CLEAN_VENVS="0              # Set to 1 to enable automatic venv cleanup"
+CLEAN_VENVS="0"
 # Python virtual environment cleanup
-VENV_MAX_AGE_DAYS="120      # Consider venvs older than 120 days for cleanup"
-VENV_MAX_GB="1              # and larger than 1GB"
+VENV_MAX_AGE_DAYS="120"
+VENV_MAX_GB="1"
 
 # =============================================================================
 # CLOUD AND NETWORK SETTINGS
@@ -76,7 +76,7 @@ VENV_MAX_GB="1              # and larger than 1GB"
 CLOUDSDK_CORE_PROJECT=perplexity-clone-project
 
 # Cloud logging (optional)
-GCLOUD_LOGGING="0           # Set to 1 to enable Google Cloud logging"
+GCLOUD_LOGGING="0"
 GCLOUD_LOG_NAME=maintenance
 
 # OneDrive monitoring (deprecated)
@@ -85,26 +85,26 @@ GCLOUD_LOG_NAME=maintenance
 # PACKAGE MANAGEMENT SETTINGS
 # =============================================================================
 
-UPDATE_HOMEBREW="1          # Auto-update Homebrew packages"
-UPDATE_MAS_APPS="1          # Auto-update Mac App Store apps"
-UPDATE_NODE_GLOBAL="1       # Auto-update global Node.js packages"
+UPDATE_HOMEBREW="1"
+UPDATE_MAS_APPS="1"
+UPDATE_NODE_GLOBAL="1"
 # Control which package managers get updated
-UPDATE_PIP_USER_PKGS="0     # Conservative: don't auto-update pip packages"
-UPDATE_RUBY_GEMS="1         # Auto-update Ruby gems"
+UPDATE_PIP_USER_PKGS="0"
+UPDATE_RUBY_GEMS="1"
 
 # Homebrew cask update settings
-UPDATE_GREEDY_LATEST="0     # Set to 1 to update casks with version :latest (more frequent updates)"
+UPDATE_GREEDY_LATEST="0"
 
 # =============================================================================
 # ADVANCED SETTINGS
 # =============================================================================
 
 # Performance settings
-GIT_MAINTENANCE_PARALLEL="2  # Number of parallel Git operations"
+GIT_MAINTENANCE_PARALLEL="2"
 
-BACKUP_BEFORE_CLEANUP="0    # Create backups before major cleanups (disk space intensive)"
+BACKUP_BEFORE_CLEANUP="0"
 # Safety settings - these should generally stay enabled
-REQUIRE_CLEAN_REPOS="1      # Skip Git maintenance on repos with uncommitted changes"
+REQUIRE_CLEAN_REPOS="1"
 
 # =============================================================================
 # ENVIRONMENT OVERRIDES
@@ -114,7 +114,7 @@ REQUIRE_CLEAN_REPOS="1      # Skip Git maintenance on repos with uncommitted cha
 # HOMEBREW_NO_AUTO_UPDATE=1  # Disable Homebrew auto-update during operations
 # HOMEBREW_NO_ENV_HINTS=1    # Hide Homebrew environment hints
 # Google Drive monitoring
-GDRIVE_SYNC_CHECK_HOURS="48  # Alert if no sync activity for 48 hours"
+GDRIVE_SYNC_CHECK_HOURS="48"
 
 # =============================================================================
 # CLOUD DRIVE PATHS
@@ -128,4 +128,4 @@ PROTONDRIVE_ROOT="$HOME/Library/CloudStorage/ProtonDrive-abhimehro@pm.me-folder"
 
 # Proton one-way backup destination under Proton Drive
 PROTON_BACKUP_DEST="$PROTONDRIVE_ROOT/HomeBackup"
-PROTON_BACKUP_EXPECT_DAYS="7  # Expected backup freshness window for ProtonDrive"
+PROTON_BACKUP_EXPECT_DAYS="7"


### PR DESCRIPTION
Fixes an issue in `maintenance/conf/config.env` where inline comments were placed inside double quotes during variable assignments (e.g., `NOTIFY_MODE="auto  # auto|none"`). This syntax causes the comment to be parsed as part of the string value, leading to issues with scripts expecting specific formats or numeric types. Also applied quotes to `GIT_SKIP_PATTERNS`.

---
*PR created automatically by Jules for task [6756699646946991280](https://jules.google.com/task/6756699646946991280) started by @abhimehro*