### PR TITLE
🎨 Palette: Hide cursor during spinners to prevent flicker

### DIFF
--- a/configs/.config/mole/install.sh
+++ b/configs/.config/mole/install.sh
@@ -22,6 +22,7 @@ start_line_spinner() {
     # shellcheck disable=SC1003
     [[ -z "$chars" ]] && chars='|/-\\'
     local i=0
+    tput civis 2>/dev/null || true
     (while true; do
         c="${chars:$((i % ${#chars})):1}"
         printf "\r${BLUE}%s${NC} %s" "$c" "$msg"
@@ -34,6 +35,7 @@ stop_line_spinner() { if [[ -n "$_SPINNER_PID" ]]; then
     kill "$_SPINNER_PID" 2> /dev/null || true
     wait "$_SPINNER_PID" 2> /dev/null || true
     _SPINNER_PID=""
+    tput cnorm 2>/dev/null || true
     printf "\r\033[K"
 fi; }
 

--- a/configs/.config/mole/lib/core/ui.sh
+++ b/configs/.config/mole/lib/core/ui.sh
@@ -348,6 +348,9 @@ start_inline_spinner() {
             [[ -z "$chars" ]] && chars="|/-\\"
             local i=0
 
+            # Hide cursor to prevent flicker
+            tput civis 2>/dev/null || true
+
             # Clear line on first output to prevent text remnants from previous messages
             printf "\r\033[2K" >&2 || true
 
@@ -360,7 +363,8 @@ start_inline_spinner() {
                 /bin/sleep 0.05
             done
 
-            # Clean up stop file before exiting
+            # Clean up stop file and restore cursor before exiting
+            tput cnorm 2>/dev/null || true
             rm -f "$stop_file" 2> /dev/null || true
             exit 0
         ) &
@@ -397,8 +401,11 @@ stop_inline_spinner() {
         INLINE_SPINNER_PID=""
         INLINE_SPINNER_STOP_FILE=""
 
-        # Clear the line - use \033[2K to clear entire line, not just to end
-        [[ -t 1 ]] && printf "\r\033[2K" >&2 || true
+        # Clear the line and restore cursor
+        if [[ -t 1 ]]; then
+            tput cnorm 2>/dev/null || true
+            printf "\r\033[2K" >&2 || true
+        fi
     fi
 }
 


### PR DESCRIPTION
💡 **What:** Added `tput civis` to hide the cursor when starting `start_line_spinner` and `start_inline_spinner`, and added `tput cnorm` to restore it when stopping or exiting.
🎯 **Why:** To prevent distracting cursor flickering while the spinner animation redelivers output, improving the micro-UX of the CLI.
📸 **Before/After:** No visual output change, but the cursor no longer jumps back and forth at the end of the line.
♿ **Accessibility:** Reduces visual noise.

---
*PR created automatically by Jules for task [6512142216101976103](https://jules.google.com/task/6512142216101976103) started by @abhimehro*