### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-78 eval command injection in dynamic variable assignments

### DIFF
--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -648,7 +648,13 @@ build_regex_var() {
             regex="$regex|$p"
         fi
     done
-    eval "$var_name=\"\$regex\""
+
+    # SECURITY: Prevent CWE-78 command injection
+    if [[ ! "$var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$var_name' for regex assignment" >&2
+        return 1
+    fi
+    printf -v "$var_name" "%s" "$regex"
 }
 
 # Lazy-loaded regex (only built when needed)

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -832,9 +832,15 @@ update_progress_if_needed() {
     local current_time
     current_time=$(get_epoch_seconds)
 
+    # SECURITY: Prevent CWE-78 command injection
+    if [[ ! "$last_update_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$last_update_var' for progress update" >&2
+        return 1
+    fi
+
     # Get last update time from variable
     local last_time
-    eval "last_time=\${$last_update_var:-0}"
+    last_time="${!last_update_var:-0}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed
@@ -844,7 +850,7 @@ update_progress_if_needed() {
         start_section_spinner "Scanning items... $completed/$total"
 
         # Update the last_update_time variable
-        eval "$last_update_var=$current_time"
+        printf -v "$last_update_var" "%s" "$current_time"
         return 0
     fi
 

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -840,7 +840,7 @@ update_progress_if_needed() {
 
     # Get last update time from variable
     local last_time
-    last_time="${!last_update_var:-0}"
+    last_time="${!last_update_var}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -175,7 +175,7 @@ debug_timer_end() {
     fi
 
     local start_ts
-    start_ts="${!start_var:-}"
+    start_ts="${!start_var}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -151,17 +151,31 @@ debug_log() {
 debug_timer_start() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local varname="$1"
+
+    # SECURITY: Prevent CWE-78 command injection
+    if [[ ! "$varname" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$varname' for timer start" >&2
+        return 1
+    fi
+
     local ts
     ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)
-    eval "$varname=$ts"
+    printf -v "$varname" "%s" "$ts"
 }
 
 debug_timer_end() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local label="$1"
     local start_var="$2"
+
+    # SECURITY: Prevent CWE-78 command injection
+    if [[ ! "$start_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$start_var' for timer end" >&2
+        return 1
+    fi
+
     local start_ts
-    eval "start_ts=\$$start_var"
+    start_ts="${!start_var:-}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection (CWE-78) via unsafe use of `eval` for dynamic variable assignments and lookups. If variable names are derived from untrusted sources, an attacker could achieve arbitrary command execution.
🎯 Impact: Arbitrary code execution with the privileges of the script runner.
🔧 Fix: Refactored the code to use secure bash features: `printf -v` for assignment and `${!var}` for indirect expansion. Crucially, added strict regex validation (`^[a-zA-Z_][a-zA-Z0-9_]*$`) for all dynamic variable names prior to assignment or lookup to prevent injection via bash array index evaluation.
✅ Verification: Ensure the test suite passes (`make test-all`). Verify no new `eval` usages exist in the modified sections.

========== ELIR ==========
PURPOSE: Prevents arbitrary command execution in shell scripts that use dynamic variable assignments.
SECURITY: Command Injection (CWE-78). Replaces `eval` with validated `printf -v` and `${!var}`.
FAILS IF: Variable name validation regex is overly permissive, or if the terminal environment does not support Bash 3.1+.
VERIFY: That no unintended commands are executed if variable names are maliciously crafted.
MAINTAIN: Always validate variable names using `[[ "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]` before passing them to `printf -v`, `eval`, or using indirect expansion.

---
*PR created automatically by Jules for task [13131980374562492818](https://jules.google.com/task/13131980374562492818) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->