### PR TITLE
🛡️ Sentinel: [HIGH] Fix AppleScript Injection (CWE-74) via osascript

### DIFF
--- a/configs/.config/fish/_backups/20260423-085518/conf.d/done.fish
+++ b/configs/.config/fish/_backups/20260423-085518/conf.d/done.fish
@@ -279,14 +279,12 @@ if set -q __done_enabled
                 end
 
             else if type -q osascript # AppleScript
-                # escape double quotes that might exist in the message and break osascript. fixes #133
-                set -l message (string replace --all '"' '\"' "$message")
-                set -l title (string replace --all '"' '\"' "$title")
+
 
                 if test "$__done_notify_sound" -eq 1
-                    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Glass\""
+                    osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Glass"' -e 'end run' "$message" "$title"
                 else
-                    osascript -e "display notification \"$message\" with title \"$title\""
+                    osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title"
                 end
 
             else if type -q notify-send # Linux notify-send

--- a/maintenance/bin/archive/onedrive_monitor.sh
+++ b/maintenance/bin/archive/onedrive_monitor.sh
@@ -119,7 +119,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
 	if [[ $ONEDRIVE_STATUS != "Running" ]] || [[ $SYNC_STATUS == *"No recent activity"* ]]; then
-		osascript -e "display notification \"$STATUS_MSG\" with title \"OneDrive Monitor - Issues Detected\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS_MSG" "OneDrive Monitor - Issues Detected" 2>/dev/null || true
 		log_warn "OneDrive monitoring detected potential issues"
 	else
 		log_info "OneDrive appears to be working normally"

--- a/maintenance/bin/brew_maintenance.sh
+++ b/maintenance/bin/brew_maintenance.sh
@@ -244,7 +244,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"${STATUS_MSG}\" with title \"Homebrew Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "Homebrew Maintenance" 2>/dev/null || true
 fi
 
 log_info "Homebrew maintenance complete: ${STATUS_MSG}"

--- a/maintenance/bin/deep_cleaner.sh
+++ b/maintenance/bin/deep_cleaner.sh
@@ -326,7 +326,7 @@ log_info "Deep cleaning analysis complete"
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e 'display notification "Analysis complete. Check report for cleanup recommendations." with title "Deep Cleaner"' 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Analysis complete. Check report for cleanup recommendations." "Deep Cleaner" 2>/dev/null || true
 fi
 
 echo ""

--- a/maintenance/bin/editor_cleanup.sh
+++ b/maintenance/bin/editor_cleanup.sh
@@ -160,10 +160,10 @@ total_freed_mb=$((total_freed / 1024))
 # Notification
 if command -v osascript >/dev/null 2>&1; then
 	if [[ $total_freed_mb -gt 0 ]]; then
-		osascript -e "display notification \"Completed - Freed ${total_freed_mb}MB\" with title \"Editor Cleanup\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Completed - Freed ${total_freed_mb}MB" "Editor Cleanup" 2>/dev/null || true
 		log_info "Editor cache cleanup freed ${total_freed_mb}MB total"
 	else
-		osascript -e 'display notification "Completed - Caches already clean" with title "Editor Cleanup"' 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Completed - Caches already clean" "Editor Cleanup" 2>/dev/null || true
 		log_info "Editor caches were already clean"
 	fi
 fi

--- a/maintenance/bin/google_drive_monitor.sh
+++ b/maintenance/bin/google_drive_monitor.sh
@@ -211,7 +211,8 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
 	if [[ $GDRIVE_STATUS != "Running" ]] || [[ $SYNC_STATUS == *"No recent activity"* ]] || [[ $SYNC_STATUS == *"errors"* ]]; then
-		osascript -e "display notification \"$STATUS_MSG\n$BACKUP_MSG\" with title \"Google Drive Monitor - Issues Detected\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS_MSG
+$BACKUP_MSG" "Google Drive Monitor - Issues Detected" 2>/dev/null || true
 		log_warn "Google Drive monitoring detected potential issues"
 	else
 		log_info "Google Drive appears to be working normally"

