### PR TITLE
🎨 Palette: Graceful cleanup of CLI animations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -94,3 +94,8 @@
 
 **Learning:** Unconditional ANSI color codes in Node.js CLI tools create severe "terminal spam" for screen readers and CI environments. Even if a script conditionally handles interactive features (like a spinner), unconditionally styling static output (like headers and static messages) still breaks accessibility.
 **Action:** Make both cursor manipulation codes and styling variables (like `COLORS`) strictly conditional on `process.stdout.isTTY` using ternary operators, ensuring a clean and accessible text fallback.
+
+## 2026-04-10 - Graceful Cleanup of CLI Animations
+
+**Learning:** When interrupting an asynchronous stream (like a CLI loading spinner) or handling an error, hardcoded prefix strings in the cleanup function can cause visual artifacts. If the stream starts and fails, or if a user hits Ctrl+C, they might be left with orphaned text like "Assistant: " hanging on their terminal prompt.
+**Action:** Separate terminal clearing logic (e.g. `clearSpinner`) from content rendering. Only print standard prefixes when the response actually begins streaming, and ensure error handlers and signal traps completely clear the line.

--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -7,6 +7,7 @@ const COLORS = {
   Reset: isTTY ? "\x1b[0m" : "",
   Cyan: isTTY ? "\x1b[36m" : "",
   Green: isTTY ? "\x1b[32m" : "",
+  Red: isTTY ? "\x1b[31m" : "",
   Dim: isTTY ? "\x1b[2m" : "",
 };
 
@@ -28,20 +29,12 @@ const thinkingMessages = [
   "Looking at the sky...",
 ];
 
-const stopSpinner = () => {
+const clearSpinner = () => {
   if (spinnerInterval) {
     clearInterval(spinnerInterval);
     spinnerInterval = undefined;
     if (process.stdout.isTTY) {
-      process.stdout.write(
-        ANSI.ShowCursor +
-          "\r" +
-          COLORS.Green +
-          "Assistant:" +
-          COLORS.Reset +
-          " " +
-          ANSI.ClearLine,
-      );
+      process.stdout.write(ANSI.ShowCursor + "\r" + ANSI.ClearLine);
     }
   }
 };
@@ -167,9 +160,17 @@ const session = await client.createSession({
   tools: [getWeather, getCurrentTime],
 });
 
+let responseStarted = false;
+
 session.on((event: SessionEvent) => {
   if (event.type === "assistant.message_delta") {
-    stopSpinner();
+    if (!responseStarted) {
+      clearSpinner();
+      process.stdout.write(
+        COLORS.Green + "Assistant:" + COLORS.Reset + " "
+      );
+      responseStarted = true;
+    }
     process.stdout.write(event.data.deltaContent);
   }
 });
@@ -210,7 +211,7 @@ printHeader();
 
 // Graceful shutdown on Ctrl+C
 rl.on("SIGINT", async () => {
-  stopSpinner();
+  clearSpinner();
   console.log(`\n${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
   try {
     await client.stop();
@@ -223,7 +224,7 @@ rl.on("SIGINT", async () => {
 
 // Graceful shutdown on EOF (Ctrl+D)
 rl.on("close", async () => {
-  stopSpinner();
+  clearSpinner();
   console.log(`\n${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
   try {
     await client.stop();
@@ -277,10 +278,16 @@ ${COLORS.Cyan}Commands:${COLORS.Reset}
     }
 
     startSpinner();
+    responseStarted = false;
     try {
       await session.sendAndWait({ prompt: input });
+    } catch (err: any) {
+      clearSpinner();
+      console.log(
+        `${COLORS.Red}Error:${COLORS.Reset} Could not reach the assistant. Please try again. (${err?.message || "Unknown error"})`
+      );
     } finally {
-      stopSpinner();
+      clearSpinner();
     }
     console.log("\n");
     prompt();


### PR DESCRIPTION
🎨 Palette: Graceful Cleanup of CLI Animations

💡 **What:** Refactored the loading spinner cleanup logic (`stopSpinner` -> `clearSpinner`) in the interactive Copilot CLI demo and introduced a `responseStarted` flag to defer printing the `Assistant:` prefix. Also added user-friendly error handling to the prompt flow.

🎯 **Why:** If an asynchronous network call failed or a user hit `Ctrl+C` before the assistant actually started streaming its response, the hardcoded prefix inside the cleanup function would leave orphaned text like `Assistant: ` hanging above their shell prompt, creating visual clutter. Decoupling the clearing logic from the rendering logic creates a cleaner micro-UX.

♿ **Accessibility:** By safely clearing the line and using a `catch` block with a clear error message (colored `Red` for visibility), users are explicitly informed of network/model failures rather than being left waiting indefinitely or with broken terminal output.

📸 **Before:**
```
$ pnpm start
You: hello
Assistant: 
$ |
```

📸 **After:**
```
$ pnpm start
You: hello

Goodbye! 👋
$ |
```

---
*PR created automatically by Jules for task [15048802640377403397](https://jules.google.com/task/15048802640377403397) started by @abhimehro*