### PR TITLE
🧪 [testing improvement] Add missing-error-test for run_gh

### DIFF
--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,0 +1,1 @@
+git diff HEAD~1 HEAD

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff HEAD~1 HEAD

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
 git diff HEAD~1 HEAD

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 import os
 from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
 
 # Ensure the project root is in the path so we can import parse_inventory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -12,6 +13,7 @@ from parse_inventory import (
     _is_pr_stale,
     _get_pr_category,
     _is_checks_failing,
+    run_gh,
 )
 
 class TestParseInventory(unittest.TestCase):
@@ -161,6 +163,34 @@ class TestParseInventory(unittest.TestCase):
         # Recent PR + CLEAN merge state + failing checks → no category assigned
         info = self._build_info("CLEAN", self._recent_iso())
         self.assertIsNone(_get_pr_category(info, "FAIL"))
+
+    # --- run_gh ---
+
+    @patch("parse_inventory.subprocess.run")
+    def test_run_gh_success(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"files": [{"filename": "foo.py"}], "updatedAt": "2026-05-03T00:00:00Z"}'
+        mock_run.return_value = mock_result
+        result = run_gh("repoA", 123)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["files"][0]["filename"], "foo.py")
+
+    @patch("parse_inventory.subprocess.run")
+    def test_run_gh_nonzero(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "error"
+        mock_run.return_value = mock_result
+        self.assertIsNone(run_gh("repoA", 123))
+
+    @patch("parse_inventory.subprocess.run")
+    def test_run_gh_invalid_json(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "invalid json"
+        mock_run.return_value = mock_result
+        self.assertIsNone(run_gh("repoA", 123))
 
 
 if __name__ == '__main__':

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -166,8 +166,9 @@ class TestParseInventory(unittest.TestCase):
 
     # --- run_gh ---
 
+    @patch("parse_inventory._load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
-    def test_run_gh_success(self, mock_run):
+    def test_run_gh_success(self, mock_run, _mock_env):
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = '{"files": [{"filename": "foo.py"}], "updatedAt": "2026-05-03T00:00:00Z"}'
@@ -176,16 +177,18 @@ class TestParseInventory(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["files"][0]["filename"], "foo.py")
 
+    @patch("parse_inventory._load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
-    def test_run_gh_nonzero(self, mock_run):
+    def test_run_gh_nonzero(self, mock_run, _mock_env):
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = "error"
         mock_run.return_value = mock_result
         self.assertIsNone(run_gh("repoA", 123))
 
+    @patch("parse_inventory._load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
-    def test_run_gh_invalid_json(self, mock_run):
+    def test_run_gh_invalid_json(self, mock_run, _mock_env):
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = "invalid json"


### PR DESCRIPTION
🎯 **What:** The testing gap for `run_gh` in `parse_inventory.py` has been addressed. The missing tests for error scenarios (non-zero return code and invalid JSON output) were lacking.
📊 **Coverage:** The test suite now includes test coverage for `run_gh` that mocks `subprocess.run` to cover three main cases: successful JSON output, command failure (non-zero return code), and malformed output (invalid JSON error path).
✨ **Result:** Test reliability is improved. Regression tests for error handling in the `run_gh` function are now running, confirming `run_gh` appropriately handles failure points gracefully by returning `None` as intended.

---
*PR created automatically by Jules for task [5996021651742880781](https://jules.google.com/task/5996021651742880781) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->