### PR TITLE
🎨 Palette: Add friendly SIGINT handlers to interactive scripts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -99,3 +99,8 @@
 
 **Learning:** When interrupting an asynchronous stream (like a CLI loading spinner) or handling an error, hardcoded prefix strings in the cleanup function can cause visual artifacts. If the stream starts and fails, or if a user hits Ctrl+C, they might be left with orphaned text like "Assistant: " hanging on their terminal prompt.
 **Action:** Separate terminal clearing logic (e.g. `clearSpinner`) from content rendering. Only print standard prefixes when the response actually begins streaming, and ensure error handlers and signal traps completely clear the line.
+
+## 2026-04-11 - Graceful SIGINT handling in interactive scripts
+
+**Learning:** When users interrupt an interactive script via Ctrl+C, abrupt termination can leave the terminal in an untidy state without giving proper feedback.
+**Action:** In interactive bash scripts, always add a `trap` for `SIGINT` that outputs a polite, color-coded cancellation message and terminates using `exit 130` (the POSIX standard for `SIGINT`).

--- a/scripts/macos/SURGICAL_CLEANUP.sh
+++ b/scripts/macos/SURGICAL_CLEANUP.sh
@@ -10,6 +10,8 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+trap 'echo -e "\n${YELLOW}👋 Cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+
 print_status() {
 	echo -e "${BLUE}[INFO]${NC} $1"
 }

--- a/scripts/setup-controld.sh
+++ b/scripts/setup-controld.sh
@@ -20,6 +20,8 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+trap 'echo -e "\n${YELLOW}👋 Cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+
 log() { echo -e "${BLUE}[INFO]${NC} $*"; }
 success() { echo -e "${GREEN}[OK]${NC} $*"; }
 error() {

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -14,7 +14,7 @@ BLUE='\033[0;34m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-trap 'echo -e "\n${YELLOW}👋 Cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+trap 'printf "\n${YELLOW}👋 Cancelled by user. Goodbye!${NC}\n"; exit 130' SIGINT
 
 # Emojis 🎨
 E_INFO="ℹ️"

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -14,6 +14,8 @@ BLUE='\033[0;34m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+trap 'echo -e "\n${YELLOW}👋 Cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+
 # Emojis 🎨
 E_INFO="ℹ️"
 E_OK="✅"


### PR DESCRIPTION
### 💡 What: 
Added a graceful `SIGINT` (Ctrl+C) trap to three interactive scripts: `setup-controld.sh`, `SURGICAL_CLEANUP.sh`, and `youtube-download.sh`.

### 🎯 Why: 
When users interrupt an interactive script via Ctrl+C, an abrupt termination can leave the terminal in an untidy state without giving proper feedback. The friendly cancellation message provides immediate, clear feedback that their intent was registered and cleanly handles the termination (using the standard POSIX `exit 130`).

### ♿ Accessibility & UX:
- Replaces an abrupt termination with a clear, color-coded status message.
- Uses standard POSIX exit code to ensure any parent or orchestrating scripts can correctly identify that the user cancelled the operation.

---
*PR created automatically by Jules for task [16690924368274904684](https://jules.google.com/task/16690924368274904684) started by @abhimehro*