### PR TITLE
🎨 Palette: Improve CLI screen reader accessibility by disabling ANSI codes in non-TTY

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -89,3 +89,8 @@
 
 **Learning:** In Node.js CLI tools, unconditional ANSI escape sequences for cursor manipulation (e.g., `\x1B[?25h`, `\x1B[K`) cause 'terminal spam' in non-TTY environments, breaking screen readers and cluttering CI logs.
 **Action:** Always wrap these in `if (process.stdout.isTTY)` checks to ensure accessibility and clean output.
+
+## 2026-03-31 - Disable ANSI Colors in non-TTY CLIs
+
+**Learning:** Unconditional ANSI color codes in Node.js CLI tools create severe "terminal spam" for screen readers and CI environments. Even if a script conditionally handles interactive features (like a spinner), unconditionally styling static output (like headers and static messages) still breaks accessibility.
+**Action:** Make both cursor manipulation codes and styling variables (like `COLORS`) strictly conditional on `process.stdout.isTTY` using ternary operators, ensuring a clean and accessible text fallback.

--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -1,17 +1,19 @@
 import { CopilotClient, defineTool, SessionEvent } from "@github/copilot-sdk";
 import * as readline from "readline";
 
+const isTTY = !!process.stdout.isTTY;
+
 const COLORS = {
-  Reset: "\x1b[0m",
-  Cyan: "\x1b[36m",
-  Green: "\x1b[32m",
-  Dim: "\x1b[2m",
+  Reset: isTTY ? "\x1b[0m" : "",
+  Cyan: isTTY ? "\x1b[36m" : "",
+  Green: isTTY ? "\x1b[32m" : "",
+  Dim: isTTY ? "\x1b[2m" : "",
 };
 
 const ANSI = {
-  HideCursor: "\x1B[?25l",
-  ShowCursor: "\x1B[?25h",
-  ClearLine: "\x1B[K",
+  HideCursor: isTTY ? "\x1B[?25l" : "",
+  ShowCursor: isTTY ? "\x1B[?25h" : "",
+  ClearLine: isTTY ? "\x1B[K" : "",
 };
 
 const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];


### PR DESCRIPTION
🎨 Palette UX Enhancement: Improved CLI Accessibility

**What:**
Made the ANSI color constants (`COLORS` and `ANSI`) conditional on `process.stdout.isTTY` in the `weather-assistant.ts` Node.js CLI script.

**Why:**
In Node.js CLI tools, unconditional ANSI escape sequences (for cursor manipulation and text colors) cause "terminal spam" in non-TTY environments. This breaks screen readers and clutters CI/headless execution logs. While the interactive spinner had a non-TTY fallback, the fallback itself was unconditionally styled using ANSI color codes.

**Accessibility Impact:**
Screen readers will now cleanly read text outputs (e.g., `Assistant: (Consulting the clouds...)`) instead of vocalizing raw escape code gibberish (like `\x1B[32m` before every word).

Tested locally with `make test-all`. Added critical accessibility journal entry.

---
*PR created automatically by Jules for task [2187041145299469251](https://jules.google.com/task/2187041145299469251) started by @abhimehro*