### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Option Injection in pgrep commands

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -47,7 +47,7 @@ wait_for_process_stop() {
 	local process_name="$1"
 	local max_retries="${2:-20}"
 	local retry=0
-	while pgrep -x "$process_name" >/dev/null 2>&1 && [[ $retry -lt $max_retries ]]; do
+	while pgrep -x -- "$process_name" >/dev/null 2>&1 && [[ $retry -lt $max_retries ]]; do
 		sleep 0.1
 		retry=$((retry + 1))
 	done

--- a/scripts/lib/controld-service.sh
+++ b/scripts/lib/controld-service.sh
@@ -90,7 +90,7 @@ _wait_for_process_stop() {
 	local process_name="$1"
 	local max_retries="${2:-20}"
 	local retry=0
-	while pgrep -x "$process_name" >/dev/null 2>&1 && [[ $retry -lt $max_retries ]]; do
+	while pgrep -x -- "$process_name" >/dev/null 2>&1 && [[ $retry -lt $max_retries ]]; do
 		sleep 0.1
 		retry=$((retry + 1))
 	done


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Option Injection (CWE-88) in process monitoring scripts

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Several utility scripts (`scripts/lib/common.sh` and `scripts/lib/controld-service.sh`) passed unvalidated variables directly to `pgrep -x`. If an attacker or a script bug supplied a process name starting with a hyphen (e.g., `-u 0`), `pgrep` would interpret the variable as a command-line flag rather than a process search string.
🎯 **Impact:** Option injection (CWE-88) can lead to unexpected behavior, false positives/negatives in process discovery, or potentially privilege escalation depending on the injected flags and how the result is consumed.
🔧 **Fix:** Added the standard POSIX `--` delimiter to separate command options from positional arguments (e.g., `pgrep -x -- "$process_name"`), forcing `pgrep` to treat the variable strictly as the search string.
✅ **Verification:** Ran `make test-all`. Verified changes applied correctly across `scripts/lib/`. Tests confirm no regressions.

══════════ ELIR ══════════
PURPOSE: Mitigate option injection vulnerabilities in process management helpers.
SECURITY: Option Injection (CWE-88) mitigation. Prevents untrusted strings from acting as shell command flags.
FAILS IF: The process name string cannot be parsed even as a literal string (highly unlikely).
VERIFY: Ensure all modified `pgrep` commands contain `--` prior to the variable.
MAINTAIN: When writing new shell scripts, always use `--` before passing dynamic variables to commands like `grep`, `pgrep`, `pkill`, `rm`, etc.

---
*PR created automatically by Jules for task [15784064505053755977](https://jules.google.com/task/15784064505053755977) started by @abhimehro*