### PR TITLE
🎨 Palette: Add accessible spinners to final-media-server.sh

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -124,3 +124,7 @@
 
 **Learning:** Using `read -n 1` for confirmation prompts (e.g., `read -p "Continue? (y/n): " -n 1`) allows users to accidentally trigger actions by bumping a key. Additionally, if a user types "yes" instead of "y", the "es" and the Enter keystroke are left in the stdin buffer, potentially executing unintended commands after the script finishes.
 **Action:** Remove the `-n 1` flag from `read` prompts to require an explicit Enter press, acting as a safety confirmation and preventing buffer stuffing. When doing so, also remove any immediately following `echo` command that was previously used to print the missing newline.
+
+## 2024-05-19 - Accessible Spinners for Wait States
+**Learning:** Hardcoded sleeps without visual feedback create uncertainty; users don't know if a script is frozen or just taking time.
+**Action:** Replace arbitrary `sleep` commands with accessible spinners (e.g., `spinner_wait` function) to provide clear visual feedback during wait periods, ensuring they safely handle interrupts and only render in interactive terminals (e.g., checking `[ -t 1 ] && -z ${CI-}`) to avoid polluting logs.

--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -17,10 +17,45 @@ echo
 # Determine mode
 MODE="${1:-auto}"
 
+# Accessible Spinner
+spinner_wait() {
+	local duration=$1
+	local msg="${2:-Working}"
+
+	if [[ -t 1 && -z ${CI-} ]]; then
+		local i=1
+		local sp="/-\|"
+		local iterations=$((duration * 10))
+		local c=0
+
+		[ -t 1 ] && tput civis 2>/dev/null || true
+
+		local old_int_trap old_term_trap
+		old_int_trap=$(trap -p INT)
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		old_term_trap=$(trap -p TERM)
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+
+		while [[ $c -lt $iterations ]]; do
+			printf "\r   %s [%c]" "$msg" "${sp:i++%${#sp}:1}"
+			sleep 0.1
+			c=$((c + 1))
+		done
+		printf "\r\033[K"
+
+		[ -t 1 ] && tput cnorm 2>/dev/null || true
+		eval "${old_int_trap:-trap - INT}"
+		eval "${old_term_trap:-trap - TERM}"
+	else
+		echo "   $msg (waiting ${duration}s)..."
+		sleep "$duration"
+	fi
+}
+
 # Kill any existing servers
 echo "🧹 Cleaning up existing servers..."
 pkill -f "rclone serve" 2>/dev/null || true
-sleep 2
+spinner_wait 2 "🧹 Waiting for cleanup..."
 
 # Network discovery
 echo "🔍 Network Discovery:"
@@ -134,7 +169,7 @@ nohup rclone serve webdav "media:" \
 
 SERVER_PID=$!
 echo "   PID: $SERVER_PID"
-sleep 5
+spinner_wait 5 "⏳ Waiting for server to initialize..."
 
 # Validation
 if ps -p $SERVER_PID >/dev/null; then


### PR DESCRIPTION
💡 What: Replaced arbitrary `sleep` commands with a custom `spinner_wait` function in `media-streaming/scripts/final-media-server.sh` to provide visual feedback during background wait states (cleanup and initialization).
🎯 Why: Hardcoded sleeps without visual feedback create uncertainty, making the user wonder if the script has frozen or is just taking its time. Adding an accessible visual spinner significantly improves the user experience by providing continuous feedback.
📸 Before/After: Visual change in CLI execution showing a spinner instead of frozen pauses.
♿ Accessibility: The spinner is wrapped in a terminal check (`[[ -t 1 && -z ${CI-} ]]`) so that it automatically degrades gracefully in non-interactive or CI environments (like screen readers) to avoid polluting the terminal with character spam, while also handling SIGINT/SIGTERM safely to clean up the cursor.

---
*PR created automatically by Jules for task [13114642254672066018](https://jules.google.com/task/13114642254672066018) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->