--- a/maintenance/bin/health_check.sh
+++ b/maintenance/bin/health_check.sh
@@ -406,7 +406,7 @@ elif command -v osascript >/dev/null 2>&1; then
 	if ((PANIC_COUNT > 0)) && [[ -n $PANIC_DETAILS ]]; then
 		NOTIFICATION_TEXT+="\n${PANIC_DETAILS}"
 	fi
-	osascript -e "display notification \"${NOTIFICATION_TEXT}\" with title \"Health Check\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${NOTIFICATION_TEXT}" "Health Check" 2>/dev/null || true
 fi
 
 log_info "Health check complete: ${HEALTH_STATUS}"

--- a/maintenance/bin/health_check.sh
+++ b/maintenance/bin/health_check.sh
@@ -401,10 +401,10 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 elif command -v osascript >/dev/null 2>&1; then
 	NOTIFICATION_TEXT="${HEALTH_STATUS} | Disk: ${ROOT_USE:-?}%"
 	if [[ -n $REASONS_STR ]]; then
-		NOTIFICATION_TEXT+="\n${REASONS_STR}"
+		NOTIFICATION_TEXT+=$'\n'"${REASONS_STR}"
 	fi
 	if ((PANIC_COUNT > 0)) && [[ -n $PANIC_DETAILS ]]; then
-		NOTIFICATION_TEXT+="\n${PANIC_DETAILS}"
+		NOTIFICATION_TEXT+=$'\n'"${PANIC_DETAILS}"
 	fi
 	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${NOTIFICATION_TEXT}" "Health Check" 2>/dev/null || true
 fi

--- a/maintenance/bin/monthly_maintenance.sh
+++ b/maintenance/bin/monthly_maintenance.sh
@@ -122,7 +122,7 @@ fi
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"$STATUS\" with title \"Monthly Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Monthly Maintenance" 2>/dev/null || true
 fi
 
 log_info "Monthly maintenance finished: $STATUS"
@@ -151,7 +151,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e "display notification \"$STATUS\" with title \"Monthly Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Monthly Maintenance" 2>/dev/null || true
 fi
 
 echo "Monthly maintenance completed!"

--- a/maintenance/bin/node_maintenance.sh
+++ b/maintenance/bin/node_maintenance.sh
@@ -221,7 +221,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e "display notification \"$STATUS_MSG\" with title \"Node.js Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS_MSG" "Node.js Maintenance" 2>/dev/null || true
 fi
 
 log_info "Node.js maintenance complete: $STATUS_MSG"

--- a/maintenance/bin/quick_cleanup.sh
+++ b/maintenance/bin/quick_cleanup.sh
@@ -174,7 +174,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-execute "$HOME/Library/Maintenance/bin/view_logs.sh quick_cleanup" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e "display notification \"Cleaned ${CLEANED} items | Disk: ${DISK_USE}%\" with title \"Quick Cleanup\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Cleaned ${CLEANED} items | Disk: ${DISK_USE}%" "Quick Cleanup" 2>/dev/null || true
 fi
 
 log_info "Quick cleanup completed: ${CLEANED} items cleaned"

--- a/maintenance/bin/service_monitor.sh
+++ b/maintenance/bin/service_monitor.sh
@@ -314,9 +314,9 @@ echo "$REPORT"
 # Send notification if not in automated mode
 if [[ ${AUTOMATED_RUN:-0} != "1" ]] && command -v osascript >/dev/null 2>&1; then
 	if ((ISSUES > 0)); then
-		osascript -e "display notification \"Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT\" with title \"⚠️ Service Monitor\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT" "⚠️ Service Monitor" 2>/dev/null || true
 	elif ((WARNINGS > 0)); then
-		osascript -e "display notification \"Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT\" with title \"ℹ️ Service Monitor\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT" "ℹ️ Service Monitor" 2>/dev/null || true
 	fi
 fi
 

