### PR TITLE
salvage: Bolt partition()/startswith() perf (orchestrate test 2026-05-09; salvages #911)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -141,3 +141,7 @@
 ## 2026-03-10 - [Memory Efficiency and PEP-8 in Data Extraction]
 **Learning:** Using `type() is dict` violates PEP-8 conventions. Furthermore, passing list comprehensions (e.g., `[x for x in data]`) to aggregate functions like `set.update()` forces the entire filtered sequence into memory at once, creating unnecessary memory spikes during large JSON extractions.
 **Action:** When extracting data based on type, always use `isinstance()`. When passing filtered sequences to aggregate functions that accept iterables (like `.update()`), preserve memory efficiency by using generator expressions `(...)` instead of list comprehensions `[...]`.
+
+## 2026-05-24 - [Avoid re.match and split overhead for simple parsing]
+**Learning:** Using `re.match` for simple prefix string extractions (like `## repo/name`) is up to ~3x slower than `str.startswith()` combined with list slicing. Similarly, breaking strings on a single character using `str.split("=", 1)` or extracting suffix/prefix with `split("/")[-1]` introduces unnecessary list allocation overhead. The `str.partition()` and `str.rpartition()` methods are implemented in C and provide ~30-40% faster string splitting without allocating new lists.
+**Action:** For simple string prefix extractions, prefer `startswith` + slicing over regular expressions. When splitting a string on a single separator, use `partition` or `rpartition` instead of `split`.

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -12,9 +12,10 @@ def _parse_env_line(line, env_dict):
         return
     if line.startswith("export "):
         line = line[7:].strip()
-    if "=" not in line:
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    key, sep, val = line.partition("=")
+    if not sep:
         return
-    key, val = line.split("=", 1)
     env_dict[key] = val.strip("'\"")
 
 
@@ -83,7 +84,8 @@ categorized = {
 }
 
 for pr in ready_prs:
-    repo, pr_id = pr.split("#")
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    repo, _, pr_id = pr.partition("#")
     info = run_gh(
         [
             "gh",

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -12,9 +12,10 @@ def _parse_env_line(line, env_dict):
         return
     if line.startswith("export "):
         line = line[7:].strip()
-    if "=" not in line:
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    key, sep, val = line.partition("=")
+    if not sep:
         return
-    key, val = line.split("=", 1)
     env_dict[key] = val.strip("'\"")
 
 
@@ -48,7 +49,8 @@ def run_gh(cmd_list):
 
 
 def fetch_pr_info(pr):
-    repo, pr_id = pr.split("#")
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    repo, _, pr_id = pr.partition("#")
     info = run_gh(
         [
             "gh",

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime, timezone
 import json
 import subprocess
@@ -13,10 +12,10 @@ def _parse_env_line(line, env_dict):
         return
     if line.startswith("export "):
         line = line[7:].strip()
-    if "=" not in line:
-        return
-    # ⚡ Bolt Optimization: Use partition instead of split for faster key-value separation
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
     key, sep, val = line.partition("=")
+    if not sep:
+        return
     env_dict[key] = val.strip("'\"")
 
 @lru_cache(maxsize=None)
@@ -54,7 +53,7 @@ current_repo = None
 
 # Repo -> [ (pr_id, author, merge, checks, hints), ... ]
 for line in lines:
-    # ⚡ Bolt Optimization: Replace re.match with startswith and slicing for ~4x faster line parsing
+    # ⚡ Bolt Optimization: Replace re.match with startswith() + slicing for faster line parsing
     if line.startswith('## '):
         current_repo = line[3:].strip()
         repos[current_repo] = []

--- a/run_merges.py
+++ b/run_merges.py
@@ -13,9 +13,10 @@ def _parse_env_line(line, env_dict):
         return
     if line.startswith("export "):
         line = line[7:].strip()
-    if "=" not in line:
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    key, sep, val = line.partition("=")
+    if not sep:
         return
-    key, val = line.split("=", 1)
     env_dict[key] = val.strip("'\"")
 
 

--- a/scratch_inventory.py
+++ b/scratch_inventory.py
@@ -35,7 +35,8 @@ for repo in repos:
     if res.returncode == 0:
         prs = json.loads(res.stdout)
         for pr in prs:
-            pr["repo"] = repo.split("/")[-1]
+            # ⚡ Bolt Optimization: Use rpartition() over split() to avoid intermediate list allocation overhead
+            pr["repo"] = repo.rpartition("/")[2]
             all_prs.append(pr)
 
 out_md = []

--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -38,7 +38,8 @@ for repo in repos:
     if success:
         prs = json.loads(stdout)
         for pr in prs:
-            pr["repo"] = repo.split("/")[-1]
+            # ⚡ Bolt Optimization: Use rpartition() over split() to avoid intermediate list allocation overhead
+            pr["repo"] = repo.rpartition("/")[2]
             pr["full_repo"] = repo
             all_prs.append(pr)
 

--- a/scripts/_load_pr_review_agent_config.py
+++ b/scripts/_load_pr_review_agent_config.py
@@ -50,7 +50,8 @@ def _emit_bot_authors(bots: Any) -> None:
     for item in bots:
         if not isinstance(item, str):
             continue
-        ent = item.split("#", 1)[0].strip()
+        # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+        ent = item.partition("#")[0].strip()
         if ent:
             print(f"bot\t{ent}")
 


### PR DESCRIPTION
Salvage of #911 onto current `origin/main`.

Replays the single Bolt commit `fd9fcc25` from #911 onto a fresh branch from main. The original PR was DIRTY against main due to overlapping Bolt commits already merged on main; this salvage resolves the trivial `parse_inventory.py` conflict by deduplicating the comment lines and dropping the redundant `partition()` call already present on main.

**Diff:** 8 files, +27/-16 LOC.

**Resolution notes:**

- `parse_inventory.py`: removed two duplicate `# ⚡ Bolt Optimization` comments; main already absorbed equivalent `partition()` and `startswith()` rewrites via earlier Bolt PRs.
- All other files (`categorize_ready.py`, `detect_duplicates.py`, `run_merges.py`, `scratch_inventory.py`, `scratch_triage.py`, `scripts/_load_pr_review_agent_config.py`, `.jules/bolt.md`) cherry-picked cleanly with no conflicts.

**Closes #911** (so the original DIRTY PR can be replaced by this rebased version).

---
Salvage performed in `/tmp/salvage-2026-05-10/pc` (no working-tree manipulation in the active workspace, per Lesson 0df).

Reference: `tasks/pr-merge-results-2026-05-09.json` deferred ("Bolt perf, DIRTY against main").

Draft because: review the deduplication call before merging.

Made with [Cursor](https://cursor.com)