### PR TITLE
perf: cache GH_TOKEN.env parsing in PR automation scripts (salvages #812)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -129,3 +129,7 @@
 ## 2026-06-25 - [List Comprehensions with Direct Dict Lookups]
 **Learning:** In Python data parsing scripts, combining list comprehensions with `type(dict) is dict` and direct dictionary lookups (`"key" in dict and dict["key"] == val`) provides a ~15-20% performance boost over using generator expressions with `isinstance()` and `.get()` calls by avoiding function overhead.
 **Action:** When extracting data from large JSON arrays based on nested conditions, prefer list comprehensions over generator expressions and use direct `in` checks combined with `type() is dict` instead of `.get()` and `isinstance()`.
+
+## 2026-03-10 - Cached Environment parsing in iterative scripts
+**Learning:** Repetitive file IO (e.g., parsing `.env` files) inside helper functions that are called in loops (like API wrappers across a large queue) creates a massive performance bottleneck.
+**Action:** Use Python's `functools.lru_cache` to cache environment or configuration file parsing that runs repeatedly but remains static during execution.

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from functools import lru_cache
 
 
 def _parse_env_line(line, env_dict):
@@ -17,14 +18,21 @@ def _parse_env_line(line, env_dict):
     env_dict[key] = val.strip("'\"")
 
 
-def _load_gh_token_env():
-    env = os.environ.copy()
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars():
+    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    parsed_vars = {}
     try:
         with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
             for line in f:
-                _parse_env_line(line, env)
+                _parse_env_line(line, parsed_vars)
     except FileNotFoundError:
         pass
+    return parsed_vars
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    env.update(_get_parsed_env_vars())
     return env
 
 

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from collections import defaultdict
+from functools import lru_cache
 
 
 def _parse_env_line(line, env_dict):
@@ -19,14 +20,21 @@ def _parse_env_line(line, env_dict):
     env_dict[key] = val.strip("'\"")
 
 
-def _load_gh_token_env():
-    env = os.environ.copy()
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars():
+    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    parsed_vars = {}
     try:
         with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
             for line in f:
-                _parse_env_line(line, env)
+                _parse_env_line(line, parsed_vars)
     except FileNotFoundError:
         pass
+    return parsed_vars
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    env.update(_get_parsed_env_vars())
     return env
 
 

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 import json
 import subprocess
 import os
+from functools import lru_cache
 
 def _parse_env_line(line, env_dict):
     line = line.strip()
@@ -17,14 +18,21 @@ def _parse_env_line(line, env_dict):
     key, val = line.split("=", 1)
     env_dict[key] = val.strip("'\"")
 
-def _load_gh_token_env():
-    env = os.environ.copy()
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars():
+    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    parsed_vars = {}
     try:
         with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
             for line in f:
-                _parse_env_line(line, env)
+                _parse_env_line(line, parsed_vars)
     except FileNotFoundError:
         pass
+    return parsed_vars
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    env.update(_get_parsed_env_vars())
     return env
 
 def run_gh(repo, pr):

--- a/run_merges.py
+++ b/run_merges.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import time
+from functools import lru_cache
 
 
 def _parse_env_line(line, env_dict):
@@ -18,14 +19,21 @@ def _parse_env_line(line, env_dict):
     env_dict[key] = val.strip("'\"")
 
 
-def _load_gh_token_env():
-    env = os.environ.copy()
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars():
+    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    parsed_vars = {}
     try:
         with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
             for line in f:
-                _parse_env_line(line, env)
+                _parse_env_line(line, parsed_vars)
     except FileNotFoundError:
         pass
+    return parsed_vars
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    env.update(_get_parsed_env_vars())
     return env
 
 


### PR DESCRIPTION
## Summary

Salvages the legitimate performance improvement from #812, rebased cleanly on top of the post-Lesson-0-cascade `main`. The original PR became DIRTY after the 7-PR security/UX merge cascade in the 2026-04-25 review session and was deferred for rebase.

## What changed

Adds `@functools.lru_cache(maxsize=None)` on a private `_get_parsed_env_vars()` helper in each of the four PR automation scripts:
- `categorize_ready.py`
- `detect_duplicates.py`
- `parse_inventory.py`
- `run_merges.py`

The helper opens `../email-security-pipeline/GH_TOKEN.env` once per process and returns a parsed dict; `_load_gh_token_env()` then layers it onto a fresh `os.environ.copy()` per call. This preserves the original mutable-dict isolation while eliminating redundant file IO when these scripts are invoked in tight loops (which they are, when triaging dozens of PRs).

Plus the `.jules/bolt.md` journal entry from #812.

## Conflict resolution

The only merge conflict was in `.jules/bolt.md` (a journal append-only file). Both #812's entry and the entry currently on main were kept, with a blank line between them for readability. No code conflicts.

## Verification

- `python3 -m py_compile` on all four scripts succeeds.
- `grep "lru_cache\|_get_parsed_env_vars" *.py` confirms the optimization is applied to all four targets.

## Provenance

Original commit: `a66bf44` (`google-labs-jules[bot]`, 2026-04-24). Author preserved on the cherry-pick. The original PR (#812) can be closed as superseded by this one once it merges.

═══ ELIR ═══
PURPOSE: Recover a legitimate, low-risk perf optimization (lru_cache on .env parsing in 4 automation scripts) that became unmergeable after the parent merge cascade. Pure salvage — no logic changes from #812's intent.
SECURITY: No new permissions, no new external deps, no shell=True, no secret handling change. Cache key is implicit (function takes no args), so cached value is per-process and doesn't leak across process boundaries. Mutable-dict isolation preserved.
FAILS IF: `.env` content changes mid-process (now requires process restart to pick up). Acceptable: these scripts are short-lived per-invocation.
VERIFY: Diff is identical in intent to #812 minus the journal-conflict resolution; cherry-pick provenance preserved.
MAINTAIN: If new automation scripts are added that load `GH_TOKEN.env`, copy the same pattern. Consider hoisting the helper to a shared module if a 5th script is added.