### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection in caches.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -252,3 +252,9 @@
 **Vulnerability:** Terminal Injection vulnerability where malicious input containing escape characters could manipulate the terminal display or execute arbitrary commands depending on the terminal emulator. Found in `setup.sh` logging functions.
 **Learning:** `echo -e` interpolates escape characters in variables, which is dangerous when outputting untrusted input.
 **Prevention:** Use `printf "%b[INFO]%b %s\n"` to strictly separate color formatting (hardcoded via `%b`) from user data (passed via `%s`), preventing execution or interpretation of escape characters within dynamic input.
+
+## 2026-05-09 - Command Injection Risk via eval in array length calculation
+
+**Vulnerability:** Command Injection ([CWE-78](https://cwe.mitre.org/data/definitions/78.html)) risk existed in `configs/.config/mole/lib/clean/caches.sh`. The `flush_python_group_if_needed` function used `eval` to get the length of an array and expand it by dynamic variable name (e.g. `eval 'group_count=${#'"$array_name"'[@]}'`).
+**Learning:** Using `eval` to access array properties and elements by dynamically built names in shell scripts is a command injection risk even if primarily internal.
+**Prevention:** Use Bash namerefs (`declare -n`) to access dynamically referenced array elements instead of string interpolation and `eval`.

--- a/configs/.config/mole/lib/clean/caches.sh
+++ b/configs/.config/mole/lib/clean/caches.sh
@@ -296,11 +296,11 @@ flush_python_group_if_needed() {
         return 0
     fi
 
-    local group_count=0
-    eval 'group_count=${#'"$array_name"'[@]}'
+    # Use nameref for safe dynamic array access
+    declare -n _group_ref="$array_name"
+    local group_count="${#_group_ref[@]}"
     [[ -z "$group_root" || "$group_count" -eq 0 ]] && return 0
-    eval 'local -a group_dirs=( "${'"$array_name"'[@]}" )'
-    # shellcheck disable=SC2154  # group_dirs assigned via eval above
+    local -a group_dirs=("${_group_ref[@]}")
     clean_python_bytecode_cache_group "$group_root" "${group_dirs[@]}"
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Command Injection via eval

🚨 Severity: HIGH
💡 Vulnerability: Command Injection (CWE-78) via `eval` used to dynamically reference and expand array variables based on the `array_name` parameter in `flush_python_group_if_needed`.
🎯 Impact: If `array_name` contained malicious input, `eval` could execute arbitrary bash commands. Even if primarily internal, it violates the trust boundary and creates a significant risk.
🔧 Fix: Replaced `eval` with Bash namerefs (`declare -n`) for safe dynamic array referencing. Preserved input validation. 
✅ Verification: Ran `make test-all` and verified all 34/37 unit tests still pass (3 skipped). Added learning to `.jules/sentinel.md`.

========== ELIR ==========
PURPOSE: Fix command injection vulnerability in `flush_python_group_if_needed`.
SECURITY: Replaces unsafe `eval` string interpolation with safe Bash namerefs (`declare -n`) to access dynamically named arrays.
FAILS IF: Caller is running a very old version of bash (<4.3) that doesn't support namerefs.
VERIFY: Array length and expansion logic works as expected without errors.
MAINTAIN: Always use namerefs for pass-by-reference logic in bash to avoid CWE-78.

---
*PR created automatically by Jules for task [16931717880079757227](https://jules.google.com/task/16931717880079757227) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a security-sensitive shell path by changing how dynamically named arrays are referenced; behavior should be equivalent but depends on Bash nameref support and could break on older shells.
> 
> **Overview**
> Removes `eval` usage in `flush_python_group_if_needed` (`configs/.config/mole/lib/clean/caches.sh`) by switching dynamic array length/expansion to a Bash nameref (`declare -n`), eliminating a potential CWE-78 command injection vector while keeping the existing `array_name` validation.
> 
> Adds a new entry to `.jules/sentinel.md` documenting the vulnerability and the nameref-based prevention guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ba72e4332a45bf3f3dbe221be053fdccead604. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->