### PR TITLE
⚡ Bolt: Optimize date parsing in `staleness_days`

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -607,20 +607,29 @@ def extract_horoscope_text(data: dict[str, Any]) -> str | None:
     return None
 
 
-def staleness_days(updated_at: str, today_iso: str) -> int:
-    """Return days since last update, or 0 on parse failure."""
+def staleness_days(updated_at: str, today: dt.date) -> int:
+    """Return days since last update, or 0 on parse failure.
+
+    Performance Note:
+    Accepts a pre-computed datetime.date object instead of an ISO string
+    to avoid redundant O(N) parsing operations during loop traversal.
+    """
     if not updated_at:
         return 0
     try:
         updated_date = dt.date.fromisoformat(updated_at[:10])
-        today = dt.date.fromisoformat(today_iso)
         return max((today - updated_date).days, 0)
     except (ValueError, TypeError):
         return 0
 
 
-def score_linear_issue(issue: dict[str, Any], today_iso: str) -> int:
-    """Score a Linear issue with priority, due date, state, labels, and staleness."""
+def score_linear_issue(issue: dict[str, Any], today_iso: str, today: dt.date) -> int:
+    """Score a Linear issue with priority, due date, state, labels, and staleness.
+
+    Performance Note:
+    Accepts both the string and date object formats for 'today' so string comparisons
+    (for due dates) and date math (for staleness) can both happen without conversions.
+    """
     priority = issue.get("priority") or 0
     due_date = issue.get("dueDate") or ""
     state_type = (issue.get("state", {}).get("type") or "").lower().replace("_", "")
@@ -652,7 +661,7 @@ def score_linear_issue(issue: dict[str, Any], today_iso: str) -> int:
                 score += bonus
 
     # Staleness penalty (issues untouched > 14 days get penalized)
-    stale = staleness_days(updated_at, today_iso)
+    stale = staleness_days(updated_at, today)
     if stale > 14:
         score -= min(stale - 14, 30)
 
@@ -926,7 +935,7 @@ def fetch_linear_focus_items(
                     state_type=state.get("type", ""),
                     due_date=issue.get("dueDate") or "",
                     badge=priority_labels.get(issue.get("priority") or 0, ""),
-                    score=score_linear_issue(issue, daily.today_iso),
+                    score=score_linear_issue(issue, daily.today_iso, daily.today),
                     labels=label_names,
                     updated_at=issue.get("updatedAt") or "",
                 )

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -240,20 +240,22 @@ class TestExtractHoroscopeText(unittest.TestCase):
 
 
 class TestStaleness(unittest.TestCase):
+    TODAY_DATE = dt.date(2026, 3, 25)
+
     def test_zero_for_today(self):
-        assert mb.staleness_days("2026-03-25T12:00:00Z", "2026-03-25") == 0
+        assert mb.staleness_days("2026-03-25T12:00:00Z", self.TODAY_DATE) == 0
 
     def test_positive_days(self):
-        assert mb.staleness_days("2026-03-20T12:00:00Z", "2026-03-25") == 5
+        assert mb.staleness_days("2026-03-20T12:00:00Z", self.TODAY_DATE) == 5
 
     def test_empty_string(self):
-        assert mb.staleness_days("", "2026-03-25") == 0
+        assert mb.staleness_days("", self.TODAY_DATE) == 0
 
     def test_invalid_format(self):
-        assert mb.staleness_days("not-a-date", "2026-03-25") == 0
+        assert mb.staleness_days("not-a-date", self.TODAY_DATE) == 0
 
     def test_future_date(self):
-        assert mb.staleness_days("2026-03-30T12:00:00Z", "2026-03-25") == 0
+        assert mb.staleness_days("2026-03-30T12:00:00Z", self.TODAY_DATE) == 0
 
 
 # ============================================================
@@ -263,6 +265,7 @@ class TestStaleness(unittest.TestCase):
 
 class TestScoreLinearIssue(unittest.TestCase):
     TODAY = "2026-03-25"
