### PR TITLE
🧹 chore: remove unused import os in consolidate_adblock_lists.py

### DIFF
--- a/adguard/scripts/consolidate_adblock_lists.py
+++ b/adguard/scripts/consolidate_adblock_lists.py
@@ -11,7 +11,6 @@ Usage: python3 consolidate_adblock_lists.py --input-dir <input_dir> --output-dir
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/tests/test_consolidate_adblock_lists.py
+++ b/tests/test_consolidate_adblock_lists.py
@@ -1,5 +1,4 @@
 import json
-import os
 import sys
 import unittest
 from pathlib import Path


### PR DESCRIPTION
### 🎯 **What:** The code health issue addressed
Removed the unused `import os` from `adguard/scripts/consolidate_adblock_lists.py` and its corresponding test file `tests/test_consolidate_adblock_lists.py`.

### 💡 **Why:** How this improves maintainability
Unused imports clutter the code, can lead to confusion about dependencies, and slightly increase module loading time. Since the script uses `pathlib.Path` for path manipulations and filesystem checks, the `os` module is no longer required.

### ✅ **Verification:** How you confirmed the change is safe
- Ran the full test suite using `make test-all`.
- All 135 tests passed, including those specifically for `consolidate_adblock_lists.py`.
- Obtained a positive code review rating (#Correct#).

### ✨ **Result:** The improvement achieved
Cleaned up the codebase by removing redundant imports, aligning with Python best practices and improving readability.

══════════ ELIR ══════════
PURPOSE: Remove unused `os` import in the AdGuard consolidation script and its test file to improve code health and maintainability.
SECURITY: No security impact; removing unused imports reduces potential attack surface by eliminating unnecessary module loading.
FAILS IF: Standard Python import mechanism fails (unlikely for a removal).
VERIFY: Run `python3 -m unittest tests/test_consolidate_adblock_lists.py` to ensure the script and tests still function without the `os` module.
MAINTAIN: The script uses `pathlib.Path` for filesystem operations, which supersedes the need for the `os` module in this context.

---
*PR created automatically by Jules for task [8869940961827549185](https://jules.google.com/task/8869940961827549185) started by @abhimehro*