### PR TITLE
🧪 Add tests for run_checked in repository_automation_common

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -127,5 +127,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: pip install pyyaml
+
       - name: Run all tests (shell + Python)
         run: make test-all

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -127,8 +127,5 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install pyyaml
-
       - name: Run all tests (shell + Python)
         run: make test-all

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -1,4 +1,5 @@
 import sys
+import types
 import unittest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
@@ -7,6 +8,16 @@ import subprocess
 # Add scripts directory to path to import the module
 scripts_dir = Path(__file__).parent.parent / ".github" / "scripts"
 sys.path.append(str(scripts_dir))
+
+# Stub the `yaml` module so this test can run with stdlib only (no pip deps),
+# matching the repo convention documented in AGENTS.md / CONTRIBUTING.md.
+# `repository_automation_common` imports `yaml` at module load, but the
+# functions under test (`run_checked`, `run_process`) do not use YAML at all.
+if "yaml" not in sys.modules:
+    _yaml = types.ModuleType("yaml")
+    _yaml.safe_load = lambda *_a, **_kw: {}
+    _yaml.safe_dump = lambda *_a, **_kw: ""
+    sys.modules["yaml"] = _yaml
 
 import repository_automation_common
 from repository_automation_common import run_checked
@@ -33,6 +44,10 @@ class TestRunChecked(unittest.TestCase):
         mock_subprocess_run.return_value = mock_result
         command = ["ls", "-l"]
 
+        # Capture expected env before execution to avoid spurious failures if
+        # os.environ is mutated between execution and assertion.
+        expected_env = repository_automation_common.command_env()
+
         # Execution
         result = run_checked(command)
 
@@ -45,7 +60,7 @@ class TestRunChecked(unittest.TestCase):
             text=True,
             input=None,
             timeout=None,
-            env=repository_automation_common.command_env(),
+            env=expected_env,
         )
         self.assertEqual(result, mock_result)
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -1,0 +1,53 @@
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import subprocess
+
+# Add scripts directory to path to import the module
+scripts_dir = Path(__file__).parent.parent / ".github" / "scripts"
+sys.path.append(str(scripts_dir))
+
+import repository_automation_common
+from repository_automation_common import run_checked
+
+class TestRunChecked(unittest.TestCase):
+    @patch("repository_automation_common.run_process")
+    def test_run_checked_calls_run_process_with_check_true(self, mock_run_process):
+        # Setup
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_run_process.return_value = mock_result
+        command = ["echo", "hello"]
+
+        # Execution
+        result = run_checked(command)
+
+        # Assertion
+        mock_run_process.assert_called_once_with(command, check=True)
+        self.assertEqual(result, mock_result)
+
+    @patch("repository_automation_common.subprocess.run")
+    def test_run_checked_integration_with_subprocess(self, mock_subprocess_run):
+        # We can also mock subprocess.run to verify the entire chain
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_subprocess_run.return_value = mock_result
+        command = ["ls", "-l"]
+
+        # Execution
+        result = run_checked(command)
+
+        # Assertion
+        mock_subprocess_run.assert_called_once_with(
+            command,
+            cwd=repository_automation_common.ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            input=None,
+            timeout=None,
+            env=repository_automation_common.command_env(),
+        )
+        self.assertEqual(result, mock_result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** `run_checked` in `.github/scripts/repository_automation_common.py` was missing tests to ensure it correctly delegates to `run_process` while enforcing `check=True`.
📊 **Coverage:** The new tests cover the successful delegation to `run_process` and specifically verify that `check=True` is always passed, guaranteeing exceptions are raised on failure as intended.
✨ **Result:** Increased confidence that `run_checked` behaves correctly, providing a safer wrapper for repository automation scripts that rely on checked subprocess execution.

---
*PR created automatically by Jules for task [12162046104039535074](https://jules.google.com/task/12162046104039535074) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->