### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in mole core scripts

### DIFF
--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -639,7 +639,7 @@ build_regex_var() {
 			regex="$regex|$p"
 		fi
 	done
-	eval "$var_name=\"\$regex\""
+	printf -v "$var_name" "%s" "$regex"
 }
 
 # Lazy-loaded regex (only built when needed)

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -153,15 +153,14 @@ debug_timer_start() {
     local varname="$1"
     local ts
     ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)
-    eval "$varname=$ts"
+    printf -v "$varname" "%s" "$ts"
 }
 
 debug_timer_end() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local label="$1"
     local start_var="$2"
-    local start_ts
-    eval "start_ts=\$$start_var"
+    local start_ts="${!start_var}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command Injection ([CWE-78](https://cwe.mitre.org/data/definitions/78.html)) risk existed in `configs/.config/mole/lib/core/app_protection.sh` and `configs/.config/mole/lib/core/log.sh`. These scripts used `eval` to assign variables dynamically based on function arguments (`eval "$var_name=\"\$regex\""`, `eval "$varname=$ts"`) and read variables (`eval "start_ts=\$$start_var"`). If an attacker could control the variable names passed to these functions, they could inject arbitrary bash commands.
🎯 **Impact:** Potential arbitrary command execution if dynamically passed variables originate from untrusted input, compromising the system running the mole scripts.
🔧 **Fix:** Refactored unsafe `eval` usage. Replaced dynamic variable assignments with the safe `printf -v "$varname" "%s" "$value"` syntax. Replaced dynamic variable reads with Bash's native indirect variable expansion `${!start_var}`.
✅ **Verification:** Ran `bash tests/run_all_tests.sh` to ensure no tests fail as a result of these modifications.
📝 **Maintenance:** Logged critical learning in `.jules/sentinel.md` regarding the unsafe `eval` pattern and the secure refactoring techniques.

---
*PR created automatically by Jules for task [17962710238290979298](https://jules.google.com/task/17962710238290979298) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->