### PR TITLE
⚡ Bolt: Combine multiple find queries into a single evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -111,3 +111,13 @@
 
 **Learning:** In Python automation scripts calling functions like `matches_any` or `numeric_version` inside loops, using an `@functools.lru_cache` helper function at the module scope caches both regex application and normalisation overhead (e.g. `tuple()` casts and `os.path.normcase` internally), yielding ~50% performance gains on repeated inputs compared to just caching the regex compilation.
 **Action:** When repeatedly calling string matching logic inside loop comprehensions, write a lightweight module-scoped helper decorated with `lru_cache(maxsize=512)` that delegates to the target function to bypass duplicate internal processing logic safely.
+
+## 2026-06-25 - [Avoid N+1 Filesystem Queries in Find Patterns]
+
+**Learning:** Running `find` repeatedly inside a loop over an array of filename patterns creates an N+1 query problem, leading to massive redundant filesystem scanning overhead.
+**Action:** Combine all `-name` patterns dynamically into an array with the `-o` (OR) operator and pass them to a single `find` command. Guard the `find` execution to ensure the pattern array isn't empty, as `find` throws a syntax error on empty parentheses `\( \)`.
+
+## 2026-06-25 - [macOS BSD Find Limitations]
+
+**Learning:** macOS uses BSD `find`, which does not support the GNU-specific `-quit` flag. Using `-quit` on macOS causes silent script failures if `stderr` is redirected, which can break conditional logic (e.g. `grep -q .` succeeding falsely or failing falsely).
+**Action:** Do not use the `-quit` flag in `find` commands within macOS-specific scripts. If early exit behavior is needed on the first match, use `find ... | head -n 1` or `grep -q .`.

--- a/scripts/macos/SURGICAL_CLEANUP.sh
+++ b/scripts/macos/SURGICAL_CLEANUP.sh
@@ -114,7 +114,16 @@ show_cleanup_preview() {
 
 	local count=0
 
-	for pattern in "${REMOVE_PATTERNS[@]}"; do
+	if [ ${#REMOVE_PATTERNS[@]} -gt 0 ]; then
+		# ⚡ Bolt Optimization: Combine find patterns to avoid N+1 filesystem queries
+		local find_args=()
+		for i in "${!REMOVE_PATTERNS[@]}"; do
+			if [ "$i" -gt 0 ]; then
+				find_args+=("-o")
+			fi
+			find_args+=("-name" "${REMOVE_PATTERNS[$i]}")
+		done
+
 		while IFS= read -r -d '' file; do
 			if [ -e "$file" ]; then
 				local size
@@ -122,8 +131,8 @@ show_cleanup_preview() {
 				echo "🗑️  $file ($size)"
 				((count++))
 			fi
-		done < <(find "$HOME" -maxdepth 1 -name "$pattern" -print0 2>/dev/null)
-	done
+		done < <(find "$HOME" -maxdepth 1 \( "${find_args[@]}" \) -print0 2>/dev/null)
+	fi
 
 	echo
 	echo -e "${YELLOW}Found $count items to remove${NC}"
@@ -151,15 +160,24 @@ perform_surgical_removal() {
 
 	local removed_count=0
 
-	for pattern in "${REMOVE_PATTERNS[@]}"; do
+	if [ ${#REMOVE_PATTERNS[@]} -gt 0 ]; then
+		# ⚡ Bolt Optimization: Combine find patterns to avoid N+1 filesystem queries
+		local find_args=()
+		for i in "${!REMOVE_PATTERNS[@]}"; do
+			if [ "$i" -gt 0 ]; then
+				find_args+=("-o")
+			fi
+			find_args+=("-name" "${REMOVE_PATTERNS[$i]}")
+		done
+
 		while IFS= read -r -d '' file; do
 			if [ -e "$file" ]; then
 				print_status "Removing: ${file##*/}"
 				rm -rf "$file" 2>/dev/null || true
 				((removed_count++))
 			fi
-		done < <(find "$HOME" -maxdepth 1 -name "$pattern" -print0 2>/dev/null)
-	done
+		done < <(find "$HOME" -maxdepth 1 \( "${find_args[@]}" \) -print0 2>/dev/null)
+	fi
 
 	# Special handling for .config directory - keep only fish
 	if [ -d "$HOME/.config" ]; then
@@ -243,11 +261,22 @@ verify_cleanup() {
 
 	echo
 	local remaining_junk=0
-	for pattern in "${REMOVE_PATTERNS[@]}"; do
-		if find "$HOME" -maxdepth 1 -name "$pattern" | grep -q .; then
+
+	if [ ${#REMOVE_PATTERNS[@]} -gt 0 ]; then
+		# ⚡ Bolt Optimization: Combine find patterns to avoid N+1 filesystem queries
+		local find_args=()
+		for i in "${!REMOVE_PATTERNS[@]}"; do
+			if [ "$i" -gt 0 ]; then
+				find_args+=("-o")
+			fi
+			find_args+=("-name" "${REMOVE_PATTERNS[$i]}")
+		done
+
+		# Print matches and exit early by piping to grep -q which stops after the first match
+		if find "$HOME" -maxdepth 1 \( "${find_args[@]}" \) -print 2>/dev/null | grep -q .; then
 			((remaining_junk++))
 		fi
-	done
+	fi
 
 	if [ $remaining_junk -eq 0 ]; then
 		echo -e "${GREEN}🎉 All junk successfully removed!${NC}"


### PR DESCRIPTION
💡 What: Replaced a `for` loop executing multiple `find` processes with a single `find` command dynamically constructed with `-o` flags.

🎯 Why: Running `find "$HOME"` inside a loop over every junk pattern caused significant and redundant filesystem I/O overhead (the N+1 query problem). Consolidating the queries into a single evaluation dramatically speeds up the cleanup script's execution.

📊 Impact: Reduces `find` evaluations on the `$HOME` directory from N (where N is the number of patterns, roughly 30) down to 1 per function block.

🔬 Measurement: Verified the script logic holds identical evaluation matching, passing the full automated shell script test suite. The performance improvement scales linearly with the size of the HOME directory.

---
*PR created automatically by Jules for task [10650005774366030694](https://jules.google.com/task/10650005774366030694) started by @abhimehro*