### PR TITLE
🎨 Palette: Explicit defaults for CLI prompts

### DIFF
--- a/configs/.config/mole/bin/touchid.sh
+++ b/configs/.config/mole/bin/touchid.sh
@@ -92,6 +92,7 @@ enable_touchid() {
 	if ! supports_touchid; then
 		log_warning "This Mac may not support Touch ID"
 		read -rp "Continue anyway? [y/N] " confirm
+		confirm=${confirm:-N}
 		if [[ ! $confirm =~ ^[Yy]$ ]]; then
 			echo -e "${YELLOW}Cancelled${NC}"
 			return 1

--- a/scripts/install_all_configs.sh
+++ b/scripts/install_all_configs.sh
@@ -53,6 +53,7 @@ substep "Verify all symlinks"
 echo ""
 while true; do
 	read -r -p "Ready to proceed? (y/N) " reply
+	reply=${reply:-N}
 	echo ""
 	case "$reply" in
 	[Yy]*)


### PR DESCRIPTION
🎨 **Palette: Explicit Defaults in Interactive CLIs**

**💡 What:**
Added explicit parameter expansion defaults (e.g. `reply=${reply:-N}`) immediately following the `read -p` prompts in `install_all_configs.sh` and `configs/.config/mole/bin/touchid.sh`.

**🎯 Why:**
When offering a default option in a CLI prompt (e.g., "[y/N]"), explicitly setting the default value in code is safer and more robust than relying on empty string matching in `case` or `if` statements down the line. This prevents "false affordances" where the UI promises a default but the code might not strictly enforce it.

**♿ Accessibility / UX:**
Improves the interactive CLI UX by making the intention explicit in code and standardizing prompt fallback behaviors across scripts. No visual change, strictly behavioral robustness.

---
*PR created automatically by Jules for task [13130451252540568976](https://jules.google.com/task/13130451252540568976) started by @abhimehro*