### PR TITLE
🧪 test: implement missing coverage for extract_horoscope_text

### DIFF
--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -233,6 +233,37 @@ class TestExtractHoroscopeText(unittest.TestCase):
     def test_whitespace_only(self):
         assert mb.extract_horoscope_text({"horoscope": "   "}) is None
 
+    def test_flat_horoscope_data(self):
+        assert mb.extract_horoscope_text({"horoscope_data": "Flat data."}) == "Flat data."
+
+    def test_priority_order(self):
+        payload = {
+            "data": {"horoscope_data": "Priority 1"},
+            "horoscope_data": "Priority 2",
+            "horoscope": "Priority 3",
+            "description": "Priority 4",
+        }
+        assert mb.extract_horoscope_text(payload) == "Priority 1"
+
+        del payload["data"]
+        assert mb.extract_horoscope_text(payload) == "Priority 2"
+
+        del payload["horoscope_data"]
+        assert mb.extract_horoscope_text(payload) == "Priority 3"
+
+    def test_non_string_candidates(self):
+        payload = {
+            "horoscope_data": 123,
+            "horoscope": ["not", "a", "string"],
+            "description": "The only string.",
+        }
+        assert mb.extract_horoscope_text(payload) == "The only string."
+
+    def test_nested_not_dict(self):
+        # If 'data' is a string, it shouldn't crash nested.get
+        payload = {"data": "not-a-dict", "horoscope": "Fallback."}
+        assert mb.extract_horoscope_text(payload) == "Fallback."
+
 
 # ============================================================
 # Staleness Calculation


### PR DESCRIPTION
🧪 **What:** This PR addresses the testing gap for the `extract_horoscope_text` pure function in `morning-brief.py`.
📊 **Coverage:** 
- Tested nested `horoscope_data` extraction.
- Tested top-level `horoscope_data`, `horoscope`, and `description` fallbacks.
- Verified priority order (precedence) of these keys.
- Ensured non-string values are ignored and continue the search.
- Confirmed stability when the `data` field is not a dictionary.
✨ **Result:** Improved test coverage and reliability for the horoscope extraction logic, ensuring it handles various API response formats safely.

══════════ ELIR ══════════
PURPOSE: Added unit tests for `extract_horoscope_text` to ensure reliable dictionary traversal and candidate selection.
SECURITY: No security-sensitive logic modified; tests verify type safety for untrusted API responses.
FAILS IF: Precedence of horoscope keys is changed or non-string values are incorrectly returned.
VERIFY: Run `python3 -m unittest tests.test_morning_brief -v`.
MAINTAIN: Candidates follow a specific precedence; `nested.horoscope_data` is highest priority.


---
*PR created automatically by Jules for task [10755384256027742666](https://jules.google.com/task/10755384256027742666) started by @abhimehro*