### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in dynamic variable assignment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -242,3 +242,8 @@
 **Vulnerability:** Information Exposure (CWE-214) / Exposure of Sensitive Information Through Process Arguments. `done.fish` passed the `__done_kitty_remote_control_password` to `kitty @` via the `--password` command-line flag.
 **Learning:** Process command lines are typically globally readable on Unix-like systems via `ps` or `/proc`. Passing secrets as command-line arguments is insecure.
 **Prevention:** Use environment variables, standard input (STDIN), or file descriptors to pass secrets to processes securely, as these are not exposed in the process table. For kitty specifically, the `KITTY_RC_PASSWORD` environment variable provides a secure alternative to the `--password` CLI flag.
+
+## 2026-05-05 - Command Injection Risk via eval in dynamic variable assignment
+**Vulnerability:** Command Injection (CWE-78) risk existed in log timers and app protection regex building due to the use of eval.
+**Learning:** Dynamic variable names were assigned via eval, allowing arbitrary command execution if an attacker controls the variable name.
+**Prevention:** Refactor to use printf -v for dynamic assignment and indirect expansion (${!var}) for dynamic reading.

--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -639,7 +639,7 @@ build_regex_var() {
 			regex="$regex|$p"
 		fi
 	done
-	eval "$var_name=\"\$regex\""
+	printf -v "$var_name" "%s" "$regex"
 }
 
 # Lazy-loaded regex (only built when needed)

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -153,15 +153,14 @@ debug_timer_start() {
     local varname="$1"
     local ts
     ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)
-    eval "$varname=$ts"
+    printf -v "$varname" "%s" "$ts"
 }
 
 debug_timer_end() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local label="$1"
     local start_var="$2"
-    local start_ts
-    eval "start_ts=\$$start_var"
+    local start_ts="${!start_var}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Command Injection vulnerability (CWE-78) was identified in `configs/.config/mole/lib/core/app_protection.sh` and `configs/.config/mole/lib/core/log.sh`. Both files utilized the `eval` command for dynamic variable assignment (`eval "$varname=$ts"`) and dynamic variable reading (`eval "start_ts=\$$start_var"`).
🎯 **Impact:** If an attacker can control or influence the variable names passed to these functions, they could execute arbitrary shell commands within the context of the running script. This pattern compromises the trust boundary.
🔧 **Fix:** 
- In `app_protection.sh`, replaced `eval "$var_name=\"\$regex\""` with `printf -v "$var_name" "%s" "$regex"`.
- In `log.sh`, replaced `eval "$varname=$ts"` with `printf -v "$varname" "%s" "$ts"`, and replaced `eval "start_ts=\$$start_var"` with indirect variable expansion `start_ts="${!start_var}"`. 
- Added a Sentinel journal entry documenting the vulnerability and prevention pattern.
✅ **Verification:** 
- Ran all tests using `bash tests/run_all_tests.sh` which confirmed no regressions were introduced.
- Verified syntax safety locally and confirmed `printf -v` and `${!var}` are supported in the Bash environment utilized by the project.

---
*PR created automatically by Jules for task [8522753299274463503](https://jules.google.com/task/8522753299274463503) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->