### PR TITLE
🎨 Palette: Delay static prefixes in CLI loading states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 
 **Learning:** When adding optional notifications to CLI scripts (like `terminal-notifier` on macOS), users without the third-party tool installed miss out on the UX improvement.
 **Action:** Always provide a native fallback when possible (e.g., using `osascript -e 'display notification...'` on Darwin) to ensure the UX enhancement reaches all users on that platform without requiring extra dependencies.
+
+## 2024-04-16 - Delaying static prefixes in CLI loading states
+**Learning:** Printing static prefixes (like "Assistant:") before a dynamic spinner completes causes screen reader redundancy and can leave visual artifacts on the terminal if the process is interrupted before the stream begins.
+**Action:** Delay printing static prefixes until the dynamic stream actually begins, and ensure that signal (SIGINT) and error handlers completely clear the line using `\r\x1B[K` to prevent orphaned text artifacts upon interruption.

--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -34,7 +34,7 @@ const clearSpinner = () => {
     clearInterval(spinnerInterval);
     spinnerInterval = undefined;
     if (process.stdout.isTTY) {
-      process.stdout.write(ANSI.ShowCursor + "\r" + ANSI.ClearLine);
+      process.stdout.write("\r" + ANSI.ClearLine + ANSI.ShowCursor);
     }
   }
 };
@@ -48,7 +48,7 @@ const startSpinner = () => {
   // Fallback for non-TTY (CI, screen readers) or when terminal isn't fully interactive
   if (!process.stdout.isTTY) {
     process.stdout.write(
-      `${COLORS.Green}Assistant:${COLORS.Reset} ${COLORS.Dim}(${msg})${COLORS.Reset}\n`,
+      `${COLORS.Dim}(${msg})${COLORS.Reset}\n`,
     );
     return;
   }
@@ -56,7 +56,7 @@ const startSpinner = () => {
   process.stdout.write(ANSI.HideCursor);
   spinnerInterval = setInterval(() => {
     process.stdout.write(
-      `\r${COLORS.Green}Assistant:${COLORS.Reset} ${spinnerFrames[i]} ${COLORS.Dim}(${msg})${COLORS.Reset}`,
+      `\r${spinnerFrames[i]} ${COLORS.Dim}(${msg})${COLORS.Reset}`,
     );
     i = (i + 1) % spinnerFrames.length;
   }, 80);
@@ -212,7 +212,10 @@ printHeader();
 // Graceful shutdown on Ctrl+C
 rl.on("SIGINT", async () => {
   clearSpinner();
-  console.log(`\n${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
+  if (process.stdout.isTTY) {
+    process.stdout.write("\r" + ANSI.ClearLine);
+  }
+  console.log(`${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
   try {
     await client.stop();
   } catch (e) {
@@ -225,7 +228,10 @@ rl.on("SIGINT", async () => {
 // Graceful shutdown on EOF (Ctrl+D)
 rl.on("close", async () => {
   clearSpinner();
-  console.log(`\n${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
+  if (process.stdout.isTTY) {
+    process.stdout.write("\r" + ANSI.ClearLine);
+  }
+  console.log(`${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
   try {
     await client.stop();
   } catch (e) {

--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -209,8 +209,7 @@ const printHeader = () => {
 
 printHeader();
 
-// Graceful shutdown on Ctrl+C
-rl.on("SIGINT", async () => {
+const handleShutdown = async () => {
   clearSpinner();
   if (process.stdout.isTTY) {
     process.stdout.write("\r" + ANSI.ClearLine);
@@ -223,22 +222,13 @@ rl.on("SIGINT", async () => {
   }
   rl.close();
   process.exit(0);
-});
+};
+
+// Graceful shutdown on Ctrl+C
+rl.on("SIGINT", handleShutdown);
 
 // Graceful shutdown on EOF (Ctrl+D)
-rl.on("close", async () => {
-  clearSpinner();
-  if (process.stdout.isTTY) {
-    process.stdout.write("\r" + ANSI.ClearLine);
-  }
-  console.log(`${COLORS.Green}Goodbye! 👋${COLORS.Reset}`);
-  try {
-    await client.stop();
-  } catch (e) {
-    // Ignore error
-  }
-  process.exit(0);
-});
+rl.on("close", handleShutdown);
 
 const prompt = () => {
   rl.question(`${COLORS.Cyan}You:${COLORS.Reset} `, async (input) => {

--- a/test-ux.sh
+++ b/test-ux.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-# test
+# Test file

--- a/test-ux.sh
+++ b/test-ux.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-# Test file
+# test


### PR DESCRIPTION
🎨 Palette: Delay static prefixes in CLI loading states

💡 What: Refactored the CLI loading spinner in `copilot-demo/weather-assistant.ts` to delay printing static text (like the "Assistant:" prefix) until the stream actually begins. Also added `\r` and `ANSI.ClearLine` to correctly erase the line during manual interruptions (Ctrl+C) or EOF.
🎯 Why: Printing a static prefix before dynamic content is fully ready leads to a disjointed visual experience and redundancy in screen readers. If a user interrupts the command or an error occurs during fetching, the static prefix gets left behind as an orphaned artifact on the terminal prompt.
♿ Accessibility: Non-TTY screen reader fallback is much cleaner as it no longer includes an upfront duplicate prefix during the thinking phase. Interactive spinners will no longer leak orphaned prefixes.

---
*PR created automatically by Jules for task [9234506694899587782](https://jules.google.com/task/9234506694899587782) started by @abhimehro*