### PR TITLE
refactor(parse_inventory): remove re dependency from _parse_repo_name

### DIFF
--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import subprocess
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -73,8 +72,9 @@ def _should_skip_table_row(line):
 
 
 def _parse_repo_name(line):
-    m = re.match(r"^## (.*)", line)
-    return m.group(1).strip() if m else None
+    if line.startswith("## "):
+        return line[3:].strip()
+    return None
 
 
 def _is_valid_pr_row(pr_id, author, hints):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Remove the `re` import from `parse_inventory.py` by parsing `## ` section headers with `startswith` and slicing.

## Why

On current `main`, `import re` was not actually dead: `_parse_repo_name` still called `re.match`. The reported issue matches the state **after** removing that call but **before** dropping the import. This change makes the header parse a plain string operation so the `re` module is genuinely unnecessary and cannot drift back into a dead-import state.

## How

`_parse_repo_name` now returns `line[3:].strip()` when the line starts with `## `, matching the previous `^## (.*)` behavior for normal inventory lines (including `## repoA` used in tests).

## Testing

- `make test-quick` — OK
- `python3 -m unittest tests.test_parse_inventory -v` (22 tests) — OK
- `python3 -m unittest tests.test_vulnerability_fix.TestRunGhListArgs.test_parse_inventory -v` — OK

## Security

No security impact. Parsing logic is unchanged; no new subprocess or file paths.

---

## Checklist

- [x] `make test-quick` passes locally
- [ ] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed (behavior unchanged)
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a2f8ca-27d9-4083-b2c8-60776722e244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a2f8ca-27d9-4083-b2c8-60776722e244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

