### PR TITLE
🧹 Remove unused os import from consolidate_adblock_lists.py

### DIFF
--- a/adguard/scripts/consolidate_adblock_lists.py
+++ b/adguard/scripts/consolidate_adblock_lists.py
@@ -11,7 +11,6 @@ Usage: python3 consolidate_adblock_lists.py --input-dir <input_dir> --output-dir
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
- 🎯 **What:** Removed the unused `import os` statement from `adguard/scripts/consolidate_adblock_lists.py`.
- 💡 **Why:** Removing unused imports improves code readability and maintainability.
- ✅ **Verification:** Confirmed `os` is not used in the script and verified that all existing tests pass after removal.
- ✨ **Result:** Improved code health by eliminating dead code.

---
*PR created automatically by Jules for task [18232739206314392457](https://jules.google.com/task/18232739206314392457) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->