### PR TITLE
🛡️ Sentinel: Fix cleartext password logging in infuse-media-server.py

### DIFF
--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -329,7 +329,14 @@ def _get_or_prompt_password(args, user, generated_user):
         print("   (Random username generated. Set custom user via --user)")
 
     while not password:
-        password = getpass.getpass("   Enter password for Basic Auth: ")
+        try:
+            password = getpass.getpass("   Enter password for Basic Auth: ")
+        except (EOFError, KeyboardInterrupt):
+            print(
+                "\n❌ Error: Password entry aborted. Cannot start server without a password.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if not password:
             print("   Password cannot be empty. Please try again.")
     print("   Password set securely.\n")

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -290,54 +290,59 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         self.wfile.write(content.encode("utf-8"))
 
 
+def _get_or_generate_user(args):
+    user = args.user or os.environ.get("AUTH_USER")
+    if user:
+        return user, False
+    user_alphabet = string.ascii_lowercase + string.digits
+    return "user_" + "".join(secrets.SystemRandom().choices(user_alphabet, k=8)), True
+
+
+def _get_or_prompt_password(args, user, generated_user):
+    password = args.password or os.environ.get("AUTH_PASS")
+    if password:
+        print(
+            "\n🔒 Security: Authentication Enabled (using configured credentials; password is hidden)\n"
+        )
+        return password
+
+    if not sys.stdout.isatty():
+        print(
+            "\n❌ Error: Auto-generating a password is not supported when output is not a TTY.",
+            file=sys.stderr,
+        )
+        print(
+            "   (e.g., when output is redirected to a file or running in automation/CI)",
+            file=sys.stderr,
+        )
+        print(
+            "Please provide a password using the --password argument or the AUTH_PASS environment variable.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    import getpass
+
+    print("\n🔒 Security: Authentication Enabled")
+    print(f"   User: {user}")
+    if generated_user:
+        print("   (Random username generated. Set custom user via --user)")
+
+    while not password:
+        password = getpass.getpass("   Enter password for Basic Auth: ")
+        if not password:
+            print("   Password cannot be empty. Please try again.")
+    print("   Password set securely.\n")
+    return password
+
+
 def setup_authentication(args):
     """Set up authentication credentials with secure defaults.
 
     Returns: tuple (AUTH_USER, AUTH_PASS, EXPECTED_AUTH_TOKEN) or exits if password cannot be generated.
     """
-    user = args.user or os.environ.get("AUTH_USER")
-    password = args.password or os.environ.get("AUTH_PASS")
-
-    generated_user = False
-    if not user:
-        user_alphabet = string.ascii_lowercase + string.digits
-        user = "user_" + "".join(secrets.SystemRandom().choices(user_alphabet, k=8))
-        generated_user = True
-
-    if not password:
-        # If output is a TTY, securely prompt for a password
-        if sys.stdout.isatty():
-            import getpass
-
-            print("\n🔒 Security: Authentication Enabled")
-            print(f"   User: {user}")
-            if generated_user:
-                print("   (Random username generated. Set custom user via --user)")
-
-            while not password:
-                password = getpass.getpass("   Enter password for Basic Auth: ")
-                if not password:
-                    print("   Password cannot be empty. Please try again.")
-            print("   Password set securely.\n")
-        else:
-            # Fail and require user to set a password to avoid logging it
-            print(
-                "\n❌ Error: Auto-generating a password is not supported when output is not a TTY.",
-                file=sys.stderr,
-            )
-            print(
-                "   (e.g., when output is redirected to a file or running in automation/CI)",
-                file=sys.stderr,
-            )
-            print(
-                "Please provide a password using the --password argument or the AUTH_PASS environment variable.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-    else:
-        print(
-            "\n🔒 Security: Authentication Enabled (using configured credentials; password is hidden)\n"
-        )
+    user, generated_user = _get_or_generate_user(args)
+    password = _get_or_prompt_password(args, user, generated_user)
 
     expected_token = base64.b64encode(f"{user}:{password}".encode("utf-8")).decode(
         "utf-8"

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -305,18 +305,20 @@ def setup_authentication(args):
         generated_user = True
 
     if not password:
-        # If output is a TTY, generate a password for interactive use
+        # If output is a TTY, securely prompt for a password
         if sys.stdout.isatty():
-            alphabet = string.ascii_letters + string.digits
-            password = "".join(secrets.SystemRandom().choices(alphabet, k=16))
+            import getpass
+
             print("\n🔒 Security: Authentication Enabled")
             print(f"   User: {user}")
-            print(f"   Password: {password}")
             if generated_user:
                 print("   (Random username generated. Set custom user via --user)")
-            print(
-                "   (A random password has been generated and shown above. Store it securely, and consider setting a custom password via --password or AUTH_PASS.)\n"
-            )
+
+            while not password:
+                password = getpass.getpass("   Enter password for Basic Auth: ")
+                if not password:
+                    print("   Password cannot be empty. Please try again.")
+            print("   Password set securely.\n")
         else:
             # Fail and require user to set a password to avoid logging it
             print(

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -308,7 +308,7 @@ def _get_or_prompt_password(args, user, generated_user):
 
     if not sys.stdout.isatty():
         print(
-            "\n❌ Error: Auto-generating a password is not supported when output is not a TTY.",
+            "\n❌ Error: Interactive password entry is not supported when output is not a TTY.",
             file=sys.stderr,
         )
         print(

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,1 @@
-🎯 **What:** The `infuse-media-server.py` script previously auto-generated a password and printed it in cleartext to the terminal/console if no password was supplied via CLI arguments or environment variables.
 
-⚠️ **Risk:** Cleartext passwords written to stdout can be inadvertently captured in terminal history, logs, CI/CD outputs, or monitoring systems. This exposes the password and undermines the Basic Authentication protection for the media server.
-
-🛡️ **Solution:** The script now securely prompts for a password using `getpass.getpass()` in interactive mode (TTY). Instead of generating and logging a password, it forces the user to interactively enter a password without echoing it to the screen. If non-interactive mode is used, the script retains its original safe behavior of failing and instructing the user to configure the password appropriately via the environment.
-
-Additionally, to fix a CodeScene Code Health CI failure for "Bumpy Road Ahead" / high cognitive complexity, the password setup logic was refactored by flattening `setup_authentication` into two focused helper functions: `_get_or_generate_user` and `_get_or_prompt_password`.

--- a/pr_description.md
+++ b/pr_description.md
@@ -3,3 +3,5 @@
 ⚠️ **Risk:** Cleartext passwords written to stdout can be inadvertently captured in terminal history, logs, CI/CD outputs, or monitoring systems. This exposes the password and undermines the Basic Authentication protection for the media server.
 
 🛡️ **Solution:** The script now securely prompts for a password using `getpass.getpass()` in interactive mode (TTY). Instead of generating and logging a password, it forces the user to interactively enter a password without echoing it to the screen. If non-interactive mode is used, the script retains its original safe behavior of failing and instructing the user to configure the password appropriately via the environment.
+
+Additionally, to fix a CodeScene Code Health CI failure for "Bumpy Road Ahead" / high cognitive complexity, the password setup logic was refactored by flattening `setup_authentication` into two focused helper functions: `_get_or_generate_user` and `_get_or_prompt_password`.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🎯 **What:** The `infuse-media-server.py` script previously auto-generated a password and printed it in cleartext to the terminal/console if no password was supplied via CLI arguments or environment variables.
+
+⚠️ **Risk:** Cleartext passwords written to stdout can be inadvertently captured in terminal history, logs, CI/CD outputs, or monitoring systems. This exposes the password and undermines the Basic Authentication protection for the media server.
+
+🛡️ **Solution:** The script now securely prompts for a password using `getpass.getpass()` in interactive mode (TTY). Instead of generating and logging a password, it forces the user to interactively enter a password without echoing it to the screen. If non-interactive mode is used, the script retains its original safe behavior of failing and instructing the user to configure the password appropriately via the environment.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,127 +1,71 @@
-# Backlog Cleanup Orchestration — 2026-05-09
+# Vulnerability Fix: Cleartext Password Logging
 
-- [x] Interview scope: Phase 1 review-and-merge enabled; Phase 2 light salvage triage only.
-- [x] Read local runbooks, lessons, and prior reports.
-- [x] Run GitHub preflight for configured repos and verify sixth repo access explicitly.
-- [x] Build live six-repo inventory with automation-signal expansion.
-- [x] Execute safe Phase 1 merges/closures only after gates pass.
-- [x] Document light salvage triage candidates without creating salvage branches.
-- [x] Write a new dated addendum/run file and link it from the session report log.
-- [x] Verify docs and summarize results.
+## Vulnerability Details
+- **File:** `media-streaming/archive/scripts/infuse-media-server.py`
+- **Line:** 314
+- **Vulnerability:** Cleartext password logged to console.
+- **Impact:** If the console output is captured by a logging system, CI/CD pipeline, or terminal history, the generated password is exposed in plaintext. This compromises the Basic Authentication mechanism intended to protect the media server.
 
----
+## Proposed Fix
+The generated password should not be printed in plaintext to the console. The current implementation:
+```python
+        if sys.stdout.isatty():
+            alphabet = string.ascii_letters + string.digits
+            password = "".join(secrets.SystemRandom().choices(alphabet, k=16))
+            print("\n🔒 Security: Authentication Enabled")
+            print(f"   User: {user}")
+            print(f"   Password: {password}")
+            ...
+```
 
-# Backlog Cleanup Final Pass — 2026-05-10
+Instead of printing it, we can securely prompt the user for a password using `getpass.getpass()`, or just print the password.
 
-- [x] Pull live state for all 6 repos and reconcile against 2026-05-09 action log.
-- [x] Merge `series_correction#15` (salvage from prior run, sole-of-kind, CLEAN).
-- [x] Close-superseded the Hydrograph #169/#170/#171 cluster (covered by merged #172).
-- [x] Close-superseded `series_correction#13` (replaced by salvage #15).
-- [x] Close-duplicate `personal-config#884` (twin of #867 per Lesson 0dd).
-- [x] Close-superseded `personal-config#880` (intent absorbed by `60f7e904 fix(morning-brief)`).
-- [x] Escalate trust-boundary PRs (`personal-config#901`; `email-security-pipeline#791/#793/#796`).
-- [x] Close-stale Jules junk-fixture bleed PRs (`personal-config#831/#836/#840/#849/#862/#867/#869`).
-- [x] Close-superseded `personal-config#858` (`os` import already absent on main).
-- [x] Salvage `personal-config#911` → draft #916 (Bolt partition perf, /tmp clone).
-- [x] Salvage `personal-config#899` → draft #917 (parse_inventory refactor + 22 tests, /tmp clone).
-- [x] Salvage `personal-config#856` → draft #918 (check_summary tests merged into existing module, /tmp clone).
-- [x] Close-superseded `ctrld-sync#771` (main now has dedicated `pluralize()` helper).
-- [x] Close-stale `series_correction#11` (refactor PR; salvage aborted with 6 conflicts vs PR #10 tests).
-- [x] Update `tasks/pr-review-session-reports.md` with 2026-05-10 final cleanup section.
-- [x] Write `tasks/pr-final-cleanup-2026-05-10.json` action log.
+Wait, the rationale says: "Clear fix: either don't print the password, or securely prompt for one. Can be easily commented out or replaced."
 
----
+If we are auto-generating a password, printing it is the only way the user can know what it is if it's generated dynamically, *unless* they pass it in. If it is auto-generated and printed to stdout, it's visible. If it's a daemon, `sys.stdout.isatty()` is false so it fails and asks them to provide it.
+But printing secrets to stdout is generally a bad idea if it can be avoided, or if it stays in logs. Since `isatty()` is checked, it only prints to interactive terminals. However, the issue explicitly flags `print(f"   Password: {password}")` as a vulnerability (Cleartext password logged to console).
 
-# Follow-up: Trunk + markdownlint@0.48.0 empty-stdout JSON parse bug (2026-05-09)
+Let's modify `setup_authentication` so that if a password is not provided:
+1. We prompt for it using `getpass.getpass("Enter password for media server: ")`.
+2. If the user doesn't enter anything (or if it's not a tty and we fail earlier, but the existing code already handles the not a TTY case), we can generate one. Actually, if it's interactive, we should prompt for the password. If they want it generated, they shouldn't use interactive mode without specifying one. Wait, prompting is more secure.
 
-**Status:** Open. Discovered while committing the recovery + upstream-sync
-batch on 2026-05-09 / 2026-05-10. Required `git commit --no-verify` plus
-manual `trufflehog` / `git diff --check` / token-regex sweep as a
-security-equivalent check.
+Let's check `setup_authentication`:
+```python
+def setup_authentication(args):
+    user = args.user or os.environ.get("AUTH_USER")
+    password = args.password or os.environ.get("AUTH_PASS")
 
-**Repro:**
+    generated_user = False
+    if not user:
+        user_alphabet = string.ascii_lowercase + string.digits
+        user = "user_" + "".join(secrets.SystemRandom().choices(user_alphabet, k=8))
+        generated_user = True
 
-1. Stage any markdown file with no markdownlint findings.
-2. `git commit -m "test"` (or `trunk check --filter=markdownlint --no-progress`).
-3. Markdownlint emits an **empty stdout** instead of `[]` when there are no findings.
-4. Trunk's JSON parser fails with `parse error at line 1, column 7: syntax error while parsing array - unexpected ':'; expected ']'` (the parser falls through to the next pipeline stage's output and chokes there).
-5. Hook reports `1 failure, no issues` and blocks the commit.
+    if not password:
+        if sys.stdout.isatty():
+            import getpass
+            print("\n🔒 Security: Authentication Enabled")
+            print(f"   User: {user}")
+            if generated_user:
+                print("   (Random username generated. Set custom user via --user)")
 
-**Impact:** Every markdown commit on macOS where the markdownlint tool
-is at v0.48.0 must use `--no-verify` and run security checks manually.
-Defeats the purpose of the pre-commit hook for markdown-only changes.
+            password = getpass.getpass("   Enter password (or leave blank to auto-generate): ")
+            if not password:
+                alphabet = string.ascii_letters + string.digits
+                password = "".join(secrets.SystemRandom().choices(alphabet, k=16))
+                # If we auto-generate, we either have to print it or they can't log in!
+                # Wait, if we print it, it violates the requirement.
+                # Let's just NOT auto-generate passwords. Require the user to type one.
+```
+Wait, if we use `getpass`, they can just type a password.
+```python
+            import getpass
+            while not password:
+                password = getpass.getpass("   Enter password for Basic Auth: ")
+                if not password:
+                    print("   Password cannot be empty. Please try again.")
+            print("   Password set securely.")
+```
+This is much better. No cleartext password in the terminal.
 
-**Proposed fixes (pick one):**
-
-- File upstream against `trunk-io/plugins` describing the empty-stdout
-  vs `[]` discrepancy and asking either Trunk or markdownlint to be
-  tolerant.
-- Pin `markdownlint` in `.trunk/trunk.yaml` to a version where `--json`
-  emits `[]` on clean runs (verify locally before pinning).
-- Add a `.trunk/configs/.markdownlint.yaml` adjustment if it nudges the
-  CLI into emitting `[]` (e.g., a mode flag).
-
-**Also worth bundling into the same change:**
-
-- Add a `prettier-ignore` for `.claude/skills/**/SKILL.md` since those
-  files are auto-managed by RepoPrompt (`repoprompt_managed: true`) and
-  fighting prettier creates churn on the next sync.
-
-**Acceptance:** A clean markdown-only commit succeeds without
-`--no-verify` and with prettier untouching the auto-managed skill files.
-
----
-
-# Demo Security Hardening — 2026-04-23
-
-- [x] Add env-based Azure config + fail-fast validation in `copilot-demo/weather-assistant.ts`
-- [x] Sanitize realtime error logging in `copilot-demo/weather-assistant.ts`
-- [x] Revert root `package.json` to `{}` and keep dependencies in `copilot-demo/package.json`
-- [x] Verify with TypeScript check in `copilot-demo`
-- [x] Commit and push changes to `origin/main`
-
----
-
-# Automation Expansion & PR Review Maintenance
-
-## 1. Discovery & Verification
-
-- [ ] **Check Jules Daily QA execution status** on `Seatek_Analysis` and `Hydrograph_Versus_Seatek_Sensors_Project`. _Success criteria: Green checkmark on the most recent run._
-- [ ] **Fetch failing step logs** for `repository-automation-daily.yml` (the orchestrator workflow file) in `personal-config` to target the exact `quality-assurance` error configured in `.github/repository-automation.yml` (the config dictionary).
-
-## 2. Infrastructure Cleanup
-
-_Target Repositories: `personal-config`, `email-security-pipeline`, `ctrld-sync`, `Seatek_Analysis`, `Hydrograph_Versus_Seatek_Sensors_Project`_
-
-- [ ] **Remove outright** `.github/workflows/greetings.yml` across all 5 repos.
-- [ ] **Remove outright** `.github/workflows/changelog.yml` across all 5 repos.
-- [ ] **Verify** no remaining composite actions or workflow dispatches reference the deleted files.
-
-## 3. Workflow Modernization
-
-- [ ] **Draft `release-drafter.yml`** for modern changelog generation, integrating it via independent configs tracking the default `main` branch.
-- [ ] **Pin Supply Chain:** Lock `release-drafter/release-drafter` to a specific, verified commit SHA instead of the mutable `@v6` tag.
-- [ ] **Update Documentation:** Modify `docs/automated-pr-review-agent.md` directly to explicitly state first-interaction routing is handled by the PR agent.
-
-## 4. Fix personal-config Daily Automation
-
-_(Blocked by Section 1: Proceed only after fetching actionable log data)_
-
-- [ ] Address the `quality-assurance` bottleneck.
-- [ ] If relying on a configuration waiver (bypassing the quality gate), ensure the waiver is explicitly documented to expire after 7 days or the next sprint review.
-
-## 5. PR Review Session Execution
-
-- [ ] Execute `scripts/run-pr-review-session.sh` in `personal-config`.
-- [ ] Process output into `tasks/pr-inventory.md` and triage using `tasks/pr-triage.md`.
-- [ ] Act on the inventory: Squash-merge passing PRs, consolidate trivial updates, and close stalemates.
-- [ ] **Ambiguity Catch-all:** Flag ambiguous PRs in `tasks/pr-triage.md` with a `needs-discussion` label for manual resolution in the next cycle.
-
----
-
-**Security Considerations & Trust Boundaries:**
-
-- **Attack Surface Reduction:** Removing the legacy unmaintained `first-interaction` action shrinks supply-chain exposure.
-- **Supply-Chain Hardening:** Pinning `release-drafter` to an immutable commit SHA prevents injection via compromised mutable tags.
-- **Least-Privilege Authorization:** The `release-drafter.yml` workflow will be explicitly constrained to `permissions: { contents: write }` (no pull-request write vectors).
-- **Assumptions:** The `run-pr-review-session.sh` enforces hard boundaries. No autonomous merges of code failing _Security Gate 2_ (as defined in `docs/automated-pr-review-agent.md`) will be permitted. _Zero-diff / superseded_ heuristic rules (also defined in `docs/automated-pr-review-agent.md`) will govern closure rationale.
+Let's verify what happens if `user` is generated. It prints `User: user_XXXXXX`. That's fine.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,71 +1,139 @@
-# Vulnerability Fix: Cleartext Password Logging
+# Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
-## Vulnerability Details
-- **File:** `media-streaming/archive/scripts/infuse-media-server.py`
-- **Line:** 314
-- **Vulnerability:** Cleartext password logged to console.
-- **Impact:** If the console output is captured by a logging system, CI/CD pipeline, or terminal history, the generated password is exposed in plaintext. This compromises the Basic Authentication mechanism intended to protect the media server.
+- [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.
+- [x] Preserve non-TTY fail-fast behavior (require `--password` or `AUTH_PASS`).
+- [x] Refactor `setup_authentication` into `_get_or_generate_user` and `_get_or_prompt_password` to reduce cognitive complexity.
+- [x] Correct stale "Auto-generating a password" error message in non-TTY branch.
+- [x] Handle `EOFError`/`KeyboardInterrupt` from `getpass.getpass()` with a graceful exit.
 
-## Proposed Fix
-The generated password should not be printed in plaintext to the console. The current implementation:
-```python
-        if sys.stdout.isatty():
-            alphabet = string.ascii_letters + string.digits
-            password = "".join(secrets.SystemRandom().choices(alphabet, k=16))
-            print("\n🔒 Security: Authentication Enabled")
-            print(f"   User: {user}")
-            print(f"   Password: {password}")
-            ...
-```
+---
 
-Instead of printing it, we can securely prompt the user for a password using `getpass.getpass()`, or just print the password.
+# Backlog Cleanup Orchestration — 2026-05-09
 
-Wait, the rationale says: "Clear fix: either don't print the password, or securely prompt for one. Can be easily commented out or replaced."
+- [x] Interview scope: Phase 1 review-and-merge enabled; Phase 2 light salvage triage only.
+- [x] Read local runbooks, lessons, and prior reports.
+- [x] Run GitHub preflight for configured repos and verify sixth repo access explicitly.
+- [x] Build live six-repo inventory with automation-signal expansion.
+- [x] Execute safe Phase 1 merges/closures only after gates pass.
+- [x] Document light salvage triage candidates without creating salvage branches.
+- [x] Write a new dated addendum/run file and link it from the session report log.
+- [x] Verify docs and summarize results.
 
-If we are auto-generating a password, printing it is the only way the user can know what it is if it's generated dynamically, *unless* they pass it in. If it is auto-generated and printed to stdout, it's visible. If it's a daemon, `sys.stdout.isatty()` is false so it fails and asks them to provide it.
-But printing secrets to stdout is generally a bad idea if it can be avoided, or if it stays in logs. Since `isatty()` is checked, it only prints to interactive terminals. However, the issue explicitly flags `print(f"   Password: {password}")` as a vulnerability (Cleartext password logged to console).
+---
 
-Let's modify `setup_authentication` so that if a password is not provided:
-1. We prompt for it using `getpass.getpass("Enter password for media server: ")`.
-2. If the user doesn't enter anything (or if it's not a tty and we fail earlier, but the existing code already handles the not a TTY case), we can generate one. Actually, if it's interactive, we should prompt for the password. If they want it generated, they shouldn't use interactive mode without specifying one. Wait, prompting is more secure.
+# Backlog Cleanup Final Pass — 2026-05-10
 
-Let's check `setup_authentication`:
-```python
-def setup_authentication(args):
-    user = args.user or os.environ.get("AUTH_USER")
-    password = args.password or os.environ.get("AUTH_PASS")
+- [x] Pull live state for all 6 repos and reconcile against 2026-05-09 action log.
+- [x] Merge `series_correction#15` (salvage from prior run, sole-of-kind, CLEAN).
+- [x] Close-superseded the Hydrograph #169/#170/#171 cluster (covered by merged #172).
+- [x] Close-superseded `series_correction#13` (replaced by salvage #15).
+- [x] Close-duplicate `personal-config#884` (twin of #867 per Lesson 0dd).
+- [x] Close-superseded `personal-config#880` (intent absorbed by `60f7e904 fix(morning-brief)`).
+- [x] Escalate trust-boundary PRs (`personal-config#901`; `email-security-pipeline#791/#793/#796`).
+- [x] Close-stale Jules junk-fixture bleed PRs (`personal-config#831/#836/#840/#849/#862/#867/#869`).
+- [x] Close-superseded `personal-config#858` (`os` import already absent on main).
+- [x] Salvage `personal-config#911` → draft #916 (Bolt partition perf, /tmp clone).
+- [x] Salvage `personal-config#899` → draft #917 (parse_inventory refactor + 22 tests, /tmp clone).
+- [x] Salvage `personal-config#856` → draft #918 (check_summary tests merged into existing module, /tmp clone).
+- [x] Close-superseded `ctrld-sync#771` (main now has dedicated `pluralize()` helper).
+- [x] Close-stale `series_correction#11` (refactor PR; salvage aborted with 6 conflicts vs PR #10 tests).
+- [x] Update `tasks/pr-review-session-reports.md` with 2026-05-10 final cleanup section.
+- [x] Write `tasks/pr-final-cleanup-2026-05-10.json` action log.
 
-    generated_user = False
-    if not user:
-        user_alphabet = string.ascii_lowercase + string.digits
-        user = "user_" + "".join(secrets.SystemRandom().choices(user_alphabet, k=8))
-        generated_user = True
+---
 
-    if not password:
-        if sys.stdout.isatty():
-            import getpass
-            print("\n🔒 Security: Authentication Enabled")
-            print(f"   User: {user}")
-            if generated_user:
-                print("   (Random username generated. Set custom user via --user)")
+# Follow-up: Trunk + markdownlint@0.48.0 empty-stdout JSON parse bug (2026-05-09)
 
-            password = getpass.getpass("   Enter password (or leave blank to auto-generate): ")
-            if not password:
-                alphabet = string.ascii_letters + string.digits
-                password = "".join(secrets.SystemRandom().choices(alphabet, k=16))
-                # If we auto-generate, we either have to print it or they can't log in!
-                # Wait, if we print it, it violates the requirement.
-                # Let's just NOT auto-generate passwords. Require the user to type one.
-```
-Wait, if we use `getpass`, they can just type a password.
-```python
-            import getpass
-            while not password:
-                password = getpass.getpass("   Enter password for Basic Auth: ")
-                if not password:
-                    print("   Password cannot be empty. Please try again.")
-            print("   Password set securely.")
-```
-This is much better. No cleartext password in the terminal.
+**Status:** Open. Discovered while committing the recovery + upstream-sync
+batch on 2026-05-09 / 2026-05-10. Required `git commit --no-verify` plus
+manual `trufflehog` / `git diff --check` / token-regex sweep as a
+security-equivalent check.
 
-Let's verify what happens if `user` is generated. It prints `User: user_XXXXXX`. That's fine.
+**Repro:**
+
+1. Stage any markdown file with no markdownlint findings.
+2. `git commit -m "test"` (or `trunk check --filter=markdownlint --no-progress`).
+3. Markdownlint emits an **empty stdout** instead of `[]` when there are no findings.
+4. Trunk's JSON parser fails with `parse error at line 1, column 7: syntax error while parsing array - unexpected ':'; expected ']'` (the parser falls through to the next pipeline stage's output and chokes there).
+5. Hook reports `1 failure, no issues` and blocks the commit.
+
+**Impact:** Every markdown commit on macOS where the markdownlint tool
+is at v0.48.0 must use `--no-verify` and run security checks manually.
+Defeats the purpose of the pre-commit hook for markdown-only changes.
+
+**Proposed fixes (pick one):**
+
+- File upstream against `trunk-io/plugins` describing the empty-stdout
+  vs `[]` discrepancy and asking either Trunk or markdownlint to be
+  tolerant.
+- Pin `markdownlint` in `.trunk/trunk.yaml` to a version where `--json`
+  emits `[]` on clean runs (verify locally before pinning).
+- Add a `.trunk/configs/.markdownlint.yaml` adjustment if it nudges the
+  CLI into emitting `[]` (e.g., a mode flag).
+
+**Also worth bundling into the same change:**
+
+- Add a `prettier-ignore` for `.claude/skills/**/SKILL.md` since those
+  files are auto-managed by RepoPrompt (`repoprompt_managed: true`) and
+  fighting prettier creates churn on the next sync.
+
+**Acceptance:** A clean markdown-only commit succeeds without
+`--no-verify` and with prettier untouching the auto-managed skill files.
+
+---
+
+# Demo Security Hardening — 2026-04-23
+
+- [x] Add env-based Azure config + fail-fast validation in `copilot-demo/weather-assistant.ts`
+- [x] Sanitize realtime error logging in `copilot-demo/weather-assistant.ts`
+- [x] Revert root `package.json` to `{}` and keep dependencies in `copilot-demo/package.json`
+- [x] Verify with TypeScript check in `copilot-demo`
+- [x] Commit and push changes to `origin/main`
+
+---
+
+# Automation Expansion & PR Review Maintenance
+
+## 1. Discovery & Verification
+
+- [ ] **Check Jules Daily QA execution status** on `Seatek_Analysis` and `Hydrograph_Versus_Seatek_Sensors_Project`. _Success criteria: Green checkmark on the most recent run._
+- [ ] **Fetch failing step logs** for `repository-automation-daily.yml` (the orchestrator workflow file) in `personal-config` to target the exact `quality-assurance` error configured in `.github/repository-automation.yml` (the config dictionary).
+
+## 2. Infrastructure Cleanup
+
+_Target Repositories: `personal-config`, `email-security-pipeline`, `ctrld-sync`, `Seatek_Analysis`, `Hydrograph_Versus_Seatek_Sensors_Project`_
+
+- [ ] **Remove outright** `.github/workflows/greetings.yml` across all 5 repos.
+- [ ] **Remove outright** `.github/workflows/changelog.yml` across all 5 repos.
+- [ ] **Verify** no remaining composite actions or workflow dispatches reference the deleted files.
+
+## 3. Workflow Modernization
+
+- [ ] **Draft `release-drafter.yml`** for modern changelog generation, integrating it via independent configs tracking the default `main` branch.
+- [ ] **Pin Supply Chain:** Lock `release-drafter/release-drafter` to a specific, verified commit SHA instead of the mutable `@v6` tag.
+- [ ] **Update Documentation:** Modify `docs/automated-pr-review-agent.md` directly to explicitly state first-interaction routing is handled by the PR agent.
+
+## 4. Fix personal-config Daily Automation
+
+_(Blocked by Section 1: Proceed only after fetching actionable log data)_
+
+- [ ] Address the `quality-assurance` bottleneck.
+- [ ] If relying on a configuration waiver (bypassing the quality gate), ensure the waiver is explicitly documented to expire after 7 days or the next sprint review.
+
+## 5. PR Review Session Execution
+
+- [ ] Execute `scripts/run-pr-review-session.sh` in `personal-config`.
+- [ ] Process output into `tasks/pr-inventory.md` and triage using `tasks/pr-triage.md`.
+- [ ] Act on the inventory: Squash-merge passing PRs, consolidate trivial updates, and close stalemates.
+- [ ] **Ambiguity Catch-all:** Flag ambiguous PRs in `tasks/pr-triage.md` with a `needs-discussion` label for manual resolution in the next cycle.
+
+---
+
+**Security Considerations & Trust Boundaries:**
+
+- **Attack Surface Reduction:** Removing the legacy unmaintained `first-interaction` action shrinks supply-chain exposure.
+- **Supply-Chain Hardening:** Pinning `release-drafter` to an immutable commit SHA prevents injection via compromised mutable tags.
+- **Least-Privilege Authorization:** The `release-drafter.yml` workflow will be explicitly constrained to `permissions: { contents: write }` (no pull-request write vectors).
+- **Assumptions:** The `run-pr-review-session.sh` enforces hard boundaries. No autonomous merges of code failing _Security Gate 2_ (as defined in `docs/automated-pr-review-agent.md`) will be permitted. _Zero-diff / superseded_ heuristic rules (also defined in `docs/automated-pr-review-agent.md`) will govern closure rationale.
+
+


### PR DESCRIPTION
🎯 **What:** The `infuse-media-server.py` script previously auto-generated a password and printed it in cleartext to the terminal/console if no password was supplied via CLI arguments or environment variables.

⚠️ **Risk:** Cleartext passwords written to stdout can be inadvertently captured in terminal history, logs, CI/CD outputs, or monitoring systems. This exposes the password and undermines the Basic Authentication protection for the media server.

🛡️ **Solution:** The script now securely prompts for a password using `getpass.getpass()` in interactive mode (TTY). Instead of generating and logging a password, it forces the user to interactively enter a password without echoing it to the screen. If non-interactive mode is used, the script retains its original safe behavior of failing and instructing the user to configure the password appropriately via the environment.

---
*PR created automatically by Jules for task [15996668465820615699](https://jules.google.com/task/15996668465820615699) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->