+    TODAY_DATE = dt.date(2026, 3, 25)
 
     def _issue(self, **overrides):
         base = {
@@ -278,50 +281,50 @@ class TestScoreLinearIssue(unittest.TestCase):
 
     def test_due_today_urgent(self):
         issue = self._issue(priority=1, dueDate=self.TODAY)
-        score = mb.score_linear_issue(issue, self.TODAY)
+        score = mb.score_linear_issue(issue, self.TODAY, self.TODAY_DATE)
         assert score >= 180  # 100 + 80 + state
 
     def test_no_priority_no_due(self):
         issue = self._issue()
-        score = mb.score_linear_issue(issue, self.TODAY)
+        score = mb.score_linear_issue(issue, self.TODAY, self.TODAY_DATE)
         assert score >= 0
         assert score < 50
 
     def test_started_state_bonus(self):
         issue = self._issue(state={"name": "In Progress", "type": "started"})
-        score_started = mb.score_linear_issue(issue, self.TODAY)
+        score_started = mb.score_linear_issue(issue, self.TODAY, self.TODAY_DATE)
         issue_backlog = self._issue(state={"name": "Backlog", "type": "backlog"})
-        score_backlog = mb.score_linear_issue(issue_backlog, self.TODAY)
+        score_backlog = mb.score_linear_issue(issue_backlog, self.TODAY, self.TODAY_DATE)
         assert score_started > score_backlog
 
     def test_label_bonus(self):
         issue_bug = self._issue(labels={"nodes": [{"name": "Bug"}]})
         issue_plain = self._issue()
-        assert mb.score_linear_issue(issue_bug, self.TODAY) > mb.score_linear_issue(
-            issue_plain, self.TODAY
+        assert mb.score_linear_issue(issue_bug, self.TODAY, self.TODAY_DATE) > mb.score_linear_issue(
+            issue_plain, self.TODAY, self.TODAY_DATE
         )
 
     def test_staleness_penalty(self):
         issue_stale = self._issue(updatedAt="2026-02-01T00:00:00Z")
         issue_fresh = self._issue(updatedAt="2026-03-24T00:00:00Z")
-        assert mb.score_linear_issue(issue_fresh, self.TODAY) >= mb.score_linear_issue(
-            issue_stale, self.TODAY
+        assert mb.score_linear_issue(issue_fresh, self.TODAY, self.TODAY_DATE) >= mb.score_linear_issue(
+            issue_stale, self.TODAY, self.TODAY_DATE
         )
 
     def test_cycle_bonus(self):
         issue_cycle = self._issue(cycle={"id": "abc"})
         issue_no_cycle = self._issue()
-        assert mb.score_linear_issue(issue_cycle, self.TODAY) > mb.score_linear_issue(
-            issue_no_cycle, self.TODAY
+        assert mb.score_linear_issue(issue_cycle, self.TODAY, self.TODAY_DATE) > mb.score_linear_issue(
+            issue_no_cycle, self.TODAY, self.TODAY_DATE
         )
 
     def test_score_never_negative(self):
         issue = self._issue(updatedAt="2020-01-01T00:00:00Z")
-        assert mb.score_linear_issue(issue, self.TODAY) >= 0
+        assert mb.score_linear_issue(issue, self.TODAY, self.TODAY_DATE) >= 0
 
     def test_missing_fields(self):
         """Issues with completely missing fields should not crash."""
-        score = mb.score_linear_issue({}, self.TODAY)
+        score = mb.score_linear_issue({}, self.TODAY, self.TODAY_DATE)
         assert isinstance(score, int)
         assert score >= 0
 


### PR DESCRIPTION
💡 **What:** Modified `staleness_days` and `score_linear_issue` in `scripts/morning-brief/morning-brief.py` to accept a pre-computed `datetime.date` object (`today`) instead of repeatedly parsing a string (`today_iso`). Also added performance comments explaining the rationale.

🎯 **Why:** The script previously called `dt.date.fromisoformat(today_iso)` for every single Linear issue evaluated inside `staleness_days`. This parsing operation inside a loop introduces unnecessary overhead. Lifting the parsing out of the loop and passing the object down transforms the parsing from O(N) to O(1).

📊 **Impact:** Reduces redundant string parsing by 100% inside the `staleness_days` tight loop, slightly improving the performance of the Linear issue ranking logic.

🔬 **Measurement:** Code execution speed can be verified by observing the generation time, though the win is a micro-optimization on date math. Tests successfully assert exact parity in functional behavior.

---
*PR created automatically by Jules for task [16865362249520743909](https://jules.google.com/task/16865362249520743909) started by @abhimehro*