### PR TITLE
🧹 [remove unused mock_open import]

### DIFF
--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 # Add the project root to sys.path so we can import the script
 project_root = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
- 🎯 **What:** Removed unused `mock_open` import from `tests/test_extract_domains.py`.
- 💡 **Why:** Unused imports clutter the code and can cause confusion. Removing them improves maintainability and readability.
- ✅ **Verification:** Ran the full test suite (`python3 -m unittest discover tests`) to ensure no functionality was broken.
- ✨ **Result:** The codebase is cleaner and adheres better to code health standards.

---
*PR created automatically by Jules for task [2271827017645722067](https://jules.google.com/task/2271827017645722067) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->