### PR TITLE
🎨 Palette: Prevent visual artifacts on CLI spinner interrupt

### DIFF
--- a/maintenance/bin/run_all_maintenance.sh
+++ b/maintenance/bin/run_all_maintenance.sh
@@ -137,7 +137,7 @@ spinner() {
 		tput civis 2>/dev/null || true
 
 		# Trap to restore cursor if interrupted
-		trap 'tput cnorm 2>/dev/null || true; exit' INT TERM
+		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; exit' INT TERM
 
 		local start_time
 		start_time=$(date +%s)
@@ -185,7 +185,7 @@ wait_for_pids() {
 
 	if [ -t 1 ] && [ -z "${CI-}" ]; then
 		tput civis 2>/dev/null || true
-		trap 'tput cnorm 2>/dev/null || true; trap - INT TERM; kill -s INT $$' INT TERM
+		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT TERM; kill -s INT $$' INT TERM
 
 		local start_time
 		start_time=$(date +%s)

--- a/maintenance/bin/smart_scheduler.sh
+++ b/maintenance/bin/smart_scheduler.sh
@@ -44,11 +44,11 @@ spinner_wait() {
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap 'tput cnorm 2>/dev/null || true; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap 'tput cnorm 2>/dev/null || true; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		local interval=0.5
 		iterations=$(echo "$duration / $interval" | bc -l | cut -d. -f1)

--- a/scripts/bootstrap_fish_plugins.sh
+++ b/scripts/bootstrap_fish_plugins.sh
@@ -22,7 +22,7 @@ warn() { echo -e "${YELLOW}⚠️  [WARN]${NC}  $*"; }
 err() { echo -e "${RED}❌ [ERR]${NC}   $*" >&2; }
 
 # Restore cursor on exit/interrupt
-trap '[ -t 1 ] && tput cnorm 2>/dev/null || true' EXIT INT TERM
+trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"' EXIT INT TERM
 
 # Spinner function (Palette 🎨 UX enhanced)
 spinner() {

--- a/scripts/windscribe-connect.sh
+++ b/scripts/windscribe-connect.sh
@@ -44,11 +44,11 @@ spinner_wait() {
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r${BLUE}[%c]${NC} %s..." "${sp:i++%${#sp}:1}" "$msg"


### PR DESCRIPTION
✨ **Palette: Clear CLI spinner lines on interrupt**

💡 **What:**
Updated `trap` commands in several CLI scripts to include `printf "\r\033[K"` when restoring the terminal cursor upon an interrupt (e.g. `Ctrl+C`).

🎯 **Why:**
When looping over a `\r` spinner, the current line is constantly being overwritten. If a user interrupts the script during this process, the terminal often drops them back to their prompt on the exact same line, leaving partial spinner characters or "garbage" text behind. Clearing the line completely on exit ensures a clean, predictable terminal experience, acting as a small but impactful UX enhancement.

♿ **Accessibility:**
Provides a cleaner exit state for screen readers by ensuring partial updates aren't orphaned on the console output upon termination.

---
*PR created automatically by Jules for task [9405743747748587837](https://jules.google.com/task/9405743747748587837) started by @abhimehro*