### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) in PR scripts

### DIFF
--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,8 +1,25 @@
 import subprocess
 import json
+import os
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    try:
+        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"): continue
+                if line.startswith("export "): line = line[7:].strip()
+                if "=" in line:
+                    key, val = line.split("=", 1)
+                    env[key] = val.strip("'\"")
+    except FileNotFoundError:
+        pass
+    return env
 
 def run_gh(cmd):
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    env = _load_gh_token_env()
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if result.returncode != 0:
         return None
     try:
@@ -47,7 +64,7 @@ categorized = {
 
 for pr in ready_prs:
     repo, pr_id = pr.split('#')
-    info = run_gh(f"source ../email-security-pipeline/GH_TOKEN.env && gh pr view {pr_id} -R {repo} --json title,mergeStateStatus")
+    info = run_gh(["gh", "pr", "view", str(pr_id), "-R", str(repo), "--json", "title,mergeStateStatus"])
     if not info: continue
     
     # Exclude unstable/dirty

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -1,10 +1,27 @@
 import re
 import json
 import subprocess
+import os
 from collections import defaultdict
 
+def _load_gh_token_env():
+    env = os.environ.copy()
+    try:
+        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"): continue
+                if line.startswith("export "): line = line[7:].strip()
+                if "=" in line:
+                    key, val = line.split("=", 1)
+                    env[key] = val.strip("'\"")
+    except FileNotFoundError:
+        pass
+    return env
+
 def run_gh(cmd):
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    env = _load_gh_token_env()
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if result.returncode != 0:
         return None
     try:
@@ -23,7 +40,7 @@ ready_only = [pr for pr in ready_prs if not any(pr in l for l in lines[:lines.in
 file_groups = defaultdict(list)
 for pr in ready_only:
     repo, pr_id = pr.split('#')
-    info = run_gh(f"source ../email-security-pipeline/GH_TOKEN.env && gh pr view {pr_id} -R {repo} --json files,title,number")
+    info = run_gh(["gh", "pr", "view", str(pr_id), "-R", str(repo), "--json", "files,title,number"])
     if not info:
         continue
     files = tuple(sorted([f['path'] for f in info.get('files', [])]))

--- a/run_merges.py
+++ b/run_merges.py
@@ -1,9 +1,26 @@
 import subprocess
 import json
 import time
+import os
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    try:
+        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"): continue
+                if line.startswith("export "): line = line[7:].strip()
+                if "=" in line:
+                    key, val = line.split("=", 1)
+                    env[key] = val.strip("'\"")
+    except FileNotFoundError:
+        pass
+    return env
 
 def run_gh(cmd):
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    env = _load_gh_token_env()
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if result.returncode != 0:
         return None
     try:
@@ -12,7 +29,8 @@ def run_gh(cmd):
         return result.stdout
 
 def get_diff(repo, pr):
-    result = subprocess.run(f"source ../email-security-pipeline/GH_TOKEN.env && gh pr diff {pr} -R {repo}", shell=True, capture_output=True, text=True)
+    env = _load_gh_token_env()
+    result = subprocess.run(["gh", "pr", "diff", str(pr), "-R", str(repo)], capture_output=True, text=True, env=env)
     return result.stdout
 
 queue = [
@@ -54,7 +72,7 @@ for repo, pr, title in queue:
     print(f"\nProcessing {repo}#{pr}: {title}")
     
     # Re-check status
-    info = run_gh(f"source ../email-security-pipeline/GH_TOKEN.env && gh pr view {pr} -R {repo} --json mergeStateStatus")
+    info = run_gh(["gh", "pr", "view", str(pr), "-R", str(repo), "--json", "mergeStateStatus"])
     if not info:
         print("Failed to get info")
         continue
@@ -95,7 +113,8 @@ for repo, pr, title in queue:
         continue
         
     print(f"Gate 2 passed. Merging...")
-    res = subprocess.run(f"source ../email-security-pipeline/GH_TOKEN.env && gh pr merge {pr} -R {repo} --squash --delete-branch", shell=True, capture_output=True, text=True)
+    env = _load_gh_token_env()
+    res = subprocess.run(["gh", "pr", "merge", str(pr), "-R", str(repo), "--squash", "--delete-branch"], capture_output=True, text=True, env=env)
     if res.returncode == 0:
         print(f"Successfully merged {repo}#{pr}")
         results['merged'].append((repo, pr, title))


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command Injection ([CWE-78](https://cwe.mitre.org/data/definitions/78.html)). The scripts `parse_inventory.py`, `detect_duplicates.py`, and `run_merges.py` used `subprocess.run` with `shell=True` and string-interpolated variables containing PR data parsed from a markdown file. An attacker controlling the markdown input could inject arbitrary shell commands.
🎯 **Impact:** Remote Code Execution (RCE). Arbitrary shell commands could be executed in the context of the GitHub Action or local user running the script, potentially exfiltrating tokens or modifying the repository.
🔧 **Fix:** 
1. Removed `shell=True` from all `subprocess.run` calls.
2. Converted command strings (e.g., `gh pr view {pr_id}...`) into secure string lists.
3. Implemented `_load_gh_token_env()` to manually parse the `.env` file natively in Python, eliminating the need to use bash `source` to load the token.
✅ **Verification:** Verified via `make test-all` and local shell tests.

---
*PR created automatically by Jules for task [3452330178149433852](https://jules.google.com/task/3452330178149433852) started by @abhimehro*