### PR TITLE
Update cloud agent testing skill for duplicate triage

### DIFF
--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -171,7 +171,8 @@ Key assertions:
 if [ -f tests/test_detect_duplicates_triage.py ]; then
   python3 -m unittest tests.test_detect_duplicates_triage -v
 else
-  python3 -m unittest discover -s tests -p 'test_*.py' -v
+  echo "tests/test_detect_duplicates_triage.py is missing; port/create it or run the mocked temp-workspace scenario manually before claiming duplicate-triage validation."
+  exit 1
 fi
 ```
 

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -20,6 +20,13 @@ make test-quick          # smoke: lib tests + path_validation
 
 ---
 
+## Devin Secrets Needed
+
+- **None required** for local lint/unit tests and mock-based CLI tests.
+- **`GH_TOKEN` / `GH_TOKEN_2`** may be needed only for live GitHub/`gh` flows; prefer mocked `gh` on `PATH` for deterministic tests of triage logic.
+
+---
+
 ## 1) Repo-wide — Cloud workspace & quality gates
 
 ### Environment setup
@@ -142,6 +149,24 @@ bash tests/test_lib_dns_utils.sh
 python3 -m unittest discover -s tests -p 'test_*.py' -v
 # Single module:
 python3 -m unittest tests.test_path_validation -v
+```
+
+### Duplicate triage (`detect_duplicates.py`)
+
+Use an isolated temp workspace with `tasks/pr-triage.md` and a mocked `gh` executable first on `PATH` to test rewrite behavior deterministically. Include adversarial PR numbers where one is a prefix of another, e.g. SUPERSEDED has `abhimehro/example#123` and READY has `#12`, `#123`, and `#124`.
+
+Key assertions:
+
+- The script exits `0` and prints `Duplicates: []` when mocked file sets are unique.
+- `## SUPERSEDED` preserves existing entries exactly once.
+- `## READY` keeps prefix PRs like `#12` when `#123` appears before READY.
+- `## READY` removes PRs already in SUPERSEDED.
+- `## DUPLICATE` stays empty when mocked file paths differ.
+
+```bash
+python3 -m unittest tests.test_detect_duplicates_triage -v
+python3 -m unittest discover -s tests -p 'test_vulnerability_fix.py' -v
+git ls-files .trunk/plugins/trunk  # should print nothing; local Trunk plugin symlinks must stay untracked
 ```
 
 ---

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -155,7 +155,9 @@ python3 -m unittest tests.test_path_validation -v
 
 When changing `detect_duplicates.py`, validate the rewrite behavior in an isolated temp workspace with `tasks/pr-triage.md` and a mocked `gh` executable first on `PATH`. Use full `abhimehro/<repo>#<number>` entries because the script only processes lines beginning with `- abhimehro/`.
 
-Use adversarial PR numbers where one is a prefix of another, e.g. SUPERSEDED has `abhimehro/example#123` and READY has `abhimehro/example#12`, `abhimehro/example#123`, and `abhimehro/example#124`. These assertions require the duplicate-triage fixes from PR #869 or an equivalent implementation; if they fail on an older branch, fix the script before relying on the runbook.
+Use adversarial PR numbers where one is a prefix of another, e.g. SUPERSEDED has `abhimehro/example#123` and READY has `abhimehro/example#12`, `abhimehro/example#123`, and `abhimehro/example#124`. These assertions are pass criteria only after the duplicate-triage fixes from PR #869 (or an equivalent implementation) are present; on older branches, treat failures as confirmation that the script must be fixed before relying on the runbook.
+
+PR #869 adds a dedicated `tests/test_detect_duplicates_triage.py` regression for this scenario. If that file is not present on your branch, port/create the regression first or run the same mocked temp-workspace scenario manually; do not run a module-specific unittest command for a file that does not exist.
 
 Key assertions:
 
@@ -166,7 +168,8 @@ Key assertions:
 - `## DUPLICATE` stays empty when mocked file paths differ.
 
 ```bash
-python3 -m unittest tests.test_detect_duplicates_triage -v
+# After the duplicate-triage regression exists on this branch:
+python3 -m unittest discover -s tests -p 'test_*.py' -v
 ```
 
 ---

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -169,6 +169,8 @@ Key assertions:
 
 ```bash
 # After the duplicate-triage regression exists on this branch:
+python3 -m unittest tests.test_detect_duplicates_triage -v
+# Otherwise, run full discovery and use the mocked temp-workspace assertions above:
 python3 -m unittest discover -s tests -p 'test_*.py' -v
 ```
 

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -23,7 +23,7 @@ make test-quick          # smoke: lib tests + path_validation
 ## Devin Secrets Needed
 
 - **None required** for local lint/unit tests and mock-based CLI tests.
