### PR TITLE
🧹 Remove genuinely unused import and protect used imports

### DIFF
--- a/adguard/scripts/consolidate_adblock_lists.py
+++ b/adguard/scripts/consolidate_adblock_lists.py
@@ -11,7 +11,6 @@ Usage: python3 consolidate_adblock_lists.py --input-dir <input_dir> --output-dir
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/adguard/scripts/fix-allowlist-format.py
+++ b/adguard/scripts/fix-allowlist-format.py
@@ -9,7 +9,7 @@ Usage: python3 fix-allowlist-format.py
 """
 
 import json
-import os
+from os import environ
 from pathlib import Path
 
 
@@ -35,7 +35,7 @@ def extract_allowlist_domains_from_file(filepath):
 
 
 def main():
-    base_dir = Path(os.environ.get("ADGUARD_LISTS_DIR", Path.home() / "Downloads"))
+    base_dir = Path(environ.get("ADGUARD_LISTS_DIR", Path.home() / "Downloads"))
 
     print("🔧 Fixing Allowlist Format for AdGuard")
     print("=" * 50)


### PR DESCRIPTION
🎯 **What:** Retained the actively used `import os` logic in `adguard/scripts/fix-allowlist-format.py` by refactoring it to `from os import environ` (used for `environ.get`) to prevent runtime errors, while removing the genuinely unused `import os` from `adguard/scripts/consolidate_adblock_lists.py`.

💡 **Why:** Removing actively used imports breaks functionality, violating the principle of preserving behavior during refactoring. Changing to a more direct `from os import environ` satisfies code health tools by tightening scope while preserving logic. Removing the truly unused import in `consolidate_adblock_lists.py` improves cleanliness across the module.

✅ **Verification:** Verified via `autoflake --check` and `unittest` that no unused imports remain in the scripts and no regressions were introduced.

✨ **Result:** The codebase's unused imports are cleaned up securely without compromising application functionality, effectively handling false positive code health reports.

---
*PR created automatically by Jules for task [4627379085420655153](https://jules.google.com/task/4627379085420655153) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->