### PR TITLE
🎨 Palette: [Graceful TTY Degradation for spinners]

### DIFF
--- a/scripts/bootstrap_fish_plugins.sh
+++ b/scripts/bootstrap_fish_plugins.sh
@@ -22,7 +22,7 @@ warn() { echo -e "${YELLOW}⚠️  [WARN]${NC}  $*"; }
 err() { echo -e "${RED}❌ [ERR]${NC}   $*" >&2; }
 
 # Restore cursor on exit/interrupt
-trap 'tput cnorm 2>/dev/null || true' EXIT INT TERM
+trap '[ -t 1 ] && tput cnorm 2>/dev/null || true' EXIT INT TERM
 
 # Spinner function (Palette 🎨 UX enhanced)
 spinner() {
@@ -52,8 +52,8 @@ spinner() {
 	"$@" >"$temp_log" 2>&1 &
 	pid=$!
 
-	# Hide cursor
-	tput civis 2>/dev/null || true
+	# Hide cursor gracefully in TTY
+	[ -t 1 ] && tput civis 2>/dev/null || true
 
 	local elapsed=0
 	local count=0
@@ -69,8 +69,8 @@ spinner() {
 	wait $pid
 	local exit_code=$?
 
-	# Restore cursor (handled by trap too, but good to be explicit here for cleanliness)
-	tput cnorm 2>/dev/null || true
+	# Restore cursor gracefully in TTY
+	[ -t 1 ] && tput cnorm 2>/dev/null || true
 	printf "\r\033[K"
 
 	if [ $exit_code -eq 0 ]; then

--- a/scripts/windscribe-connect.sh
+++ b/scripts/windscribe-connect.sh
@@ -38,17 +38,17 @@ spinner_wait() {
 		iterations=$((duration * 10))
 		local c=0
 
-		# Hide cursor
-		tput civis 2>/dev/null || true
+		# Hide cursor gracefully in TTY
+		[ -t 1 ] && tput civis 2>/dev/null || true
 
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap 'tput cnorm 2>/dev/null || true; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap 'tput cnorm 2>/dev/null || true; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r${BLUE}[%c]${NC} %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -58,7 +58,7 @@ spinner_wait() {
 		printf "\r\033[K" # Clear line
 
 		# Restore cursor and original traps
-		tput cnorm 2>/dev/null || true
+		[ -t 1 ] && tput cnorm 2>/dev/null || true
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else


### PR DESCRIPTION
🎨 Palette: [Graceful TTY Degradation for spinners]

💡 What: Wrapped `tput civis` and `tput cnorm` commands in `scripts/windscribe-connect.sh` and `scripts/bootstrap_fish_plugins.sh` with `[ -t 1 ] &&` checks.
🎯 Why: Unconditional cursor manipulation commands print raw ANSI escape sequences and cause "terminal spam" in non-interactive shell environments (like CI systems or background cron jobs), which degrades accessibility for screen readers and pollutes logs.
📸 Before/After: Visual spinners remain identical in interactive terminals, but backend/CI execution now remains completely clean of `^[[?25l` cursor hide sequences.
♿ Accessibility: Ensures that loading spinners gracefully fallback to static text in non-TTY environments, making logs fully screen-reader friendly.

---
*PR created automatically by Jules for task [14572441525360657358](https://jules.google.com/task/14572441525360657358) started by @abhimehro*