### PR TITLE
🎨 Palette: Prevent terminal cursor flicker during inline spinner

### DIFF
--- a/configs/.config/mole/lib/core/ui.sh
+++ b/configs/.config/mole/lib/core/ui.sh
@@ -337,6 +337,9 @@ start_inline_spinner() {
 			# Clear line on first output to prevent text remnants from previous messages
 			printf "\r\033[2K" >&2 || true
 
+			# Hide terminal cursor to prevent flicker
+			tput civis >&2 2>/dev/null || true
+
 			# Cooperative exit: check for stop file instead of relying on signals
 			while [[ ! -f $stop_file ]]; do
 				local c="${chars:$((i % ${#chars})):1}"
@@ -345,6 +348,9 @@ start_inline_spinner() {
 				i=$((i + 1))
 				/bin/sleep 0.05
 			done
+
+			# Restore terminal cursor
+			tput cnorm >&2 2>/dev/null || true
 
 			# Clean up stop file before exiting
 			rm -f "$stop_file" 2>/dev/null || true
@@ -384,7 +390,10 @@ stop_inline_spinner() {
 		INLINE_SPINNER_STOP_FILE=""
 
 		# Clear the line - use \033[2K to clear entire line, not just to end
-		[[ -t 1 ]] && printf "\r\033[2K" >&2 || true
+		if [[ -t 1 ]]; then
+			printf "\r\033[2K" >&2 || true
+			tput cnorm >&2 2>/dev/null || true
+		fi
 	fi
 }
 


### PR DESCRIPTION
UX: Prevent terminal cursor flicker during inline spinner

**What**: Hides the terminal cursor while the inline spinner is running in `configs/.config/mole/lib/core/ui.sh`.
**Why**: The loop redraws the line every 0.05 seconds, causing the cursor to flicker continuously, which degrades the experience.
**Accessibility**: The commands are already gated behind a TTY check so they won't cause issues in CI or screen readers. Redirecting output to stderr prevents breaking scripts that pipe output.

---
*PR created automatically by Jules for task [17374255109321227956](https://jules.google.com/task/17374255109321227956) started by @abhimehro*