--- a/maintenance/bin/system_cleanup.sh
+++ b/maintenance/bin/system_cleanup.sh
@@ -259,7 +259,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"${STATUS_MSG}\" with title \"System Cleanup\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "System Cleanup" 2>/dev/null || true
 fi
 
 log_info "System cleanup complete: ${STATUS_MSG}"

--- a/maintenance/bin/system_metrics.sh
+++ b/maintenance/bin/system_metrics.sh
@@ -269,7 +269,7 @@ if [[ $OVERALL_HEALTH == "critical" ]]; then
 			-sound "Basso" \
 			-group "maintenance" 2>/dev/null || true
 	elif command -v osascript >/dev/null 2>&1; then
-		osascript -e 'display notification "System health is critical! Check metrics for details." with title "System Alert" sound name "Basso"' 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Basso"' -e 'end run' "System health is critical! Check metrics for details." "System Alert" 2>/dev/null || true
 	fi
 fi
 

--- a/maintenance/bin/weekly_maintenance.sh
+++ b/maintenance/bin/weekly_maintenance.sh
@@ -122,7 +122,7 @@ fi
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e "display notification \"$STATUS\" with title \"Weekly Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Weekly Maintenance" 2>/dev/null || true
 fi
 
 log_info "Weekly maintenance finished: $STATUS"
@@ -151,7 +151,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e "display notification \"$STATUS\" with title \"Weekly Maintenance\"" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Weekly Maintenance" 2>/dev/null || true
 fi
 
 echo "Weekly maintenance completed!"

--- a/maintenance/lib/archive/common_broken.sh
+++ b/maintenance/lib/archive/common_broken.sh
@@ -140,7 +140,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common.sh
+++ b/maintenance/lib/common.sh
@@ -96,7 +96,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_fixed.sh
+++ b/maintenance/lib/common_fixed.sh
@@ -211,7 +211,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_simple.sh
+++ b/maintenance/lib/common_simple.sh
@@ -91,7 +91,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -29,9 +29,7 @@ notify() {
 	if command -v terminal-notifier >/dev/null 2>&1; then
 		terminal-notifier -title "$t" -message "$m" -sound default
 	elif command -v osascript >/dev/null 2>&1; then
-		local esc_t="${t//\"/\\\"}"
-		local esc_m="${m//\"/\\\"}"
-		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$m" "$t" 2>/dev/null || true
 	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }

--- a/media-streaming/scripts/sync-alldebrid.sh
+++ b/media-streaming/scripts/sync-alldebrid.sh
@@ -47,9 +47,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		local esc_title="${title//\"/\\\"}"
-		local esc_message="${message//\"/\\\"}"
-		osascript -e "display notification \"$esc_message\" with title \"$esc_title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -150,5 +150,5 @@ info "Video saved to ~/Downloads"
 if command -v terminal-notifier >/dev/null 2>&1; then
 	terminal-notifier -title "Download Complete" -message "Video saved to Downloads"
 elif [[ $(uname) == "Darwin" ]] && command -v osascript >/dev/null 2>&1; then
-	osascript -e 'display notification "Video saved to Downloads" with title "Download Complete"'
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Video saved to Downloads" "Download Complete"
 fi


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** AppleScript Injection (CWE-74) existed across numerous bash and fish scripts where `osascript` was used with inline string interpolation. If `$message` or `$title` contained double quotes or AppleScript control characters, an attacker could escape the AppleScript string context and execute arbitrary commands.
🎯 **Impact:** Potential arbitrary code execution if notification inputs are attacker-controlled.
🔧 **Fix:** Refactored all `osascript` invocations to use the secure `on run argv` pattern, passing dynamic variables safely as positional arguments (`item 1 of argv`) instead of interpolating them directly into the script string. Also removed custom manual escaping which is no longer needed.
✅ **Verification:** Tested syntax locally and verified tests via `make test-all`.

---
*PR created automatically by Jules for task [8864898998363662613](https://jules.google.com/task/8864898998363662613) started by @abhimehro*