### PR TITLE
fix(lint): remove unused CONFIG_PATH_RESOLVED variable (SC2034)

### DIFF
--- a/scripts/get_prs.sh
+++ b/scripts/get_prs.sh
@@ -23,7 +23,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 CONFIG_FILE=""
-CONFIG_PATH_RESOLVED="" # set when repos were loaded from default or explicit config
 LIMIT=100
 INCLUDE_DETAILS=false
 BOTS_ONLY=false


### PR DESCRIPTION
## What

Remove the unused `CONFIG_PATH_RESOLVED` shell variable from `scripts/get_prs.sh`.

## Why

ShellCheck SC2034 flagged `CONFIG_PATH_RESOLVED` as defined but never read. The variable was initialized on line 26 but never referenced anywhere in the script or sourced by other scripts.

## How

Deleted the single line declaring the variable. No other code depends on it.

## Testing

- `shellcheck scripts/get_prs.sh` — clean (no warnings)
- `make test-quick` — 13 passed, 0 failed + 4 unittest OK
- `make lint-errors` — no SC2155/SC2145 violations

## Security

No security impact.

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

Link to Devin session: https://app.devin.ai/sessions/752bcd4623c547a1b4bf256778a0e61c
Requested by: @abhimehro