### PR TITLE
🎨 Palette: Add native OS notification fallback for CLI scripts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,4 @@
 ## 2026-06-03 - Native OS Notification Fallbacks
 
 **Learning:** When adding optional notifications to CLI scripts (like `terminal-notifier` on macOS), users without the third-party tool installed miss out on the UX improvement.
+**Action:** Always provide a fallback to native OS notifications (like `osascript -e` on macOS) when using third-party notification tools to ensure a consistent experience. When passing variables to `osascript`, ensure double quotes within the variables are properly escaped (e.g., `esc_val="${val//\"/\\\"}"`) to prevent syntax errors.

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -25,7 +25,13 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
 notify() {
 	local t="$1"
 	local m="$2"
-	if command -v terminal-notifier >/dev/null 2>&1; then terminal-notifier -title "$t" -message "$m" -sound default; fi
+	if command -v terminal-notifier >/dev/null 2>&1; then
+		terminal-notifier -title "$t" -message "$m" -sound default
+	elif command -v osascript >/dev/null 2>&1; then
+		local esc_t="${t//\"/\\\"}"
+		local esc_m="${m//\"/\\\"}"
+		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
+	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }
 is_video_file() { [[ $1 =~ \.(mp4|mkv|avi|mov|m4v)$ ]]; }

--- a/media-streaming/scripts/sync-alldebrid.sh
+++ b/media-streaming/scripts/sync-alldebrid.sh
@@ -46,6 +46,10 @@ notify() {
 	local message="$2"
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
+	elif command -v osascript &>/dev/null; then
+		local esc_title="${title//\"/\\\"}"
+		local esc_message="${message//\"/\\\"}"
+		osascript -e "display notification \"$esc_message\" with title \"$esc_title\"" 2>/dev/null || true
 	fi
 }
 


### PR DESCRIPTION
🎨 Palette: Added native OS notification fallbacks

💡 What: Implemented an `osascript` fallback for the `notify()` function in media streaming scripts (`rename-media.sh` and `sync-alldebrid.sh`) when the third-party `terminal-notifier` is missing.
🎯 Why: Users without `terminal-notifier` installed were missing out on the micro-UX improvement of receiving an interactive notification when long-running media processing scripts finished.
♿ Accessibility: Ensures that macOS users get consistent visual feedback out-of-the-box using native OS capabilities.
📝 Learning documented in `.jules/palette.md`.

---
*PR created automatically by Jules for task [12408137115653750558](https://jules.google.com/task/12408137115653750558) started by @abhimehro*