### PR TITLE
🔒 [security fix] Fix Option Injection (CWE-88) in pgrep and pkill

### DIFF
--- a/configs/.config/mole/lib/clean/system.sh
+++ b/configs/.config/mole/lib/clean/system.sh
@@ -126,7 +126,7 @@ clean_deep_system() {
         local app_name
         app_name=$(basename "$installer_app")
         # Skip if installer is currently running
-        if pgrep -f "$installer_app" > /dev/null 2>&1; then
+        if pgrep -f -- "$installer_app" > /dev/null 2>&1; then
             debug_log "Skipping $app_name: currently running"
             continue
         fi

--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -1554,27 +1554,27 @@ force_kill_app() {
     local match_pattern="${exec_name:-$app_name}"
 
     # Check if process is running using exact match only
-    if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         return 0
     fi
 
     # Try graceful termination first
-    pkill -x "$match_pattern" 2> /dev/null || true
+    pkill -x -- "$match_pattern" 2> /dev/null || true
     sleep 2
 
     # Check again after graceful kill
-    if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         return 0
     fi
 
     # Force kill if still running
-    pkill -9 -x "$match_pattern" 2> /dev/null || true
+    pkill -9 -x -- "$match_pattern" 2> /dev/null || true
     sleep 2
 
     # If still running and sudo is available, try with sudo
-    if pgrep -x "$match_pattern" > /dev/null 2>&1; then
+    if pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
         if sudo -n true 2> /dev/null; then
-            sudo pkill -9 -x "$match_pattern" 2> /dev/null || true
+            sudo pkill -9 -x -- "$match_pattern" 2> /dev/null || true
             sleep 2
         fi
     fi
@@ -1582,7 +1582,7 @@ force_kill_app() {
     # Final check with longer timeout for stubborn processes
     local retries=3
     while [[ $retries -gt 0 ]]; do
-        if ! pgrep -x "$match_pattern" > /dev/null 2>&1; then
+        if ! pgrep -x -- "$match_pattern" > /dev/null 2>&1; then
             return 0
         fi
         sleep 1
@@ -1590,7 +1590,7 @@ force_kill_app() {
     done
 
     # Still running after all attempts
-    pgrep -x "$match_pattern" > /dev/null 2>&1 && return 1 || return 0
+    pgrep -x -- "$match_pattern" > /dev/null 2>&1 && return 1 || return 0
 }
 
 # Note: calculate_total_size() is defined in lib/core/file_ops.sh

--- a/configs/.config/mole/lib/optimize/tasks.sh
+++ b/configs/.config/mole/lib/optimize/tasks.sh
@@ -325,7 +325,7 @@ opt_sqlite_vacuum() {
     local -a check_apps=("Mail" "Safari" "Messages")
     local app
     for app in "${check_apps[@]}"; do
-        if pgrep -x "$app" > /dev/null 2>&1; then
+        if pgrep -x -- "$app" > /dev/null 2>&1; then
             busy_apps+=("$app")
         fi
     done
@@ -510,7 +510,7 @@ browser_family_is_running() {
             pgrep -if "Zen Browser|org\\.mozilla\\.zen|Zen Browser Helper|zen .*contentproc" > /dev/null 2>&1
             ;;
         *)
-            pgrep -ix "$browser_name" > /dev/null 2>&1
+            pgrep -ix -- "$browser_name" > /dev/null 2>&1
             ;;
     esac
 }
@@ -739,7 +739,7 @@ opt_bluetooth_reset() {
             if system_profiler SPBluetoothDataType 2> /dev/null | grep -q "Connected: Yes"; then
                 local -a media_apps=("Music" "Spotify" "VLC" "QuickTime Player" "TV" "Podcasts" "Safari" "Google Chrome" "Chrome" "Firefox" "Arc" "IINA" "mpv")
                 for app in "${media_apps[@]}"; do
-                    if pgrep -x "$app" > /dev/null 2>&1; then
+                    if pgrep -x -- "$app" > /dev/null 2>&1; then
                         bt_audio_active=true
                         break
                     fi

--- a/configs/.config/mole/lib/uninstall/batch.sh
+++ b/configs/.config/mole/lib/uninstall/batch.sh
@@ -356,7 +356,7 @@ batch_uninstall_applications() {
         if [[ -e "$info_plist" ]]; then
             exec_name=$(defaults read "$info_plist" CFBundleExecutable 2> /dev/null || echo "")
         fi
-        if pgrep -qx "${exec_name:-$app_name}" 2> /dev/null; then
+        if pgrep -qx -- "${exec_name:-$app_name}" 2> /dev/null; then
             running_apps+=("$app_name")
         fi
 


### PR DESCRIPTION
🎯 **What:** Fixed an Option Injection (CWE-88) vulnerability in `pgrep` and `pkill` calls across multiple core library files.

⚠️ **Risk:** Variables containing untrusted input (e.g., process names) could be interpreted as command-line flags if they started with a hyphen, potentially allowing attackers to alter the behavior of process search or termination (e.g., killing all processes of a different user).

🛡️ **Solution:** Added the `--` separator before positional arguments in `pgrep` and `pkill` calls to ensure that all subsequent arguments are treated strictly as patterns and not parsed as command-line options.

**Files modified:**
- `configs/.config/mole/lib/core/app_protection.sh`
- `configs/.config/mole/lib/uninstall/batch.sh`
- `configs/.config/mole/lib/clean/system.sh`
- `configs/.config/mole/lib/optimize/tasks.sh`

Note: The specific code block at `configs/.config/mole/lib/core/app_protection.sh:665` was not found in the current version of the file, but the same vulnerability pattern was identified and fixed in several other locations within the same file and other core libraries.

══════════ ELIR ══════════
PURPOSE: Fix Option Injection (CWE-88) in pgrep/pkill calls across mole libraries.
SECURITY: Prevents attackers from injecting arbitrary command-line flags via process names starting with a hyphen by using the `--` separator.
FAILS IF: match_pattern is empty or contains only whitespace (handled by shell checks elsewhere).
VERIFY: Check pgrep/pkill calls in modified files for presence of `--` before variable expansion.
MAINTAIN: Always use `--` with pgrep/pkill when passing dynamic variables.

---
*PR created automatically by Jules for task [9820744538405174790](https://jules.google.com/task/9820744538405174790) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->