### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection risk via eval in dynamic array access

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -252,3 +252,8 @@
 **Vulnerability:** Terminal Injection vulnerability where malicious input containing escape characters could manipulate the terminal display or execute arbitrary commands depending on the terminal emulator. Found in `setup.sh` logging functions.
 **Learning:** `echo -e` interpolates escape characters in variables, which is dangerous when outputting untrusted input.
 **Prevention:** Use `printf "%b[INFO]%b %s\n"` to strictly separate color formatting (hardcoded via `%b`) from user data (passed via `%s`), preventing execution or interpretation of escape characters within dynamic input.
+
+## 2024-05-08 - Command Injection Risk via eval for Dynamic Arrays
+**Vulnerability:** Dynamic array expansion via `eval 'group_count=${#'"$array_name"'[@]}'` creates a risk of Command Injection if the input string is not strictly validated.
+**Learning:** Using `eval` for dynamic references is a legacy anti-pattern in Bash scripts. Although input validation mitigates the risk, the pattern is inherently dangerous.
+**Prevention:** Use Bash namerefs (`declare -n ref="$var_name"`) for safe dynamic variable and array access, which evaluates safely without shell command execution. Always pair with input validation to prevent nameref initialization errors on invalid strings.

--- a/configs/.config/mole/lib/clean/caches.sh
+++ b/configs/.config/mole/lib/clean/caches.sh
@@ -296,12 +296,12 @@ flush_python_group_if_needed() {
         return 0
     fi
 
-    local group_count=0
-    eval 'group_count=${#'"$array_name"'[@]}'
+    # Use nameref for safe dynamic array access instead of eval
+    declare -n _group_dirs_ref="$array_name" 2>/dev/null || return 0
+
+    local group_count="${#_group_dirs_ref[@]}"
     [[ -z "$group_root" || "$group_count" -eq 0 ]] && return 0
-    eval 'local -a group_dirs=( "${'"$array_name"'[@]}" )'
-    # shellcheck disable=SC2154  # group_dirs assigned via eval above
-    clean_python_bytecode_cache_group "$group_root" "${group_dirs[@]}"
+    clean_python_bytecode_cache_group "$group_root" "${_group_dirs_ref[@]}"
 }
 
 process_project_cache_matches() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `flush_python_group_if_needed` function in `configs/.config/mole/lib/clean/caches.sh` used `eval` to dynamically expand array names (e.g., `eval 'group_count=${#'"$array_name"'[@]}'`). This created a risk of Command Injection if the input string `$array_name` was maliciously crafted.
🎯 Impact: While currently mitigated by strict regex validation on the `$array_name` parameter, the use of `eval` for dynamic referencing is a fragile legacy anti-pattern. If the validation were ever bypassed or removed, an attacker could execute arbitrary shell commands with the privileges of the script.
🔧 Fix: Replaced the insecure `eval` calls with modern Bash namerefs (`declare -n`). This provides safe dynamic array access that evaluates correctly without executing shell commands. The existing input validation was preserved to prevent script crashes on invalid identifier strings.
✅ Verification: Ran `bash tests/run_all_tests.sh` to ensure no regressions were introduced. All tests passed.

Documented the pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12132402325731742400](https://jules.google.com/task/12132402325731742400) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->