-- **`GH_TOKEN` / `GH_TOKEN_2`** may be needed only for live GitHub/`gh` flows; prefer mocked `gh` on `PATH` for deterministic tests of triage logic.
+- **`GH_TOKEN`** may be needed only for live GitHub/`gh` flows; prefer mocked `gh` on `PATH` for deterministic tests of triage logic.
 
 ---
 

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -153,20 +153,20 @@ python3 -m unittest tests.test_path_validation -v
 
 ### Duplicate triage (`detect_duplicates.py`)
 
-Use an isolated temp workspace with `tasks/pr-triage.md` and a mocked `gh` executable first on `PATH` to test rewrite behavior deterministically. Include adversarial PR numbers where one is a prefix of another, e.g. SUPERSEDED has `abhimehro/example#123` and READY has `#12`, `#123`, and `#124`.
+When changing `detect_duplicates.py`, validate the rewrite behavior in an isolated temp workspace with `tasks/pr-triage.md` and a mocked `gh` executable first on `PATH`. Use full `abhimehro/<repo>#<number>` entries because the script only processes lines beginning with `- abhimehro/`.
+
+Use adversarial PR numbers where one is a prefix of another, e.g. SUPERSEDED has `abhimehro/example#123` and READY has `abhimehro/example#12`, `abhimehro/example#123`, and `abhimehro/example#124`. These assertions require the duplicate-triage fixes from PR #869 or an equivalent implementation; if they fail on an older branch, fix the script before relying on the runbook.
 
 Key assertions:
 
 - The script exits `0` and prints `Duplicates: []` when mocked file sets are unique.
-- `## SUPERSEDED` preserves existing entries exactly once.
-- `## READY` keeps prefix PRs like `#12` when `#123` appears before READY.
-- `## READY` removes PRs already in SUPERSEDED.
+- `## SUPERSEDED` preserves `- abhimehro/example#123` exactly once.
+- `## READY` keeps the prefix PR `- abhimehro/example#12` when `abhimehro/example#123` appears before READY.
+- `## READY` removes the already-SUPERSEDED `- abhimehro/example#123`.
 - `## DUPLICATE` stays empty when mocked file paths differ.
 
 ```bash
 python3 -m unittest tests.test_detect_duplicates_triage -v
-python3 -m unittest discover -s tests -p 'test_vulnerability_fix.py' -v
-git ls-files .trunk/plugins/trunk  # should print nothing; local Trunk plugin symlinks must stay untracked
 ```
 
 ---

--- a/.claude/skills/cloud-agents-starter/SKILL.md
+++ b/.claude/skills/cloud-agents-starter/SKILL.md
@@ -168,10 +168,11 @@ Key assertions:
 - `## DUPLICATE` stays empty when mocked file paths differ.
 
 ```bash
-# After the duplicate-triage regression exists on this branch:
-python3 -m unittest tests.test_detect_duplicates_triage -v
-# Otherwise, run full discovery and use the mocked temp-workspace assertions above:
-python3 -m unittest discover -s tests -p 'test_*.py' -v
+if [ -f tests/test_detect_duplicates_triage.py ]; then
+  python3 -m unittest tests.test_detect_duplicates_triage -v
+else
+  python3 -m unittest discover -s tests -p 'test_*.py' -v
+fi
 ```
 
 ---


### PR DESCRIPTION
## What

Update the cloud-agent testing skill with reusable guidance for validating `detect_duplicates.py` duplicate-triage rewrites.

## Why

Future agents need a concise runbook for the adversarial duplicate-triage scenario discovered while testing PR #869, including the `#12`/`#123` prefix case and SUPERSEDED preservation behavior. The docs also need to be safe to follow on branches where PR #869's dedicated regression test has not yet been ported.

## How

- Added a `Duplicate triage (detect_duplicates.py)` section to `.claude/skills/cloud-agents-starter/SKILL.md`.
- Documented the isolated temp-workspace + mocked `gh` approach using full `abhimehro/<repo>#<number>` entries.
- Listed concrete pass criteria for SUPERSEDED preservation, READY exact matching, and empty DUPLICATE output for unique file sets.
- Clarified that these pass criteria require PR #869's fixes or an equivalent implementation.
- Clarified that `tests/test_detect_duplicates_triage.py` is added by PR #869; if missing on a branch, agents should port/create it or run the same mocked scenario manually instead of running a non-existent module-specific command.

## Testing

- `trunk check .claude/skills/cloud-agents-starter/SKILL.md` passed with no new issues.
- Skill doc sanity checks passed: no unconditional `python3 -m unittest tests.test_detect_duplicates_triage -v`, full repo-prefixed examples remain, and missing-regression guidance is present.
- CI is green: 9 passed, 0 failed, 0 pending.

## Security

No security impact. Documentation-only change; no secrets or `.env` files included.

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

Link to Devin session: https://app.devin.ai/sessions/072186ec18524d0c887e3a5855efe12f
Requested by: @abhimehro