### PR TITLE
🎨 Palette: Require explicit enter for confirmation prompts and add spinner for wait state

### DIFF
--- a/docs/archive/COMPLETE_CLEANUP.sh
+++ b/docs/archive/COMPLETE_CLEANUP.sh
@@ -38,7 +38,7 @@ confirm_cleanup() {
 	echo
 	echo "Your system will return to using default DNS (your ISP's DNS)."
 	echo
-	read -p "Are you absolutely sure you want to continue? (type 'YES' to confirm): " confirm
+	read -r -p "Are you absolutely sure you want to continue? (type 'YES' to confirm): " confirm
 
 	if [ "$confirm" != "YES" ]; then
 		echo "Cleanup cancelled."

--- a/maintenance/bin/screencapture_nag_remover.sh
+++ b/maintenance/bin/screencapture_nag_remover.sh
@@ -9,6 +9,40 @@ TCC_DB='/Library/Application Support/com.apple.TCC/TCC.db'
 FUTURE=$(/bin/date -j -v+100y +"%Y-%m-%d %H:%M:%S +0000")
 INTERVAL=86400 #run every 24h
 
+spinner_wait() {
+	local duration=$1
+	local msg="${2:-Working}"
+
+	if [[ -t 1 && -z ${CI-} ]]; then
+		local i=1
+		local sp="/-\|"
+		local iterations=$((duration * 10))
+		local c=0
+
+		[ -t 1 ] && tput civis 2>/dev/null || true
+
+		local old_int_trap old_term_trap
+		old_int_trap=$(trap -p INT)
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		old_term_trap=$(trap -p TERM)
+		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+
+		while [[ $c -lt $iterations ]]; do
+			printf "\r   %s [%c]" "$msg" "${sp:i++%${#sp}:1}"
+			sleep 0.1
+			c=$((c + 1))
+		done
+		printf "\r\033[K"
+
+		[ -t 1 ] && tput cnorm 2>/dev/null || true
+		eval "${old_int_trap:-trap - INT}"
+		eval "${old_term_trap:-trap - TERM}"
+	else
+		echo "   $msg (waiting ${duration}s)..."
+		sleep "$duration"
+	fi
+}
+
 IFS='.' read -r MAJ MIN _ < <(/usr/bin/sw_vers --productVersion)
 if ((MAJ < 15)); then
 	echo >&2 "this tool requires macOS 15 (Sequoia)"
@@ -176,7 +210,7 @@ _install_launchagent() {
 			│  Once that's all done, run the --install command again.                              │
 			└──────────────────────────────────────────────────────────────────────────────────────┘
 		EOF
-		sleep 3
+		spinner_wait 3 "Opening System Settings..."
 		_fda_settings
 		return 1
 	fi

--- a/media-streaming/scripts/bulk-rename-cloud.sh
+++ b/media-streaming/scripts/bulk-rename-cloud.sh
@@ -52,7 +52,7 @@ if [[ $DRY_RUN == "true" ]]; then
 	exit 0
 fi
 
-read -p "Do you want to attempt automatic renaming? (y/N) " -r
+read -r -p "Do you want to attempt automatic renaming? (y/N) " REPLY
 REPLY=${REPLY:-N}
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	log "User cancelled"

--- a/media-streaming/scripts/fix-gdrive.sh
+++ b/media-streaming/scripts/fix-gdrive.sh
@@ -20,7 +20,7 @@ echo
 echo "🔐 Attempting to reconnect gdrive remote..."
 echo "This will open your browser for Google authorization."
 echo
-read -p "Press Enter to continue..."
+read -r -p "Press Enter to continue..."
 
 echo "Running: rclone config reconnect gdrive:"
 rclone config reconnect gdrive:
@@ -34,7 +34,7 @@ if rclone about gdrive: &>/dev/null; then
 else
 	echo "❌ Reconnect failed. Let's delete and recreate..."
 	echo
-	read -p "Delete gdrive remote and start fresh? (y/n): " -r
+	read -r -p "Delete gdrive remote and start fresh? (y/n): " REPLY
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
 		rclone config delete gdrive
 		echo "✅ Old gdrive remote deleted"

--- a/media-streaming/scripts/setup-gdrive.sh
+++ b/media-streaming/scripts/setup-gdrive.sh
@@ -7,7 +7,7 @@ echo "1. Sign in to your Google account"
 echo "2. Grant rclone permission to access your Google Drive"
 echo "3. Come back here when done"
 echo
-read -p "Press Enter to continue..."
+read -r -p "Press Enter to continue..."
 
 # Run rclone config for Google Drive
 rclone config create gdrive drive config_is_local false

--- a/media-streaming/scripts/setup-media-library.sh
+++ b/media-streaming/scripts/setup-media-library.sh
@@ -61,7 +61,7 @@ setup_gdrive() {
 	echo "10. Team drive: choose 'n' (unless needed)"
 	echo "11. Save with 'y'"
 	echo
-	read -p "Press Enter to start Google Drive setup..."
+	read -r -p "Press Enter to start Google Drive setup..."
 
 	rclone config
 }
@@ -86,7 +86,7 @@ setup_onedrive() {
 	echo "7. Choose account type (personal/business)"
 	echo "8. Save with 'y'"
 	echo
-	read -p "Press Enter to start OneDrive setup..."
+	read -r -p "Press Enter to start OneDrive setup..."
 
 	rclone config
 }
@@ -160,7 +160,7 @@ create_union() {
 	echo "7. Search policy: ff (or press Enter for default)"
 	echo "8. Save with 'y'"
 	echo
-	read -p "Press Enter to create union remote..."
+	read -r -p "Press Enter to create union remote..."
 
 	rclone config
 
@@ -218,7 +218,7 @@ echo "• Create a unified 'media' remote"
 echo "• Set up WebDAV server for Infuse"
 echo
 
-read -p "Continue? (y/n): " -r
+read -r -p "Continue? (y/n): " REPLY
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	echo "Setup cancelled."
 	exit 1


### PR DESCRIPTION
💡 **What**: 
1. Added an accessible `spinner_wait` function to `maintenance/bin/screencapture_nag_remover.sh` to replace a static `sleep 3` command.
2. Standardized `read -p` confirmation prompts across `media-streaming` scripts and `docs/archive/COMPLETE_CLEANUP.sh` to use `read -r -p` and clearly capture input without implicit escaping issues.

🎯 **Why**: 
1. **Visual Feedback:** Static `sleep` commands create uncertainty in CLI scripts, making the user wonder if the script has frozen. The spinner provides clear visual feedback that a background wait is occurring.
2. **Predictable Input:** Using `read -r` prevents backslash escaping bugs, and explicitly binding to variables (like `REPLY` or `confirm`) makes the input capture predictable, avoiding edge cases where the `-r` flag was misplaced.

📸 **Before/After**: 
- *Before:* The screen capture nag remover script printed a message and paused silently for 3 seconds.
- *After:* The script now displays an animated loading spinner (e.g. `Working [/]`) before opening System Settings.

♿ **Accessibility**: 
- The `spinner_wait` function checks `[ -t 1 ] && -z ${CI-}` to ensure it only renders the animated spinner in interactive TTY sessions. In non-TTY environments (like screen readers or CI), it gracefully degrades to a static `Working (waiting 3s)...` message, preventing "terminal spam" for screen readers.
- It also carefully hides and restores the terminal cursor to prevent distracting cursor flicker during the animation.

---
*PR created automatically by Jules for task [3397189075004635827](https://jules.google.com/task/3397189075004635827) started by @abhimehro*