### PR TITLE
⚡ Bolt: [performance improvement] optimize categorize_ready PR fetching with ThreadPoolExecutor

### DIFF
--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 from functools import lru_cache
+import concurrent.futures
 
 
 def _parse_env_line(line, env_dict):
@@ -83,7 +84,7 @@ categorized = {
     "PERFORMANCE/REFACTOR/UI/FEATURE": [],
 }
 
-for pr in ready_prs:
+def fetch_pr_info(pr):
     # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
     repo, _, pr_id = pr.partition("#")
     info = run_gh(
@@ -98,6 +99,13 @@ for pr in ready_prs:
             "title,mergeStateStatus",
         ]
     )
+    return pr, info
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls while preserving order using map()
+    results = executor.map(fetch_pr_info, ready_prs)
+
+for pr, info in results:
     if not info:
         continue
 


### PR DESCRIPTION
💡 **What:** Refactored the `categorize_ready.py` script to use `concurrent.futures.ThreadPoolExecutor` when fetching PR statuses via the `gh pr view` command.
🎯 **Why:** The previous implementation sequentially iterated over the list of PRs making a separate blocking IO API request for each one. This created an N+1 API call bottleneck. 
📊 **Impact:** Expect a significant reduction in total execution time due to parallel processing of independent `gh` read requests (matching the ~8.9x scaling recorded in `.jules/bolt.md` for parallel IO execution). Order is preserved natively by using `executor.map`.
🔬 **Measurement:** Verify by running the script on a list of PRs (`python3 categorize_ready.py`); overall wait time should drop drastically. All formatting checks and local Python tests pass as well.

---
*PR created automatically by Jules for task [1047683200311003894](https://jules.google.com/task/1047683200311003894) started by @abhimehro*