### PR TITLE
🎨 Palette: [UX] Require explicit Enter for script confirmations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -119,3 +119,8 @@
 
 **Learning:** When adding asynchronous tasks like animated spinners to CLI tools built in TypeScript/Node.js, users expect the terminal to return to a clean state if they press `Ctrl+C`. Without a proper `SIGINT` handler, the cursor remains hidden, and spinner text is left scattered on the prompt.
 **Action:** Always attach a `process.on('SIGINT')` event listener that explicitly stops timers (`clearInterval`), restores the cursor (`\x1B[?25h`), clears the line (`\r\x1B[K`), and exits cleanly with `process.exit(130)`.
+
+## 2026-06-25 - Require explicit Enter for script confirmations
+
+**Learning:** Using the '-n 1' flag with 'read' prompts for user confirmation (especially for destructive actions) causes 'buffer stuffing' bugs where extra characters (e.g., typing "yes" instead of "y") spill over into the terminal as subsequent commands. Requiring the user to press 'Enter' explicitly acts as a safety confirmation step.
+**Action:** Avoid using '-n 1' in read commands when prompting for user confirmation. Remove following 'echo' since Enter provides newline.

--- a/media-streaming/scripts/bulk-rename-cloud.sh
+++ b/media-streaming/scripts/bulk-rename-cloud.sh
@@ -52,9 +52,8 @@ if [[ $DRY_RUN == "true" ]]; then
 	exit 0
 fi
 
-read -p "Do you want to attempt automatic renaming? (y/N) " -n 1 -r
+read -p "Do you want to attempt automatic renaming? (y/N) " -r
 REPLY=${REPLY:-N}
-echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	log "User cancelled"
 	exit 0

--- a/media-streaming/scripts/fix-gdrive.sh
+++ b/media-streaming/scripts/fix-gdrive.sh
@@ -34,8 +34,7 @@ if rclone about gdrive: &>/dev/null; then
 else
 	echo "❌ Reconnect failed. Let's delete and recreate..."
 	echo
-	read -p "Delete gdrive remote and start fresh? (y/n): " -n 1 -r
-	echo
+	read -p "Delete gdrive remote and start fresh? (y/n): " -r
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
 		rclone config delete gdrive
 		echo "✅ Old gdrive remote deleted"

--- a/media-streaming/scripts/setup-media-library.sh
+++ b/media-streaming/scripts/setup-media-library.sh
@@ -218,8 +218,7 @@ echo "• Create a unified 'media' remote"
 echo "• Set up WebDAV server for Infuse"
 echo
 
-read -p "Continue? (y/n): " -n 1 -r
-echo
+read -p "Continue? (y/n): " -r
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	echo "Setup cancelled."
 	exit 1


### PR DESCRIPTION
💡 What: Refactored `read` prompts in `media-streaming/scripts/setup-media-library.sh`, `bulk-rename-cloud.sh`, and `fix-gdrive.sh` to remove the `-n 1` flag. Users must now explicitly press 'Enter' to confirm destructive or sequential setup actions. Also removed immediately following `echo` commands since 'Enter' natively provides a newline. Added a journal entry to `.jules/palette.md` documenting this insight.

🎯 Why: Using `-n 1` for single-character reads in bash scripts can lead to "buffer stuffing" bugs. If a user habitually types "yes" instead of just "y", the "es\n" spills over into the terminal execution buffer, potentially executing unintended commands and creating a broken UI experience. Forcing an explicit 'Enter' acts as a necessary safety barrier and ensures clean terminal state.

📸 Before/After:
**Before:** Prompts would immediately accept a single keystroke and proceed, potentially causing terminal spam if extra characters were typed.
**After:** Prompts wait for the user to type their response and explicitly press Enter, ensuring only intended input is processed.

♿ Accessibility: Ensures a more deliberate and predictable interaction model for terminal users, reducing the risk of accidental progression in CLI wizards.

---
*PR created automatically by Jules for task [4406142059620041546](https://jules.google.com/task/4406142059620041546) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->