### PR TITLE
🛡️ Sentinel: [HIGH] Fix Option Injection (CWE-88) in pkill/pgrep commands

### DIFF
--- a/configs/.config/mole/lib/clean/system.sh
+++ b/configs/.config/mole/lib/clean/system.sh
@@ -126,7 +126,7 @@ clean_deep_system() {
         local app_name
         app_name=$(basename "$installer_app")
         # Skip if installer is currently running
-        if pgrep -f "$installer_app" > /dev/null 2>&1; then
+        if pgrep -f -- "$installer_app" > /dev/null 2>&1; then
             debug_log "Skipping $app_name: currently running"
             continue
         fi

--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -1545,27 +1545,27 @@ force_kill_app() {
     local match_pattern="${exec_name:-$app_name}"
 
     # Check if process is running using exact match only
-    if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         return 0
     fi
 
     # Try graceful termination first
-    pkill -x "$match_pattern" 2> /dev/null || true
+    pkill -x -- "$match_pattern" 2> /dev/null || true
     sleep 2
 
     # Check again after graceful kill
-    if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         return 0
     fi
 
     # Force kill if still running
-    pkill -9 -x "$match_pattern" 2> /dev/null || true
+    pkill -9 -x -- "$match_pattern" 2> /dev/null || true
     sleep 2
 
     # If still running and sudo is available, try with sudo
-    if pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         if sudo -n true 2> /dev/null; then
-            sudo pkill -9 -x "$match_pattern" 2> /dev/null || true
+            sudo pkill -9 -x -- "$match_pattern" 2> /dev/null || true
             sleep 2
         fi
     fi
@@ -1573,7 +1573,7 @@ force_kill_app() {
     # Final check with longer timeout for stubborn processes
     local retries=3
     while [[ $retries -gt 0 ]]; do
-        if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+        if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
             return 0
         fi
         sleep 1
@@ -1581,7 +1581,7 @@ force_kill_app() {
     done
 
     # Still running after all attempts
-    pgrep -x "$match_pattern" > /dev/null 2>&1 && return 1 || return 0
+    pgrep -x -- "$match_pattern" > /dev/null 2>&1 && return 1 || return 0
 }
 
 # Note: calculate_total_size() is defined in lib/core/file_ops.sh

--- a/configs/.config/mole/lib/optimize/tasks.sh
+++ b/configs/.config/mole/lib/optimize/tasks.sh
@@ -324,7 +324,7 @@ opt_sqlite_vacuum() {
     local -a check_apps=("Mail" "Safari" "Messages")
     local app
     for app in "${check_apps[@]}"; do
-        if pgrep -x "$app" > /dev/null 2>&1; then
+        if pgrep -x -- "$app" > /dev/null 2>&1; then
             busy_apps+=("$app")
         fi
     done
@@ -509,7 +509,7 @@ browser_family_is_running() {
             pgrep -if "Zen Browser|org\\.mozilla\\.zen|Zen Browser Helper|zen .*contentproc" > /dev/null 2>&1
             ;;
         *)
-            pgrep -ix "$browser_name" > /dev/null 2>&1
+            pgrep -ix -- "$browser_name" > /dev/null 2>&1
             ;;
     esac
 }
@@ -738,7 +738,7 @@ opt_bluetooth_reset() {
             if system_profiler SPBluetoothDataType 2> /dev/null | grep -q "Connected: Yes"; then
                 local -a media_apps=("Music" "Spotify" "VLC" "QuickTime Player" "TV" "Podcasts" "Safari" "Google Chrome" "Chrome" "Firefox" "Arc" "IINA" "mpv")
                 for app in "${media_apps[@]}"; do
-                    if pgrep -x "$app" > /dev/null 2>&1; then
+                    if pgrep -x -- "$app" > /dev/null 2>&1; then
                         bt_audio_active=true
                         break
                     fi

--- a/configs/.config/mole/lib/uninstall/batch.sh
+++ b/configs/.config/mole/lib/uninstall/batch.sh
@@ -311,7 +311,7 @@ batch_uninstall_applications() {
         if [[ -e "$info_plist" ]]; then
             exec_name=$(defaults read "$info_plist" CFBundleExecutable 2> /dev/null || echo "")
         fi
-        if pgrep -qx "${exec_name:-$app_name}" 2> /dev/null; then
+        if pgrep -qx -- "${exec_name:-$app_name}" 2> /dev/null; then
             running_apps+=("$app_name")
         fi
 


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: Option Injection (CWE-88) existed in `pgrep` and `pkill` calls across several files in `configs/.config/mole/lib/` (`app_protection.sh`, `tasks.sh`, `batch.sh`, `system.sh`). Variables containing untrusted input (e.g., process names) could be interpreted as command-line flags (like `-u 0`) if they started with a hyphen, causing the commands to execute with unintended behavior.

🎯 **Impact**: An attacker who can control or influence the variable (e.g., an app name or pattern) could inject arbitrary flags, potentially bypassing protection mechanisms, terminating unintended processes, or causing unexpected behavior in the script.

🔧 **Fix**: Added the `--` separator before passing dynamic variables to all `pgrep` and `pkill` commands (e.g., `pgrep -x -- "$match_pattern"`). This ensures that any arguments following the separator are treated strictly as literal patterns, even if they begin with a hyphen.

✅ **Verification**: 
1. `make test-all` passes successfully without regressions.
2. Verified changes using `grep -rn -E 'p(grep|kill).*-- "\$' configs/.config/mole/lib/` which shows the updated command lines correctly enforce the separator.

---
*PR created automatically by Jules for task [15727864317377264279](https://jules.google.com/task/15727864317377264279) started by @abhimehro*