### PR TITLE
test(security): CWE-78 regression tests for PR automation scripts (salvages #816 test)

### DIFF
--- a/tests/test_vulnerability_fix.py
+++ b/tests/test_vulnerability_fix.py
@@ -1,0 +1,138 @@
+"""Regression tests for CWE-78 (Command Injection) hardening of PR automation scripts.
+
+The four PR automation scripts (`categorize_ready.py`, `detect_duplicates.py`,
+`run_merges.py`, `parse_inventory.py`) historically used ``subprocess.run(cmd_str,
+shell=True)``. PR #788 ("🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78)
+in subprocess calls") replaced that with list-args and a manual `.env` parser.
+
+These tests assert the post-#788 API contract so a future refactor cannot
+silently reintroduce the vulnerability:
+
+1. ``run_gh`` MUST call ``subprocess.run`` with a *list* of arguments and MUST
+   NOT pass ``shell=True``.
+2. ``argv[0]`` MUST be the literal binary name ``"gh"`` so the subprocess
+   executes the GitHub CLI directly without shell metachar interpretation.
+3. ``_load_gh_token_env`` MUST be pure Python file IO and MUST NOT shell out.
+
+Originally proposed by automation in PR #816; that PR became unmergeable
+(228-file diff, conflicts after the Lesson-0 cascade). The test file is
+salvaged here, adapted to match main's actual ``run_gh`` signatures.
+
+The scripts execute automation logic at module import time, so we extract
+the function source into a fresh, side-effect-free module via ``ast`` rather
+than importing the full script.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+import textwrap
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_function_only(script_filename, function_names):
+    """Return a module containing only the named top-level functions / imports.
+
+    This avoids running the script's module-level automation logic (which
+    reads `tasks/pr-inventory.md`, calls `gh`, writes files, etc.) and lets
+    us unit-test the security-relevant function definitions in isolation.
+    """
+    src_path = os.path.join(REPO_ROOT, script_filename)
+    with open(src_path, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=script_filename)
+
+    keep = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            keep.append(node)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in function_names or node.name.startswith("_"):
+                keep.append(node)
+    new_tree = ast.Module(body=keep, type_ignores=[])
+    code = compile(new_tree, filename=src_path, mode="exec")
+    mod = types.ModuleType(f"_{script_filename.replace('.py', '')}_funcs")
+    mod.__file__ = src_path
+    exec(code, mod.__dict__)
+    return mod
+
+
+def _assert_safe(test_case, mock_run):
+    test_case.assertTrue(mock_run.called, "subprocess.run was not called")
+    args, kwargs = mock_run.call_args
+    cmd = args[0]
+    test_case.assertIsInstance(cmd, list, "argv must be a list, not a shell string")
+    test_case.assertEqual(cmd[0], "gh", "argv[0] must be the literal binary name 'gh'")
+    test_case.assertFalse(
+        kwargs.get("shell", False),
+        "subprocess.run must not be called with shell=True",
+    )
+
+
+# Attacker-controlled values that would have allowed shell command injection
+# under the pre-#788 ``shell=True`` implementation. With list-args and shell=False
+# they are passed through as literal argv elements and are harmless.
+INJECTION_PR = "123; touch /tmp/pwned"
+INJECTION_REPO = "owner/repo$(touch /tmp/pwned)"
+
+
+class TestRunGhListArgs(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_categorize_ready(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
+        mod = _load_function_only("categorize_ready.py", {"run_gh"})
+        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "title"])
+        _assert_safe(self, mock_run)
+
+    @patch("subprocess.run")
+    def test_detect_duplicates(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
+        mod = _load_function_only("detect_duplicates.py", {"run_gh"})
+        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "files"])
+        _assert_safe(self, mock_run)
+
+    @patch("subprocess.run")
+    def test_run_merges(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
+        mod = _load_function_only("run_merges.py", {"run_gh"})
+        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "mergeStateStatus"])
+        _assert_safe(self, mock_run)
+
+    @patch("subprocess.run")
+    def test_parse_inventory(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
+        mod = _load_function_only("parse_inventory.py", {"run_gh"})
+        # parse_inventory.run_gh has a different signature: (repo, pr).
+        mod.run_gh(INJECTION_REPO, INJECTION_PR)
+        _assert_safe(self, mock_run)
+
+
+class TestEnvLoaderShellSafety(unittest.TestCase):
+    """Defense in depth: ``_load_gh_token_env`` must be pure Python file IO.
+
+    If a future refactor accidentally re-introduces a
+    ``subprocess.Popen(... shell=True)`` to source the env file, this test will
+    catch it.
+    """
+
+    @patch("subprocess.run")
+    @patch("subprocess.Popen")
+    def test_env_loader_does_not_shell_out(self, mock_popen, mock_run):
+        mod = _load_function_only("categorize_ready.py", {"_load_gh_token_env"})
+        mod._load_gh_token_env()
+        self.assertFalse(
+            mock_run.called,
+            "_load_gh_token_env must not invoke subprocess.run",
+        )
+        self.assertFalse(
+            mock_popen.called,
+            "_load_gh_token_env must not invoke subprocess.Popen",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vulnerability_fix.py
+++ b/tests/test_vulnerability_fix.py
@@ -82,25 +82,20 @@ INJECTION_REPO = "owner/repo$(touch /tmp/pwned)"
 
 class TestRunGhListArgs(unittest.TestCase):
     @patch("subprocess.run")
-    def test_categorize_ready(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
-        mod = _load_function_only("categorize_ready.py", {"run_gh"})
-        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "title"])
-        _assert_safe(self, mock_run)
+    def test_list_arg_scripts(self, mock_run):
+        test_cases = {
+            "categorize_ready.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "title"],
+            "detect_duplicates.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "files"],
+            "run_merges.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "mergeStateStatus"],
+        }
 
-    @patch("subprocess.run")
-    def test_detect_duplicates(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
-        mod = _load_function_only("detect_duplicates.py", {"run_gh"})
-        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "files"])
-        _assert_safe(self, mock_run)
-
-    @patch("subprocess.run")
-    def test_run_merges(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
-        mod = _load_function_only("run_merges.py", {"run_gh"})
-        mod.run_gh(["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "mergeStateStatus"])
-        _assert_safe(self, mock_run)
+        for script, cmd_list in test_cases.items():
+            with self.subTest(script=script):
+                mock_run.reset_mock()
+                mock_run.return_value = MagicMock(returncode=0, stdout='{"x": 1}')
+                mod = _load_function_only(script, {"run_gh"})
+                mod.run_gh(cmd_list)
+                _assert_safe(self, mock_run)
 
     @patch("subprocess.run")
     def test_parse_inventory(self, mock_run):


### PR DESCRIPTION
## Summary

Salvages the test file from PR #816 (`🔒 [security fix] Fix Command Injection in repository automation scripts`) and adapts it to match `main`'s actual `run_gh` signatures. Adds 5 unit tests that lock in the post-#788 security contract.

## Why this salvage?

PR #816 was a **228-file, ~24k-line diff** that, after the 2026-04-25 Lesson 0 cascade, wanted to revert dozens of files merged after its branch point. Its core security work — removing `shell=True` from `run_gh` in the four PR automation scripts (`categorize_ready.py`, `detect_duplicates.py`, `run_merges.py`, `parse_inventory.py`) — is **already on main** since [PR #788](https://github.com/abhimehro/personal-config/pull/788) (`🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) in subprocess calls`).

The only piece worth keeping from #816 is the regression test, which is salvaged here as a focused, mergeable PR.

## What this PR adds

A single new file: `tests/test_vulnerability_fix.py`.

| Test | What it asserts |
| ---- | --------------- |
| `test_categorize_ready` | `run_gh` builds an argv list, `argv[0] == 'gh'`, no `shell=True` |
| `test_detect_duplicates` | same |
| `test_run_merges` | same |
| `test_parse_inventory` | same (different signature: `run_gh(repo, pr)`) |
| `test_env_loader_does_not_shell_out` | `_load_gh_token_env` is pure Python file IO; never calls `subprocess.run` or `subprocess.Popen` |

## Adaptations from #816's original test

- The original used `import categorize_ready` etc., which runs each script's module-level automation logic on import (calling `gh`, reading `tasks/pr-inventory.md`, writing files). That's not safe in a unit test. Replaced with an `ast`-based loader that pulls only the function definitions and imports into a side-effect-free shadow module.
- Rewrote callers to match the **actual** `run_gh` signatures on main:
  - `categorize_ready` / `detect_duplicates` / `run_merges` all take `cmd_list` (with `"gh"` already present at index 0).
  - `parse_inventory` takes `(repo, pr)` and builds the list internally.
- Added the defense-in-depth env-loader test (not in #816's original) so a future refactor can't reintroduce `source ... .env && gh ...` shell-out via `subprocess`.

## Verification (local)

```
$ python3 -m unittest tests.test_vulnerability_fix -v
test_env_loader_does_not_shell_out ... ok
test_categorize_ready ... ok
test_detect_duplicates ... ok
test_parse_inventory ... ok
test_run_merges ... ok
----------------------------------------------------------------------
Ran 5 tests in 0.009s

OK
```

═══ ELIR ═══
PURPOSE: Lock in the post-#788 CWE-78 hardening with tests so a future refactor cannot silently reintroduce `shell=True` in the four PR automation scripts. Net new test file; touches no production code.
SECURITY: Pure test addition. No new permissions, no new external deps, no production-code change. The `ast`-based loader is sandboxed (doesn't `exec` script-level statements) so no automation side effect at test time.
FAILS IF: A maintainer renames `run_gh` to something else (test imports break — caught immediately) or refactors the env loader to shell-out (test fails — exactly the regression we want to catch).
VERIFY: Run `python3 -m unittest tests.test_vulnerability_fix -v` — 5 tests, ~0.01s, all pass on `main`'s current code.
MAINTAIN: If a 5th PR-automation script is added that defines `run_gh`, copy a `test_<scriptname>` block. If `parse_inventory.run_gh` is ever harmonized to take `cmd_list` like the others, simplify the test.