### PR TITLE
🛡️ Sentinel: [HIGH] Fix AppleScript Injection (CWE-74) in notifications

### DIFF
--- a/maintenance/lib/archive/common_broken.sh
+++ b/maintenance/lib/archive/common_broken.sh
@@ -140,7 +140,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common.sh
+++ b/maintenance/lib/common.sh
@@ -96,7 +96,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_fixed.sh
+++ b/maintenance/lib/common_fixed.sh
@@ -211,7 +211,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_simple.sh
+++ b/maintenance/lib/common_simple.sh
@@ -91,7 +91,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: AppleScript Injection (CWE-74) existed in `maintenance/lib/common.sh`, `maintenance/lib/common_simple.sh`, `maintenance/lib/common_fixed.sh`, and `maintenance/lib/archive/common_broken.sh`. The scripts interpolated the `$message` and `$title` variables directly into an AppleScript string passed to `osascript -e`. If these variables contained unescaped double quotes, it allowed an attacker to break out of the string context and execute arbitrary AppleScript commands, which can easily pivot to arbitrary shell execution (via `do shell script`).
🎯 Impact: Local command execution/privilege escalation if notification contents are derived from untrusted input (like external network calls, log files, or file paths).
🔧 Fix: Refactored the `osascript` invocations to securely pass `$message` and `$title` as standard command-line arguments using `osascript -e 'on run argv'` and `(item N of argv)`.
✅ Verification: `make test-all` and `make lint-errors` both pass. The modified bash syntax does not trigger any new shellcheck errors.

---
*PR created automatically by Jules for task [2442135133309624882](https://jules.google.com/task/2442135133309624882) started by @abhimehro*