### PR TITLE
ci: expand Jules daily QA repository matrix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -279,6 +279,9 @@ Swap this block per project or repo.
   - `personal-config` — Shell/Python macOS configs, VPN/DNS, 1Password SSH
   - `email-security-pipeline` — Python IMAP threat detection
   - `ctrld-sync` — Control D blocklist syncing
+  - `series_correction_project_updated` — Python Seatek sensor time-series correction
+  - `Hydrograph_Versus_Seatek_Sensors_Project` — Python hydrograph and Seatek sensor analysis
+  - `Seatek_Analysis` — R-based Seatek sensor processing and workbook generation
 - Autofix conventions: Autofix commits follow `autofix(): PR #N (cycle K) -- …` with `Autofix-PR`, `Autofix-Cycle`, `Review-Inputs`, and `Mode` trailers when practical.
 
 FEW-SHOT EXAMPLES

--- a/.github/repository-automation.md
+++ b/.github/repository-automation.md
@@ -18,8 +18,15 @@ The current workflow files in this repo use the `personal-config` slot from the 
 | `ctrld-sync`              | `03:17 UTC`      | `04:11 UTC` Sunday | Leaves a buffer after the live `sync.yml` run at `02:00 UTC`, avoids top-of-hour congestion, and keeps production-sensitive automation isolated. |
 | `personal-config`         | `08:23 UTC`      | `09:11 UTC` Sunday | Mid-morning UTC is typically quieter than top-of-hour windows, and the odd-minute offset avoids bunching with common shared cron defaults.       |
 | `email-security-pipeline` | `12:41 UTC`      | `13:29 UTC` Sunday | Keeps the third repo well separated from the other two while still landing during a same-day review window.                                      |
+| `series_correction_project_updated` | `10:00 UTC` | Not scheduled here | Included in the Jules Daily QA matrix for Seatek sensor correction review. |
+| `Hydrograph_Versus_Seatek_Sensors_Project` | `10:00 UTC` | Not scheduled here | Included in the Jules Daily QA matrix for hydrograph/Seatek analysis review. |
+| `Seatek_Analysis` | `10:00 UTC` | Not scheduled here | Included in the Jules Daily QA matrix for R-tier Seatek analysis review. |
 
-Future rollouts to the other repos should reuse the table above so the three repositories never start their daily or weekly automation at the same moment.
+Future rollouts to the other repos should reuse the table above so repositories
+never start their daily or weekly automation at the same moment. The Jules Daily
+QA workflow intentionally fans out from `personal-config` because it only opens
+per-repo QA prompt issues and does not run the heavier consolidated automation
+jobs in the target repositories.
 
 ## Guardrails
 

--- a/.github/workflows/jules-daily-qa.yml
+++ b/.github/workflows/jules-daily-qa.yml
@@ -6,9 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   trigger-jules:
@@ -43,9 +41,6 @@ jobs:
             repo_domain_description: R-based Seatek sensor processing and workbook generation pipeline
             repo_priorities: R dependency reproducibility, data-processing correctness, workbook export reliability
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Trigger Jules QA
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -56,13 +51,12 @@ jobs:
         run: |
           python3 << 'PY' > prompt.md
           import os
-          import textwrap
 
           repo_name = os.environ["REPO_NAME"]
           domain = os.environ["REPO_DOMAIN_DESCRIPTION"]
           priorities = os.environ["REPO_PRIORITIES"]
 
