### PR TITLE
🧹 Remove unused import in benchmark_infuse_auth.py

### DIFF
--- a/tests/benchmarks/benchmark_infuse_auth.py
+++ b/tests/benchmarks/benchmark_infuse_auth.py
@@ -7,7 +7,6 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from unittest.mock import patch
 
 
 def wait_for_port(port, timeout=5.0):
@@ -31,7 +30,7 @@ def worker(url, i):
                 status = response.status
         except urllib.error.HTTPError as e:
             status = e.code
-        except urllib.error.URLError as e:
+        except urllib.error.URLError:
             status = -1
         end_time = time.time()
         return (i, end_time - start_time, status)
@@ -111,7 +110,7 @@ def run_benchmark(num_requests=50, concurrency=50):
     else:
         avg_latency = max_latency = min_latency = 0
 
-    print(f"\n--- Benchmark Results ---")
+    print("\n--- Benchmark Results ---")
     print(f"Total time taken: {total_time:.2f} seconds")
     print(f"401 Unauthorized responses: {len(successes)}")
     print(f"429 Too Many Requests responses: {len(rate_limited)}")


### PR DESCRIPTION
## 🧹 Remove unused import in benchmark_infuse_auth.py

🎯 **What**
Removed the unused `patch` import from `unittest.mock` on line 10 of `tests/benchmarks/benchmark_infuse_auth.py`. Also addressed two other minor code health issues in the same file proactively flagged by `trunk` linting: removed an unused exception variable `e` and an unnecessary `f-string` prefix.

💡 **Why**
Removing unused imports reduces namespace clutter and immediately improves overall code cleanliness. Removing unused exception variables and unnecessary f-string prefixes improves code readability and satisfies static analysis linters (e.g., `ruff`).

✅ **Verification**
Ran formatting and linting using `trunk check` (with autofixes). The remaining bandit warning is a false-positive outside the scope of this health change. Also successfully ran `python3 -m unittest discover tests` to ensure no functionality regressions were introduced. Note: reverted local symlink modifications triggered by `trunk` to ensure the repository remains clean.

✨ **Result**
The benchmark file is now cleaner, satisfying strict Python linting rules, without modifying any underlying testing functionality.

---
*PR created automatically by Jules for task [4135769589606979951](https://jules.google.com/task/4135769589606979951) started by @abhimehro*