### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix AppleScript Injection via osascript

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -255,3 +255,8 @@
 **Vulnerability:** AppleScript Injection (CWE-74) existed in `configs/.config/mole/lib/core/sudo.sh` where `osascript` was executing a string containing user-controlled variable `${MOLE_SUDO_PROMPT:-Admin access required}`.
 **Learning:** Using inline string interpolation in AppleScript code executed via `osascript` allows an attacker to inject arbitrary AppleScript commands if they control the variable.
 **Prevention:** Use `osascript -e 'on run argv'` and pass dynamic variables safely as command-line arguments (e.g. `(item 1 of argv)`).
+
+## 2026-05-21 - Widespread AppleScript Injection via osascript
+**Vulnerability:** AppleScript Injection (CWE-74) found in multiple scripts in `media-streaming/scripts/` and `maintenance/bin/`. Although some scripts attempted to escape double quotes (`esc_m="${m//\"/\\\"}"`), an attacker could still inject commands like `\\\" & do shell script "echo pwned" & \\"` which evaluated inside the `display notification` command.
+**Learning:** Simple string escaping is insufficient when interpolating dynamic variables into AppleScript executed via `osascript -e`. An attacker can break out of the string context and execute arbitrary AppleScript or shell commands.
+**Prevention:** Always use `osascript -e 'on run argv'` and pass dynamic variables securely as command-line arguments (e.g., `item 1 of argv`). Never construct AppleScript strings via bash interpolation.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,7 @@
+🛡️ Sentinel: [CRITICAL] Fix AppleScript Injection via osascript
+
+🚨 Severity: CRITICAL
+💡 Vulnerability: AppleScript Injection (CWE-74) via string interpolation in `osascript -e`. Even when quotes were escaped, attackers could break out using `\" & do shell script "..." & \"`.
+🎯 Impact: An attacker who can control notification variables (like title or message) could execute arbitrary shell commands on the host machine.
+🔧 Fix: Refactored `osascript -e` usages to use `on run argv` with parameter passing (`item 1 of argv`), which safely handles arbitrary characters without evaluation.
+✅ Verification: Tested against malicious strings in the terminal. No commands are evaluated, notifications display the strings literally.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,7 +1,0 @@
-🛡️ Sentinel: [CRITICAL] Fix AppleScript Injection via osascript
-
-🚨 Severity: CRITICAL
-💡 Vulnerability: AppleScript Injection (CWE-74) via string interpolation in `osascript -e`. Even when quotes were escaped, attackers could break out using `\" & do shell script "..." & \"`.
-🎯 Impact: An attacker who can control notification variables (like title or message) could execute arbitrary shell commands on the host machine.
-🔧 Fix: Refactored `osascript -e` usages to use `on run argv` with parameter passing (`item 1 of argv`), which safely handles arbitrary characters without evaluation.
-✅ Verification: Tested against malicious strings in the terminal. No commands are evaluated, notifications display the strings literally.

--- a/maintenance/bin/brew_maintenance.sh
+++ b/maintenance/bin/brew_maintenance.sh
@@ -244,7 +244,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"${STATUS_MSG}\" with title \"Homebrew Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "Homebrew Maintenance" 2>/dev/null || true
 fi
 
 log_info "Homebrew maintenance complete: ${STATUS_MSG}"

--- a/maintenance/bin/health_check.sh
+++ b/maintenance/bin/health_check.sh
@@ -406,7 +406,7 @@ elif command -v osascript >/dev/null 2>&1; then
 	if ((PANIC_COUNT > 0)) && [[ -n $PANIC_DETAILS ]]; then
 		NOTIFICATION_TEXT+="\n${PANIC_DETAILS}"
 	fi
-	osascript -e "display notification \"${NOTIFICATION_TEXT}\" with title \"Health Check\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${NOTIFICATION_TEXT}" "Health Check" 2>/dev/null || true
 fi
 
 log_info "Health check complete: ${HEALTH_STATUS}"

--- a/maintenance/bin/service_monitor.sh
+++ b/maintenance/bin/service_monitor.sh
@@ -314,9 +314,9 @@ echo "$REPORT"
 # Send notification if not in automated mode
 if [[ ${AUTOMATED_RUN:-0} != "1" ]] && command -v osascript >/dev/null 2>&1; then
 	if ((ISSUES > 0)); then
-		osascript -e "display notification \"Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT\" with title \"⚠️ Service Monitor\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT" "⚠️ Service Monitor" 2>/dev/null || true
 	elif ((WARNINGS > 0)); then
-		osascript -e "display notification \"Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT\" with title \"ℹ️ Service Monitor\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT" "ℹ️ Service Monitor" 2>/dev/null || true
 	fi
 fi
 

--- a/maintenance/bin/system_cleanup.sh
+++ b/maintenance/bin/system_cleanup.sh
@@ -259,7 +259,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"${STATUS_MSG}\" with title \"System Cleanup\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "System Cleanup" 2>/dev/null || true
 fi
 
 log_info "System cleanup complete: ${STATUS_MSG}"

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -29,9 +29,7 @@ notify() {
 	if command -v terminal-notifier >/dev/null 2>&1; then
 		terminal-notifier -title "$t" -message "$m" -sound default
 	elif command -v osascript >/dev/null 2>&1; then
-		local esc_t="${t//\"/\\\"}"
-		local esc_m="${m//\"/\\\"}"
-		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$m" "$t" 2>/dev/null || true
 	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }

--- a/media-streaming/scripts/sync-alldebrid.sh
+++ b/media-streaming/scripts/sync-alldebrid.sh
@@ -47,9 +47,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		local esc_title="${title//\"/\\\"}"
-		local esc_message="${message//\"/\\\"}"
-		osascript -e "display notification \"$esc_message\" with title \"$esc_title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: AppleScript Injection (CWE-74) via string interpolation in `osascript -e`. Even when quotes were escaped, attackers could break out using `\" & do shell script "..." & \"`.
🎯 Impact: An attacker who can control notification variables (like title or message) could execute arbitrary shell commands on the host machine.
🔧 Fix: Refactored `osascript -e` usages to use `on run argv` with parameter passing (`item 1 of argv`), which safely handles arbitrary characters without evaluation.
✅ Verification: Tested against malicious strings in the terminal. No commands are evaluated, notifications display the strings literally.

---
*PR created automatically by Jules for task [18358300748694526468](https://jules.google.com/task/18358300748694526468) started by @abhimehro*