### PR TITLE
🧹 [Code Health] Refactor get_diff to reuse run_gh

### DIFF
--- a/run_merges.py
+++ b/run_merges.py
@@ -32,6 +32,7 @@ def _get_parsed_env_vars():
         pass
     return parsed_vars
 
+
 def _load_gh_token_env():
     env = os.environ.copy()
     env.update(_get_parsed_env_vars())
@@ -50,14 +51,8 @@ def run_gh(cmd_list):
 
 
 def get_diff(repo, pr):
-    env = _load_gh_token_env()
-    result = subprocess.run(
-        ["gh", "pr", "diff", str(pr), "-R", str(repo)],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    return result.stdout
+    res = run_gh(["gh", "pr", "diff", str(pr), "-R", str(repo)])
+    return res if isinstance(res, str) else ""
 
 
 queue = [


### PR DESCRIPTION
🎯 **What:** The `get_diff` function in `run_merges.py` was refactored to reuse the existing `run_gh` helper function instead of manually invoking `subprocess.run` and duplicating the environment loading logic.
💡 **Why:** This improves maintainability and readability by reducing code duplication and centralizing the execution logic for the `gh` CLI tool.
✅ **Verification:** I confirmed the change is safe by verifying the `get_diff` function's return logic (adding a defensive string check) and ensuring that the test suite (`make test-all`) continues to pass cleanly.
✨ **Result:** The `get_diff` function is now simpler, safer, and adheres to the DRY principle without altering its expected external behavior.

---
*PR created automatically by Jules for task [1654586579964850132](https://jules.google.com/task/1654586579964850132) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->