### PR TITLE
⚡ Bolt: [performance improvement] Centralize env caching to avoid redundant parsing

### DIFF
--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,40 +1,7 @@
 import json
 import os
 import subprocess
-from functools import lru_cache
-
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from env_utils import _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,6 +1,6 @@
 import json
-import os
 import subprocess
+
 from env_utils import _load_gh_token_env
 
 

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -3,38 +3,8 @@ import json
 import os
 import subprocess
 from collections import defaultdict
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line or line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from env_utils import _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import json
-import os
 import subprocess
 from collections import defaultdict
 

--- a/env_utils.py
+++ b/env_utils.py
@@ -1,0 +1,31 @@
+import os
+from functools import lru_cache
+
+def _parse_env_line(line, env_dict):
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return
+    if line.startswith("export "):
+        line = line[7:].strip()
+    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
+    key, sep, val = line.partition("=")
+    if not sep:
+        return
+    env_dict[key] = val.strip("'\"")
+
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars():
+    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    parsed_vars = {}
+    try:
+        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
+            for line in f:
+                _parse_env_line(line, parsed_vars)
+    except FileNotFoundError:
+        pass
+    return parsed_vars
+
+def _load_gh_token_env():
+    env = os.environ.copy()
+    env.update(_get_parsed_env_vars())
+    return env

--- a/env_utils.py
+++ b/env_utils.py
@@ -1,5 +1,7 @@
 import os
 from functools import lru_cache
+from types import MappingProxyType
+
 
 def _parse_env_line(line, env_dict):
     line = line.strip()
@@ -13,9 +15,12 @@ def _parse_env_line(line, env_dict):
         return
     env_dict[key] = val.strip("'\"")
 
+
 @lru_cache(maxsize=None)
 def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
+    # ⚡ Bolt Optimization: Cache the parsed variables from the file to prevent redundant IO reads.
+    # Returns a read-only MappingProxyType view to prevent accidental mutation of the cached dict
+    # across modules sharing this centralized cache.
     parsed_vars = {}
     try:
         with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
@@ -23,7 +28,8 @@ def _get_parsed_env_vars():
                 _parse_env_line(line, parsed_vars)
     except FileNotFoundError:
         pass
-    return parsed_vars
+    return MappingProxyType(parsed_vars)
+
 
 def _load_gh_token_env():
     env = os.environ.copy()

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import subprocess
 from datetime import datetime, timezone

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -3,41 +3,8 @@ import os
 import re
 import subprocess
 from datetime import datetime, timezone
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from env_utils import _load_gh_token_env
 
 
 def run_gh(repo, pr):

--- a/run_merges.py
+++ b/run_merges.py
@@ -1,5 +1,4 @@
 import json
-import os
 import subprocess
 import time
 

--- a/run_merges.py
+++ b/run_merges.py
@@ -2,40 +2,8 @@ import json
 import os
 import subprocess
 import time
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from env_utils import _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -7,12 +7,13 @@ from datetime import datetime, timezone, timedelta
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from parse_inventory import (
-    _parse_env_line,
     parse_inventory_lines,
     _is_pr_stale,
     _get_pr_category,
     _is_checks_failing,
 )
+
+from env_utils import _parse_env_line
 
 class TestParseInventory(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
💡 What: Extracted the duplicated `_parse_env_line`, `_get_parsed_env_vars`, and `_load_gh_token_env` functions out of `categorize_ready.py`, `detect_duplicates.py`, `parse_inventory.py`, and `run_merges.py` into a single, shared `env_utils.py` module. Updated all four scripts and the test file to import the shared utility.
🎯 Why: Having four identical implementations of the `_get_parsed_env_vars` function (complete with `@lru_cache`) causes each script to independently perform file I/O to read `GH_TOKEN.env` if multiple scripts are invoked sequentially or imported together. It also violates the DRY principle, increasing maintenance overhead.
📊 Impact: Centralizing the logic ensures the file is parsed optimally and the result cached across scripts if they share an execution context. It also significantly reduces code duplication (removed ~120 lines of redundant code).
🔬 Measurement: Verify by running `make test-all` and observing that `test_parse_inventory` correctly imports and tests the refactored logic.

---
*PR created automatically by Jules for task [17903120989874068975](https://jules.google.com/task/17903120989874068975) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->