### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in dynamic variable assignment

### DIFF
--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -841,7 +841,7 @@ update_progress_if_needed() {
 		start_section_spinner "Scanning items... $completed/$total"
 
 		# Update the last_update_time variable
-		eval "$last_update_var=$current_time"
+		printf -v "$last_update_var" "%s" "$current_time"
 		return 0
 	fi
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in dynamic variable assignment

**Severity:** CRITICAL
**Vulnerability:** A Command Injection (CWE-78) risk existed in `configs/.config/mole/lib/core/base.sh` where `eval` was used for dynamic variable assignment (`eval "$last_update_var=$current_time"`).
**Impact:** While the variable name was strictly validated by regex, using `eval` to evaluate strings is an anti-pattern that can lead to arbitrary code execution if dynamic or unsanitized input is introduced.
**Fix:** Replaced the `eval` assignment with the safer Bash built-in `printf -v`, which assigns a formatted string directly to a dynamically named variable without passing it through the shell evaluator.
**Verification:** Ran `make test-all` and ensured all tests passed without regressions. Checked with `git diff`.

---
*PR created automatically by Jules for task [13727463259737503410](https://jules.google.com/task/13727463259737503410) started by @abhimehro*