### PR TITLE
🎨 Palette: Add osascript fallback for CLI notifications

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,4 @@
 ## 2026-06-03 - Native OS Notification Fallbacks
 
 **Learning:** When adding optional notifications to CLI scripts (like `terminal-notifier` on macOS), users without the third-party tool installed miss out on the UX improvement.
+**Action:** Always include a fallback to the native `osascript` command (`osascript -e 'display notification ...'`) when implementing desktop notifications in macOS shell scripts to ensure consistent UX delivery.

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -25,7 +25,14 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
 notify() {
 	local t="$1"
 	local m="$2"
-	if command -v terminal-notifier >/dev/null 2>&1; then terminal-notifier -title "$t" -message "$m" -sound default; fi
+	if command -v terminal-notifier >/dev/null 2>&1; then
+		terminal-notifier -title "$t" -message "$m" -sound default
+	elif command -v osascript >/dev/null 2>&1; then
+		# Escape double quotes for osascript
+		local esc_t="${t//\"/\\\"}"
+		local esc_m="${m//\"/\\\"}"
+		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
+	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }
 is_video_file() { [[ $1 =~ \.(mp4|mkv|avi|mov|m4v)$ ]]; }

--- a/media-streaming/scripts/sync-alldebrid.sh
+++ b/media-streaming/scripts/sync-alldebrid.sh
@@ -46,6 +46,11 @@ notify() {
 	local message="$2"
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
+	elif command -v osascript &>/dev/null; then
+		# Escape double quotes for osascript
+		local esc_t="${title//\"/\\\"}"
+		local esc_m="${message//\"/\\\"}"
+		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
 	fi
 }
 


### PR DESCRIPTION
💡 What: Added native macOS `osascript` fallback for CLI notifications in `rename-media.sh` and `sync-alldebrid.sh`.
🎯 Why: Ensures users who haven't installed the optional `terminal-notifier` dependency still receive important desktop notifications upon task completion.
♿ Accessibility: Improves visibility of background task states for a wider range of standard macOS environments.

---
*PR created automatically by Jules for task [1369965829381122656](https://jules.google.com/task/1369965829381122656) started by @abhimehro*