### PR TITLE
🎨 Palette: Add graceful exit handlers to interactive CLI scripts

### DIFF
--- a/maintenance/bin/view_logs.sh
+++ b/maintenance/bin/view_logs.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+trap 'echo -e "
+[0;31m👋 Log viewer cancelled by user. Goodbye![0m"; exit 130' SIGINT
+
 LOG_DIR="$HOME/Library/Logs/maintenance"
 TASK="${1-}"
 

--- a/scripts/network-mode-manager.sh
+++ b/scripts/network-mode-manager.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+trap 'echo -e "
+[0;31m👋 Operation cancelled by user. Goodbye![0m"; exit 130' SIGINT
+
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,9 @@
 
 set -Eeuo pipefail
 
+trap 'echo -e "
+[0;31m👋 Setup cancelled by user. Goodbye![0m"; exit 130' SIGINT
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 BOLD='\033[1m'


### PR DESCRIPTION
- 💡 What: Added SIGINT (Ctrl+C) trap handlers to `scripts/network-mode-manager.sh`, `maintenance/bin/view_logs.sh`, and `setup.sh` that print a polite message and safely stop the script with standard code 130 instead of abruptly terminating.
- 🎯 Why: When users interrupt interactive CLI scripts (like setup scripts or interactive menus) with `Ctrl+C`, abruptly terminating the script without feedback feels broken and unpolished.
- 📸 Before/After: Before, hitting Ctrl+C would just abruptly close the prompt leaving partial output. After, it clears up and says "👋 Operation cancelled by user. Goodbye!".
- ♿ Accessibility: Improves UX by providing clear feedback that an action has been explicitly cancelled rather than an error occurring.

---
*PR created automatically by Jules for task [15593504186716043070](https://jules.google.com/task/15593504186716043070) started by @abhimehro*