### PR TITLE
test(scratch_triage): run_cmd unit tests (salvages #992)

### DIFF
--- a/tests/test_scratch_triage.py
+++ b/tests/test_scratch_triage.py
@@ -1,0 +1,40 @@
+"""Unit tests for scratch_triage.run_cmd (salvages #992)."""
+
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+# Repo root on path so scratch_triage imports without package layout.
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1]))
+
+import scratch_triage  # noqa: E402
+
+
+class TestRunCmd(unittest.TestCase):
+    @patch("scratch_triage.subprocess.run")
+    def test_run_cmd_success(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout='{"ok": true}', stderr=""
+        )
+        ok, out, err = scratch_triage.run_cmd(["gh", "version"])
+        self.assertTrue(ok)
+        self.assertEqual(out, '{"ok": true}')
+        self.assertEqual(err, "")
+        mock_run.assert_called_once_with(
+            ["gh", "version"], capture_output=True, text=True
+        )
+
+    @patch("scratch_triage.subprocess.run")
+    def test_run_cmd_failure(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="not found"
+        )
+        ok, out, err = scratch_triage.run_cmd(["gh", "missing"])
+        self.assertFalse(ok)
+        self.assertEqual(out, "")
+        self.assertEqual(err, "not found")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Tests-only v2 salvage of #992: adds `tests/test_scratch_triage.py` against current `main` without scope creep.

## Salvage source
- Supersedes: #992
- Tier: T3 (routine test addition)

## Verification
```bash
python3 -m unittest discover -s tests -p 'test_scratch_triage.py' -v
```

═══ ELIR ═══
**PURPOSE:** Lock in `run_cmd` subprocess wrapper behavior with mocked tests.
**SECURITY:** No production logic change.
**FAILS IF:** `scratch_triage.run_cmd` signature changes without updating tests.
**VERIFY:** Unittest command above; CI green before merge.
**MAINTAIN:** Keep tests aligned to public API only.