### PR TITLE
🛡️ Sentinel: Fix Information Exposure in done.fish kitty remote control command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -237,3 +237,8 @@
 **Vulnerability:** Terminal Injection ([CWE-150](https://cwe.mitre.org/data/definitions/150.html)) existed in `scripts/test_ssh_connections.sh`. The script used `echo -e` to print log messages containing untrusted input, allowing an attacker to inject escape sequences to manipulate terminal output.
 **Learning:** `echo -e` interprets backslash escapes in all arguments. Even if the intent is to print a variable, `echo -e` treats it as a format string.
 **Prevention:** Use `printf "%b %s\n" "$COLOR" "$*"` for colored output instead of `echo -e` to ensure variables are printed literally.
+
+## 2026-05-03 - CLI Argument Information Exposure Fix in Fish Script
+**Vulnerability:** Information Exposure (CWE-214) / Exposure of Sensitive Information Through Process Arguments. `done.fish` passed the `__done_kitty_remote_control_password` to `kitty @` via the `--password` command-line flag.
+**Learning:** Process command lines are typically globally readable on Unix-like systems via `ps` or `/proc`. Passing secrets as command-line arguments is insecure.
+**Prevention:** Use environment variables, standard input (STDIN), or file descriptors to pass secrets to processes securely, as these are not exposed in the process table. For kitty specifically, the `KITTY_RC_PASSWORD` environment variable provides a secure alternative to the `--password` CLI flag.

--- a/configs/.config/fish/_backups/20260423-085518/conf.d/done.fish
+++ b/configs/.config/fish/_backups/20260423-085518/conf.d/done.fish
@@ -145,7 +145,7 @@ function __done_is_process_window_focused
     end
 
     if set -q __done_kitty_remote_control
-        kitty @ --password="$__done_kitty_remote_control_password" ls | jq -e ".[].tabs[] | select(any(.windows[]; .is_self)) | .is_focused" >/dev/null
+        env KITTY_RC_PASSWORD="$__done_kitty_remote_control_password" kitty @ ls | jq -e ".[].tabs[] | select(any(.windows[]; .is_self)) | .is_focused" >/dev/null
         return $status
     end
 


### PR DESCRIPTION
T3+S+H — Bug Fix (Security)

🎯 **What:** The vulnerability fixed
Hardcoded remote control password reference (`--password="$__done_kitty_remote_control_password"`) was being passed via CLI arguments to `kitty @ ls` in `done.fish`.

⚠️ **Risk:** The potential impact if left unfixed
Information exposure. Passing a password as a CLI argument exposes it in the process table (`ps`, `/proc/<pid>/cmdline`), allowing other users on the system or unauthorized processes monitoring process lists to capture the `kitty` remote control password. This password grants the ability to run arbitrary commands within the `kitty` terminal session.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the `--password=` CLI flag with the `KITTY_RC_PASSWORD` environment variable, executed via `env`. By passing the secret through an environment variable instead of a command-line argument, it is hidden from standard process listings like `ps` on most modern Unix-like systems, preventing local privilege escalation and information exposure.

✅ **Verification:**
- Ran the unit test suite (`make test-all`). All tests pass.
- Inspected the bash code structure, `env KITTY_RC_PASSWORD="..." kitty @ ls` is valid execution syntax in fish.

══════════ ELIR ══════════
**PURPOSE:** Addressed an Information Exposure vulnerability in `configs/.config/fish/_backups/20260423-085518/conf.d/done.fish` where a password was exposed via command-line arguments to `ps`.
**SECURITY:** By switching to the `KITTY_RC_PASSWORD` environment variable (using `env KITTY_RC_PASSWORD="$pass" cmd...`), the password is no longer visible to other processes tracking system metrics or snooping `/proc/<pid>/cmdline`.
**FAILS IF:** `kitty` changes its API and no longer supports `KITTY_RC_PASSWORD` (not expected, as it is the documented secure method).
**VERIFY:** Double-check that `kitty @ ls` executes properly without prompting when the variable is provided, and review the diff to ensure it was injected securely.
**MAINTAIN:** Any future subshells or commands executed with sensitive variables should leverage `env VAR=val` instead of `--password=val` or `-p val`. I have recorded this in the `.jules/sentinel.md` learning notes.

---
*PR created automatically by Jules for task [14076794259501728547](https://jules.google.com/task/14076794259501728547) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->