### PR TITLE
Palette: Graceful SIGINT exit traps

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,8 @@
 ## 2026-06-03 - Native OS Notification Fallbacks
 
 **Learning:** When adding optional notifications to CLI scripts (like `terminal-notifier` on macOS), users without the third-party tool installed miss out on the UX improvement.
+
+## 2026-06-25 - Graceful Exit Handlers
+
+**Learning:** When users interrupt interactive CLI scripts (like setup scripts) with `Ctrl+C` (`SIGINT`), abruptly terminating the script without feedback feels broken and unpolished.
+**Action:** Always add a `trap` for `SIGINT` to gracefully catch the interruption, print a clear, polite cancellation message (e.g., `👋 Setup cancelled by user. Goodbye!`), and exit cleanly with standard code 130.

--- a/media-streaming/scripts/setup-media-library.sh
+++ b/media-streaming/scripts/setup-media-library.sh
@@ -3,6 +3,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+# UX Additions
+trap 'echo -e "\n👋 Setup cancelled by user. Goodbye!"; exit 130' SIGINT
+
 echo "🎬 Ultimate Infuse + Cloud Media Library Setup"
 echo "=============================================="
 echo

--- a/scripts/macos/SURGICAL_CLEANUP.sh
+++ b/scripts/macos/SURGICAL_CLEANUP.sh
@@ -10,6 +10,9 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# UX Additions
+trap 'echo -e "\n👋 Cleanup cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+
 print_status() {
 	echo -e "${BLUE}[INFO]${NC} $1"
 }

--- a/scripts/setup-controld.sh
+++ b/scripts/setup-controld.sh
@@ -20,6 +20,9 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+# UX Additions
+trap 'echo -e "\n${YELLOW}👋 Setup cancelled by user. Goodbye!${NC}"; exit 130' SIGINT
+
 log() { echo -e "${BLUE}[INFO]${NC} $*"; }
 success() { echo -e "${GREEN}[OK]${NC} $*"; }
 error() {


### PR DESCRIPTION
Adds a trap for SIGINT to interactive scripts to exit cleanly with a polite message.

---
*PR created automatically by Jules for task [7863355362601529152](https://jules.google.com/task/7863355362601529152) started by @abhimehro*