-          print(textwrap.dedent(f"""\
+          print(f"""\
           @google-labs-jules You are an agentic QA engineer conducting an automated daily review of a GitHub repository. Your objective is to assess and maintain the repository in a healthy, functional, and maintainable state—adapting your review depth and priorities to the repository's specific domain.
 
           ## Role
@@ -103,7 +97,7 @@ jobs:
           - Note-form summaries (brief, scannable)
           - Bash commands clearly highlighted
           - Issue closed if no problems found
-          """))
+          """)
           PY
 
           gh label create automation \

--- a/.github/workflows/jules-daily-qa.yml
+++ b/.github/workflows/jules-daily-qa.yml
@@ -14,15 +14,55 @@ jobs:
   trigger-jules:
     name: Request Jules Agentic Review
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: abhimehro/personal-config
+            repo_name: personal-config
+            repo_domain_description: Personal configuration files, scripts, and system preferences
+            repo_priorities: Configuration correctness, script reliability, no hardcoded secrets, environment variable hygiene
+          - repository: abhimehro/email-security-pipeline
+            repo_name: email-security-pipeline
+            repo_domain_description: Email security processing and filtering pipeline
+            repo_priorities: Input validation, security best practices, compliance with email security standards
+          - repository: abhimehro/ctrld-sync
+            repo_name: ctrld-sync
+            repo_domain_description: Control D DNS config synchronization
+            repo_priorities: Configuration correctness, script reliability, synchronization logic accuracy
+          - repository: abhimehro/series_correction_project_updated
+            repo_name: series_correction_project_updated
+            repo_domain_description: Seatek sensor time-series discontinuity detection and correction
+            repo_priorities: Data correction accuracy, batch-processing reliability, reproducible scientific outputs
+          - repository: abhimehro/Hydrograph_Versus_Seatek_Sensors_Project
+            repo_name: Hydrograph_Versus_Seatek_Sensors_Project
+            repo_domain_description: Hydrograph and Seatek sensor analysis for NAVD88 elevation comparisons
+            repo_priorities: Data validation, secure Excel ingestion, reproducible visualization outputs
+          - repository: abhimehro/Seatek_Analysis
+            repo_name: Seatek_Analysis
+            repo_domain_description: R-based Seatek sensor processing and workbook generation pipeline
+            repo_priorities: R dependency reproducibility, data-processing correctness, workbook export reliability
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Trigger Jules QA
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          TARGET_REPOSITORY: ${{ matrix.repository }}
+          REPO_NAME: ${{ matrix.repo_name }}
+          REPO_DOMAIN_DESCRIPTION: ${{ matrix.repo_domain_description }}
+          REPO_PRIORITIES: ${{ matrix.repo_priorities }}
         run: |
-          cat << 'EOF' > prompt.md
+          python3 << 'PY' > prompt.md
+          import os
+          import textwrap
+
+          repo_name = os.environ["REPO_NAME"]
+          domain = os.environ["REPO_DOMAIN_DESCRIPTION"]
+          priorities = os.environ["REPO_PRIORITIES"]
+
+          print(textwrap.dedent(f"""\
           @google-labs-jules You are an agentic QA engineer conducting an automated daily review of a GitHub repository. Your objective is to assess and maintain the repository in a healthy, functional, and maintainable state—adapting your review depth and priorities to the repository's specific domain.
 
           ## Role
@@ -31,9 +71,9 @@ jobs:
           ---
 
           ## Repository Context
-          - **Name:** personal-config
-          - **Domain:** Personal configuration files, scripts, and system preferences
-          - **Domain-Specific Priorities:** Configuration correctness, script reliability, no hardcoded secrets, environment variable hygiene
+          - **Name:** {repo_name}
+          - **Domain:** {domain}
+          - **Domain-Specific Priorities:** {priorities}
 
           ---
 
@@ -63,9 +103,21 @@ jobs:
           - Note-form summaries (brief, scannable)
           - Bash commands clearly highlighted
           - Issue closed if no problems found
-          EOF
+          """))
+          PY
+
+          gh label create automation \
+            --repo "${TARGET_REPOSITORY}" \
+            --color "0366d6" \
+            --description "Automated maintenance and QA" || true
+
+          gh label create qa \
+            --repo "${TARGET_REPOSITORY}" \
+            --color "0e8a16" \
+            --description "Quality assurance" || true
 
           gh issue create \
-            --title "Daily QA Check - $(date +'%Y-%m-%d')" \
+            --repo "${TARGET_REPOSITORY}" \
+            --title "Daily QA Check - ${REPO_NAME} - $(date +'%Y-%m-%d')" \
             --body-file prompt.md \
             --label "automation,qa"


### PR DESCRIPTION
## What

Expand the Jules Daily QA workflow so it opens QA prompt issues for all six target repositories, including the three Seatek repos.

## Why

The daily QA workflow previously targeted only `personal-config`; Abhi asked to add `series_correction_project_updated`, `Hydrograph_Versus_Seatek_Sensors_Project`, and `Seatek_Analysis` to the workflow.

## How

- Adds a GitHub Actions matrix with repo-specific domain/priorities for `personal-config`, `email-security-pipeline`, `ctrld-sync`, `series_correction_project_updated`, `Hydrograph_Versus_Seatek_Sensors_Project`, and `Seatek_Analysis`.
- Generates the Jules prompt from environment variables instead of duplicating hard-coded prompt bodies.
- Creates/uses `automation` and `qa` labels in the target repo before opening the daily QA issue.
- Updates automation docs and Copilot repo context to include the Seatek repos.

## Testing

- `python3` YAML parse and structural assertions passed for `.github/workflows/jules-daily-qa.yml`.
- Local shell simulation passed using a stubbed `gh` binary and sentinel environment values.
- `make lint-errors` passed.
- `make test-quick` passed.

## Security

Uses `${{ secrets.GH_TOKEN }}` at step env scope and confirms the shell `run:` block does not directly interpolate `secrets.*`. No secrets, tokens, or `.env` files included.

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

Link to Devin session: https://app.devin.ai/sessions/2f6682137176411a89d01e9465519071
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->