### PR TITLE
🧪 Add tests for configured_commands in repository automation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -128,6 +128,4 @@ jobs:
           python-version: "3.12"
 
       - name: Run all tests (shell + Python)
-        run: |
-          pip install pyyaml
-          make test-all
+        run: make test-all

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -128,4 +128,6 @@ jobs:
           python-version: "3.12"
 
       - name: Run all tests (shell + Python)
-        run: make test-all
+        run: |
+          pip install pyyaml
+          make test-all

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -1,0 +1,47 @@
+import unittest
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.github/scripts'))
+
+from repository_automation_tasks import configured_commands
+
+class TestRepositoryAutomationTasks(unittest.TestCase):
+    def test_configured_commands_all_keys_present(self):
+        section = {
+            "setup_commands": [{"run": "setup1"}],
+            "commands": [{"run": "cmd1"}, {"run": "cmd2"}],
+            "security_commands": [{"run": "sec1"}]
+        }
+        expected = [
+            ("setup", {"run": "setup1"}),
+            ("command", {"run": "cmd1"}),
+            ("command", {"run": "cmd2"}),
+            ("security", {"run": "sec1"})
+        ]
+        self.assertEqual(configured_commands(section), expected)
+
+    def test_configured_commands_missing_keys(self):
+        section = {
+            "commands": [{"run": "cmd1"}]
+        }
+        expected = [
+            ("command", {"run": "cmd1"})
+        ]
+        self.assertEqual(configured_commands(section), expected)
+
+    def test_configured_commands_empty_section(self):
+        self.assertEqual(configured_commands({}), [])
+
+    def test_configured_commands_ignore_extra_keys(self):
+        section = {
+            "commands": [{"run": "cmd1"}],
+            "other_commands": [{"run": "other"}]
+        }
+        expected = [
+            ("command", {"run": "cmd1"})
+        ]
+        self.assertEqual(configured_commands(section), expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -1,10 +1,22 @@
-import unittest
-import sys
 import os
+import sys
+import unittest
+from unittest.mock import MagicMock
 
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.github/scripts'))
+# Stub out the optional third-party `yaml` dependency so this test remains
+# stdlib-only (per AGENTS.md / CONTRIBUTING.md: tests must not require pip
+# installs). `repository_automation_common` imports `yaml` at module load
+# time, but `configured_commands` itself does not use it.
+sys.modules.setdefault("yaml", MagicMock())
 
-from repository_automation_tasks import configured_commands
+sys.path.append(
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        ".github/scripts",
+    )
+)
+
+from repository_automation_tasks import configured_commands  # noqa: E402
 
 class TestRepositoryAutomationTasks(unittest.TestCase):
     def test_configured_commands_all_keys_present(self):


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `configured_commands` function in `.github/scripts/repository_automation_tasks.py`. This function previously lacked test coverage despite being a pure data transformation function.

📊 **Coverage:** The new tests in `tests/test_repository_automation_tasks.py` cover:
- All target keys present (`setup_commands`, `commands`, `security_commands`)
- Missing keys
- Empty sections
- Ignoring extra/unrelated keys

✨ **Result:** Improved test coverage and reliability. The tests ensure the function consistently returns the correct list of tuples for GitHub Actions repository automation tasks.

========== ELIR ==========
PURPOSE: Add unit tests to cover the `configured_commands` data transformation logic.
SECURITY: N/A - Test addition only.
FAILS IF: The function behavior changes to return unexpected structures or misses target keys.
VERIFY: Tests pass cleanly via `make test-all`.
MAINTAIN: The tests use `sys.path.append` to import from `.github/scripts`, which is standard for CI script testing in this repository.

---
*PR created automatically by Jules for task [2687052177157855182](https://jules.google.com/task/2687052177157855182) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->