### PR TITLE
salvage: add 9 unit tests for check_summary (orchestrate test 2026-05-09; salvages #856)

### DIFF
--- a/tests/test_get_prs_summarize.py
+++ b/tests/test_get_prs_summarize.py
@@ -6,7 +6,7 @@ from pathlib import Path
 scripts_dir = Path(__file__).parent.parent / "scripts"
 sys.path.append(str(scripts_dir))
 
-from get_prs_summarize import automation_hints
+from get_prs_summarize import automation_hints, check_summary
 
 class TestAutomationHints(unittest.TestCase):
     def test_human_pr(self):
@@ -102,6 +102,70 @@ class TestAutomationHints(unittest.TestCase):
             "body": None
         }
         self.assertEqual(automation_hints(pr), "(none — treat as human unless reviews say otherwise)")
+
+
+class TestCheckSummary(unittest.TestCase):
+    def test_none_rollup(self):
+        self.assertEqual(check_summary(None), "NO_CHECKS")
+
+    def test_empty_rollup(self):
+        self.assertEqual(check_summary([]), "NO_CHECKS")
+
+    def test_all_completed_ok(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+            {"status": "completed", "conclusion": "success"},  # case insensitive check
+        ]
+        self.assertEqual(check_summary(rollup), "COMPLETED_OK")
+
+    def test_pending_only(self):
+        rollup = [
+            {"status": "IN_PROGRESS"},
+            {"status": "QUEUED"},
+            {"status": ""},
+        ]
+        self.assertEqual(check_summary(rollup), "PENDING_3")
+
+    def test_failed_only(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+            {"status": "COMPLETED", "conclusion": "TIMED_OUT"},
+            {"status": "COMPLETED", "conclusion": "ACTION_REQUIRED"},
+            {"status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"status": "COMPLETED", "conclusion": "STARTUP_FAILURE"},
+        ]
+        self.assertEqual(check_summary(rollup), "FAIL_5")
+
+    def test_mixed_pending_and_failed(self):
+        rollup = [
+            {"status": "IN_PROGRESS"},
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+            {"status": "QUEUED"},
+        ]
+        self.assertEqual(check_summary(rollup), "PENDING_2+FAIL_1")
+
+    def test_mixed_all_three(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "IN_PROGRESS"},
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+        self.assertEqual(check_summary(rollup), "PENDING_1+FAIL_1")
+
+    def test_missing_keys(self):
+        rollup = [
+            {},  # pending (missing status defaults to "")
+            {"status": "COMPLETED"},  # not failed (missing conclusion is not in FAIL_CONCLUSIONS)
+        ]
+        self.assertEqual(check_summary(rollup), "PENDING_1")
+
+    def test_conclusion_case_insensitive(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "failure"},
+        ]
+        self.assertEqual(check_summary(rollup), "FAIL_1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Salvage of #856 onto current `origin/main`.

#856 originally added `tests/test_get_prs_summarize.py` as a *new* file, but main already has a file at that path with a different test class (`TestAutomationHints`). This salvage merges the new `TestCheckSummary` class into the existing module so both coexist as separate test classes.

**Diff:** 1 file, +65/-1 LOC.

**Verification (run inside the salvage clone, not the active workspace):**

```bash
python3 -m unittest tests.test_get_prs_summarize
# Ran 17 tests in 0.000s — OK
```

**Resolution notes:**

- Combined the two test classes (`TestAutomationHints` + new `TestCheckSummary`) in one module.
- Added `check_summary` to the existing import line.
- Cleaned up minor style nits (PEP-8 spacing) on the new class for consistency with the existing one.

**Closes #856** (so the original DIRTY-against-main PR can be replaced by this rebased version).

---
Salvage performed in `/tmp/salvage-2026-05-10/pc` (no working-tree manipulation in the active workspace, per Lesson 0df).

Reference: `tasks/pr-merge-results-2026-05-09.json` deferred ("DIRTY against main, ShellCheck failing"). The original ShellCheck failure was on unrelated shell files; this salvage is a pure Python test addition and should pass.

Draft because: re-confirm CI clears (ShellCheck, CodeScene) before merging.

Made with [Cursor](https://cursor.com)