### PR TITLE
fix(security): CWE-78 dynamic var hardening in mole core (salvages #923)

### DIFF
--- a/configs/.config/mole/lib/core/app_protection.sh
+++ b/configs/.config/mole/lib/core/app_protection.sh
@@ -632,13 +632,6 @@ bundle_matches_pattern() {
 # $2...: Array elements (passed as expanded list)
 build_regex_var() {
     local var_name="$1"
-
-    # SECURITY: [CWE-78] Validate variable name to prevent command injection
-    if [[ ! "$var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-        echo "Error: Invalid variable name '$var_name'" >&2
-        return 1
-    fi
-
     shift
     local regex=""
     for pattern in "$@"; do
@@ -655,6 +648,12 @@ build_regex_var() {
             regex="$regex|$p"
         fi
     done
+
+    # SECURITY: Prevent CWE-78 command injection
+    if [[ ! "$var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$var_name' for regex assignment" >&2
+        return 1
+    fi
     printf -v "$var_name" "%s" "$regex"
 }
 

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -832,15 +832,15 @@ update_progress_if_needed() {
     local current_time
     current_time=$(get_epoch_seconds)
 
-    # Get last update time from variable
-
-    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    # SECURITY: Prevent CWE-78 command injection
     if [[ ! "$last_update_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$last_update_var' for progress update" >&2
         return 1
     fi
 
+    # Get last update time from variable
     local last_time
-    last_time="${!last_update_var:-0}"
+    last_time="${!last_update_var}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed

--- a/configs/.config/mole/lib/core/base.sh
+++ b/configs/.config/mole/lib/core/base.sh
@@ -840,7 +840,7 @@ update_progress_if_needed() {
 
     # Get last update time from variable
     local last_time
-    last_time="${!last_update_var}"
+    last_time="${!last_update_var:-0}"
     [[ "$last_time" =~ ^[0-9]+$ ]] || last_time=0
 
     # Check if enough time has elapsed

--- a/configs/.config/mole/lib/core/log.sh
+++ b/configs/.config/mole/lib/core/log.sh
@@ -152,8 +152,9 @@ debug_timer_start() {
     [[ "${MO_DEBUG:-}" != "1" ]] && return 0
     local varname="$1"
 
-    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    # SECURITY: Prevent CWE-78 command injection
     if [[ ! "$varname" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$varname' for timer start" >&2
         return 1
     fi
 
@@ -167,8 +168,9 @@ debug_timer_end() {
     local label="$1"
     local start_var="$2"
 
-    # SECURITY: Validate variable name to prevent CWE-78 command injection
+    # SECURITY: Prevent CWE-78 command injection
     if [[ ! "$start_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: Invalid variable name '$start_var' for timer end" >&2
         return 1
     fi
 


### PR DESCRIPTION
Rebuilt from `main` after batch2 salvage PRs #986–#988 conflicted post-cascade.

**Tier T1** — human merge required per salvage policy.

Verify: `shellcheck configs/.config/mole/lib/core/{app_protection,base,log}.sh`