### PR TITLE
🎨 Palette: Add graceful exit handlers to interactive CLI scripts

### DIFF
--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# Graceful exit on Ctrl+C
+trap 'echo -e "\n\033[1;33m👋 Operation cancelled by user. Goodbye!\033[0m"; exit 130' SIGINT
+
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# Graceful exit on Ctrl+C
+trap 'echo -e "\n\033[1;33m👋 Operation cancelled by user. Goodbye!\033[0m"; exit 130' SIGINT
+
 # --- UX Helpers ---
 
 # Colors


### PR DESCRIPTION
💡 **What**: Added a `trap` for `SIGINT` (Ctrl+C) to long-running and interactive scripts (`scripts/network-mode-manager.sh` and `scripts/youtube-download.sh`).
🎯 **Why**: When users interrupt interactive CLI scripts with `Ctrl+C`, abruptly terminating without feedback feels unpolished. Catching the interruption, providing clear feedback, and exiting cleanly with the standard POSIX code (130) provides a significantly better, more robust CLI user experience.
📸 **Before/After**: Before, the script would just immediately quit (often leaving prompt artifacts depending on state). After, it prints: `👋 Operation cancelled by user. Goodbye!`.
♿ **Accessibility**: Provides clear, text-based confirmation to users (including those using screen readers) that the script was intentionally cancelled rather than failing silently or crashing.

---
*PR created automatically by Jules for task [1291522625788868959](https://jules.google.com/task/1291522625788868959) started by @abhimehro*