### PR TITLE
fix(security): eval dynamic reads in mole (salvages #951)

### DIFF
--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -828,20 +828,19 @@ update_progress_if_needed() {
     local last_update_var="$3" # Name of variable holding last update time
     local interval="${4:-2}"   # Default: update every 2 seconds
 
-    # SECURITY: [CWE-78] Validate variable name to prevent command injection
-    if [[ ! "$last_update_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-        echo "Error: Invalid variable name '$last_update_var'" >&2
-        return 1
-    fi
-
     # Get current time
     local current_time
     current_time=$(get_epoch_seconds)
 
     # Get last update time from variable
+
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    if [[ ! "$last_update_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        return 1
+    fi
+
     local last_time
-    local tmp_val="${!last_update_var:-}"
-    last_time="${tmp_val:-0}"
+    last_time="${!last_update_var:-0}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -152,9 +152,8 @@ debug_timer_start() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local varname="$1"
 
-    # SECURITY: [CWE-78] Validate variable name to prevent command injection
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
     if [[ ! "$varname" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-        echo "Error: Invalid variable name '$varname'" >&2
         return 1
     fi
 
@@ -168,14 +167,13 @@ debug_timer_end() {
     local label="$1"
     local start_var="$2"
 
-    # SECURITY: [CWE-78] Validate variable name to prevent command injection
+    # SECURITY: Validate variable name to prevent CWE-78 command injection
     if [[ ! "$start_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-        echo "Error: Invalid variable name '$start_var'" >&2
         return 1
     fi
 
     local start_ts
-    start_ts="${!start_var:-}"
+    start_ts="${!start_var}"
     [[ -z "$start_ts" ]] && return 0
     local end_ts
     end_ts=$(perl -MTime::HiRes -e 'printf "%.3f\n", Time::HiRes::time()' 2> /dev/null || date +%s)


### PR DESCRIPTION
Salvages #951. Verify: bash -n on mole core scripts.

Made with [Cursor](https://cursor.com)