### PR TITLE
🎨 Palette: Require Enter for CLI confirmation prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -119,3 +119,8 @@
 
 **Learning:** When adding asynchronous tasks like animated spinners to CLI tools built in TypeScript/Node.js, users expect the terminal to return to a clean state if they press `Ctrl+C`. Without a proper `SIGINT` handler, the cursor remains hidden, and spinner text is left scattered on the prompt.
 **Action:** Always attach a `process.on('SIGINT')` event listener that explicitly stops timers (`clearInterval`), restores the cursor (`\x1B[?25h`), clears the line (`\r\x1B[K`), and exits cleanly with `process.exit(130)`.
+
+## 2024-05-18 - Require Enter for Confirmation Prompts
+
+**Learning:** Using `read -n 1` for confirmation prompts (e.g., `read -p "Continue? (y/n): " -n 1`) allows users to accidentally trigger actions by bumping a key. Additionally, if a user types "yes" instead of "y", the "es" and the Enter keystroke are left in the stdin buffer, potentially executing unintended commands after the script finishes.
+**Action:** Remove the `-n 1` flag from `read` prompts to require an explicit Enter press, acting as a safety confirmation and preventing buffer stuffing. When doing so, also remove any immediately following `echo` command that was previously used to print the missing newline.

--- a/media-streaming/scripts/bulk-rename-cloud.sh
+++ b/media-streaming/scripts/bulk-rename-cloud.sh
@@ -52,9 +52,8 @@ if [[ $DRY_RUN == "true" ]]; then
 	exit 0
 fi
 
-read -p "Do you want to attempt automatic renaming? (y/N) " -n 1 -r
+read -p "Do you want to attempt automatic renaming? (y/N) " -r
 REPLY=${REPLY:-N}
-echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	log "User cancelled"
 	exit 0

--- a/media-streaming/scripts/fix-gdrive.sh
+++ b/media-streaming/scripts/fix-gdrive.sh
@@ -34,8 +34,7 @@ if rclone about gdrive: &>/dev/null; then
 else
 	echo "❌ Reconnect failed. Let's delete and recreate..."
 	echo
-	read -p "Delete gdrive remote and start fresh? (y/n): " -n 1 -r
-	echo
+	read -p "Delete gdrive remote and start fresh? (y/n): " -r
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
 		rclone config delete gdrive
 		echo "✅ Old gdrive remote deleted"

--- a/media-streaming/scripts/setup-media-library.sh
+++ b/media-streaming/scripts/setup-media-library.sh
@@ -218,8 +218,7 @@ echo "• Create a unified 'media' remote"
 echo "• Set up WebDAV server for Infuse"
 echo
 
-read -p "Continue? (y/n): " -n 1 -r
-echo
+read -p "Continue? (y/n): " -r
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	echo "Setup cancelled."
 	exit 1


### PR DESCRIPTION
**💡 What**: Removed the `-n 1` flag from `read -p` confirmation prompts across multiple media library scripts (`setup-media-library.sh`, `bulk-rename-cloud.sh`, `fix-gdrive.sh`).

**🎯 Why**: 
1. **Safety**: Using `-n 1` allows a user to accidentally bump a key and trigger an action (e.g., "Delete gdrive remote"). Requiring Enter adds a necessary, explicit confirmation step for these workflows.
2. **Buffer Stuffing**: If a user instinctively types "yes" and hits Enter when prompted for "(y/n)", the `-n 1` flag causes the script to only consume the "y". The remaining "es" and the Enter keystroke remain in the terminal buffer and execute as soon as the script finishes, causing errors or unintended consequences.

**📸 Before/After**: N/A - text-based CLI change.

**♿ Accessibility**: This improves cognitive accessibility by providing a standard, expected interaction model (typing an answer and pressing Enter) rather than instantly capturing keystrokes.

*(Added corresponding learning to `.jules/palette.md`)*

---
*PR created automatically by Jules for task [6842047450133080917](https://jules.google.com/task/6842047450133080917) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->