### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in caches.sh

### DIFF
--- a/configs/.config/mole/lib/clean/caches.sh
+++ b/configs/.config/mole/lib/clean/caches.sh
@@ -291,6 +291,10 @@ flush_python_group_if_needed() {
     local group_root="$1"
     local array_name="$2"
 
+    if [[ ! "$array_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+
     local group_count=0
     eval 'group_count=${#'"$array_name"'[@]}'
     [[ -z "$group_root" || "$group_count" -eq 0 ]] && return 0


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Command Injection ([CWE-78](https://cwe.mitre.org/data/definitions/78.html))
**Impact:** A potential malicious attacker controlling the `array_name` parameter in `flush_python_group_if_needed` could inject arbitrary bash commands when `eval` processes the unsanitized value (e.g. `eval 'group_count=${#'"$array_name"'[@]}'`).
**Fix:** Added an explicit regex validation check (`^[a-zA-Z_][a-zA-Z0-9_]*$`) before using `array_name` inside `eval`. If the argument does not match standard Bash variable naming rules, the function immediately exits.
**Verification:** Ran `make test-all` which passed successfully to confirm no regressions.

---
*PR created automatically by Jules for task [12104669701830026582](https://jules.google.com/task/12104669701830026582) started by @abhimehro*