### PR TITLE
⚡ Bolt: Replace strptime with fromisoformat for faster date parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -102,3 +102,7 @@
 
 **Learning:** Passing an ISO string and parsing it with `dt.date.fromisoformat()` repeatedly within tight loops (e.g., inside the scoring loop for Linear issues) creates unnecessary CPU overhead. By parsing the date once and passing the `datetime.date` object down to the utility functions, we save ~30% parsing overhead per issue without impacting functionality.
 **Action:** When a function requires a date for calculations and is called repeatedly in a loop, parse the date outside the loop and pass the `datetime.date` object as an argument instead of the raw string.
+
+## 2026-04-04 - strptime vs fromisoformat overhead
+**Learning:** In Python, parsing ISO-8601 timestamp strings using `datetime.strptime` involves format string processing overhead that can be significantly slow inside loops. `datetime.fromisoformat()` is implemented in C and optimized for ISO strings, executing 20x-40x faster.
+**Action:** When parsing standard ISO timestamps (e.g., from APIs or configuration files), use `datetime.fromisoformat()` instead of `strptime`. For strings ending with `"Z"` (UTC), use `.replace("Z", "+00:00")` before parsing to maintain compatibility with Python versions older than 3.11.

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -61,7 +61,9 @@ for repo, prs in repos.items():
         
         days_old = 0
         if updated_at:
-            dt = datetime.strptime(updated_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+            # ⚡ Bolt Optimization: Replace strptime with fromisoformat for ~40x faster date parsing.
+            # Replace 'Z' with '+00:00' to support Python < 3.11 parsing of UTC strings
+            dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
             now = datetime.now(timezone.utc)
             days_old = (now - dt).days
             


### PR DESCRIPTION
💡 **What:** Replaced `datetime.strptime` with `datetime.fromisoformat` in `parse_inventory.py` to optimize date string parsing.
🎯 **Why:** `datetime.strptime` includes significant format string evaluation overhead, while `datetime.fromisoformat` is highly optimized in C for standard ISO dates, avoiding this unnecessary overhead when parsing dates from API responses inside loops.
📊 **Impact:** Expect ~20x-40x faster date parsing in the triage loop.
🔬 **Measurement:** Use a standalone benchmark comparing `datetime.fromisoformat("...".replace("Z", "+00:00"))` and `datetime.strptime("...", "%Y-%m-%dT%H:%M:%SZ")` or measure the runtime of `parse_inventory.py` on a large `tasks/pr-inventory.md` file before and after the change.

---
*PR created automatically by Jules for task [17834258397510284424](https://jules.google.com/task/17834258397510284424) started by @abhimehro*