### PR TITLE
🧪 [Add tests for categorize_ready.py error paths]

### DIFF
--- a/tests/test_categorize_ready.py
+++ b/tests/test_categorize_ready.py
@@ -1,0 +1,48 @@
+import unittest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tests.test_vulnerability_fix import _load_function_only
+
+class TestCategorizeReady(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_function_only("categorize_ready.py", {"run_gh", "_load_gh_token_env"})
+
+    @patch('subprocess.run')
+    def test_run_gh_invalid_json(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "This is not valid JSON"
+        mock_run.return_value = mock_result
+
+        result = self.mod.run_gh(['gh', 'pr', 'view', '123'])
+
+        self.assertIsNone(result)
+
+    @patch('subprocess.run')
+    def test_run_gh_non_zero_exit(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "Error"
+        mock_run.return_value = mock_result
+
+        result = self.mod.run_gh(['gh', 'pr', 'view', '123'])
+
+        self.assertIsNone(result)
+
+    @patch('subprocess.run')
+    def test_run_gh_valid_json(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"title": "test", "state": "open"}'
+        mock_run.return_value = mock_result
+
+        result = self.mod.run_gh(['gh', 'pr', 'view', '123'])
+
+        self.assertEqual(result, {"title": "test", "state": "open"})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing missing-error-test for run_gh in categorize_ready.py.
📊 **Coverage:** The scenarios now tested are JSON parsing error (invalid JSON), non-zero subprocess exit code, and successful valid JSON parsing.
✨ **Result:** The improvement in test coverage allows confident refactoring of categorize_ready.py.

---
*PR created automatically by Jules for task [18247546206242286741](https://jules.google.com/task/18247546206242286741) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->