### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval

### DIFF
--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -648,7 +648,12 @@ build_regex_var() {
             regex="$regex|$p"
         fi
     done
-    eval "$var_name=\"\$regex\""
+
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    if [[ ! "$var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+    printf -v "$var_name" "%s" "$regex"
 }
 
 # Lazy-loaded regex (only built when needed)

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -833,6 +833,12 @@ update_progress_if_needed() {
     current_time=$(get_epoch_seconds)
 
     # Get last update time from variable
+
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    if [[ ! "$last_update_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+
     local last_time
     eval "last_time=\${$last_update_var:-0}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
@@ -844,7 +850,7 @@ update_progress_if_needed() {
         start_section_spinner "Scanning items... $completed/$total"
 
         # Update the last_update_time variable
-        eval "$last_update_var=$current_time"
+        printf -v "$last_update_var" "%s" "$current_time"
         return 0
     fi
 

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -840,7 +840,10 @@ update_progress_if_needed() {
     fi
 
     local last_time
-    eval "last_time=\${$last_update_var:-0}"
+    # SECURITY: Use Bash indirect expansion instead of eval to avoid reparsing
+    # untrusted input as shell code. The validated variable name is used only as
+    # a parameter reference here, with 0 as the default for unset or empty values.
+    last_time="${!last_update_var:-0}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -151,15 +151,27 @@ debug_log() {
 debug_timer_start() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local varname="$1"
+
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    if [[ ! "$varname" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+
     local ts
     ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)
-    eval "$varname=$ts"
+    printf -v "$varname" "%s" "$ts"
 }
 
 debug_timer_end() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local label="$1"
     local start_var="$2"
+
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    if [[ ! "$start_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+
     local start_ts
     eval "start_ts=\$$start_var"
     [[ -z "$start_ts" ]] && return 0

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -173,7 +173,8 @@ debug_timer_end() {
     fi
 
     local start_ts
-    eval "start_ts=\$$start_var"
+    # SECURITY: Use bash indirect expansion instead of eval to avoid code execution.
+    start_ts="${!start_var:-}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection (CWE-78) risk existed due to the use of `eval` with dynamic variable names.
🎯 Impact: If an attacker could control the variable names passed to these functions, they could inject arbitrary bash commands.
🔧 Fix: Added strict variable name validation (using regex `^[a-zA-Z_][a-zA-Z0-9_]*$`) before evaluating dynamic variables. Safely replaced `eval "$var_name=\"\$value\""` assignments with `printf -v "$var_name" "%s" "$value"`. Maintained `eval` for variable reading but protected it with strict validation.
✅ Verification: Ran `bash tests/run_all_tests.sh` to ensure no regressions were introduced. Evaluated script syntaxes using `bash -n`.

---
*PR created automatically by Jules for task [3568690899697140449](https://jules.google.com/task/3568690899697140449) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->