### PR TITLE
docs: add mock binary examples to testing guide

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -285,7 +285,19 @@ check_grep() {
 MOCK_BIN="$TEST_DIR/mock_bin"
 mkdir -p "$MOCK_BIN"
 
-# TODO: add mock binaries here (see patterns above)
+# Mock ping: always succeeds (avoids network dependency in CI)
+cat > "$MOCK_BIN/ping" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/ping"
+
+# Mock uptime: macOS-style "load averages:" so awk parsing succeeds
+cat > "$MOCK_BIN/uptime" << 'MOCK'
+#!/bin/bash
+echo " 10:00AM  up 1 day,  2:30, 3 users, load averages: 0.50 0.60 0.70"
+MOCK
+chmod +x "$MOCK_BIN/uptime"
 
 echo "=== Testing <name> ==="
 


### PR DESCRIPTION
📋 Purpose: Added concrete examples of mock binaries (`ping` and `uptime`) to the standard test file skeleton in `docs/TESTING.md`, replacing a TODO.
🛡️ Security: N/A (documentation change).
FAILS IF: N/A.
VERIFY: Check `docs/TESTING.md` line 288.
MAINTAIN: These examples follow the established PATH injection pattern used throughout the repo's shell tests.

---
*PR created automatically by Jules for task [8078372327275551476](https://jules.google.com/task/8078372327275551476) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->