### PR TITLE
fix(automation): resolve 43-day daily workflow failure from cascading str.replace bug

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -22,16 +22,14 @@ USE_MCP_GITHUB = os.environ.get("USE_MCP_GITHUB", "false").lower() in {
     "on",
 }
 
-# Try to import MCP GitHub server if available
-# Note: Requires the appropriate MCP client library to be installed
-# This is a placeholder for the actual MCP GitHub integration
 try:
     if USE_MCP_GITHUB:
-        import mcp
-        MCP_AVAILABLE = True
+        import importlib.util
+
+        MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
     else:
         MCP_AVAILABLE = False
-except ImportError:
+except Exception:
     MCP_AVAILABLE = False
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -440,17 +438,6 @@ def numeric_version(text: str) -> tuple[int, int, int] | None:
 
 
 def tag_exists(repo_id: str, tag: str) -> bool:
-    # Use MCP if available, otherwise fall back to gh CLI
-    if MCP_AVAILABLE and USE_MCP_GITHUB:
-        try:
-            owner, repo = repo_id.split("/")
-            # Placeholder for MCP GitHub get_file_contents call
-            # get_file_contents(owner, repo, "README.md", tag)
-            return True
-        except Exception:
-            return False
-
-    # Original gh CLI implementation
     proc = run_process([GH_BIN, "api", f"repos/{repo_id}/git/ref/tags/{tag}"])
     return proc.returncode == 0
 

--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -311,7 +311,12 @@ def flattened_updates(plans: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def apply_workflow_updates(plans: list[dict[str, Any]]) -> None:
     for plan in plans:
         updated_text = plan["text"]
+        seen: set[tuple[str, str]] = set()
         for replacement in plan["replacements"]:
+            key = (replacement["old"], replacement["new"])
+            if key in seen:
+                continue
+            seen.add(key)
             updated_text = updated_text.replace(replacement["old"], replacement["new"])
         plan["path"].write_text(updated_text)
 

--- a/.github/workflows/repository-automation-daily.yml
+++ b/.github/workflows/repository-automation-daily.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload workflow updater artifact
         if: always()
-        uses: actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: workflow-updater
           path: .automation-output/workflow-updater
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload performance artifact
         if: always()
-        uses: actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: performance-optimizer
           path: .automation-output/performance-optimizer
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload QA artifact
         if: always()
-        uses: actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: quality-assurance
           path: .automation-output/quality-assurance
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload backlog artifact
         if: always()
-        uses: actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: backlog-manager
           path: .automation-output/backlog-manager
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload status artifact
         if: always()
-        uses: actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: daily-status-report
           path: .automation-output/daily-status-report

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -16,44 +16,97 @@ sys.path.append(
     )
 )
 
-from repository_automation_tasks import configured_commands  # noqa: E402
+from repository_automation_tasks import (  # noqa: E402
+    apply_workflow_updates,
+    configured_commands,
+)
+
 
 class TestRepositoryAutomationTasks(unittest.TestCase):
     def test_configured_commands_all_keys_present(self):
         section = {
             "setup_commands": [{"run": "setup1"}],
             "commands": [{"run": "cmd1"}, {"run": "cmd2"}],
-            "security_commands": [{"run": "sec1"}]
+            "security_commands": [{"run": "sec1"}],
         }
         expected = [
             ("setup", {"run": "setup1"}),
             ("command", {"run": "cmd1"}),
             ("command", {"run": "cmd2"}),
-            ("security", {"run": "sec1"})
+            ("security", {"run": "sec1"}),
         ]
         self.assertEqual(configured_commands(section), expected)
 
     def test_configured_commands_missing_keys(self):
-        section = {
-            "commands": [{"run": "cmd1"}]
-        }
-        expected = [
-            ("command", {"run": "cmd1"})
-        ]
+        section = {"commands": [{"run": "cmd1"}]}
+        expected = [("command", {"run": "cmd1"})]
         self.assertEqual(configured_commands(section), expected)
 
     def test_configured_commands_empty_section(self):
         self.assertEqual(configured_commands({}), [])
 
     def test_configured_commands_ignore_extra_keys(self):
-        section = {
-            "commands": [{"run": "cmd1"}],
-            "other_commands": [{"run": "other"}]
-        }
-        expected = [
-            ("command", {"run": "cmd1"})
-        ]
+        section = {"commands": [{"run": "cmd1"}], "other_commands": [{"run": "other"}]}
+        expected = [("command", {"run": "cmd1"})]
         self.assertEqual(configured_commands(section), expected)
 
-if __name__ == '__main__':
+
+class TestApplyWorkflowUpdates(unittest.TestCase):
+    """Regression tests for apply_workflow_updates (cascading str.replace fix)."""
+
+    def _make_plan(self, text, replacements):
+        import tempfile
+        from pathlib import Path
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False)
+        tmp.write(text)
+        tmp.close()
+        path = Path(tmp.name)
+        return {"path": path, "text": text, "replacements": replacements}
+
+    def test_no_cascade_when_old_is_substring_of_new(self):
+        text = (
+            "uses: actions/upload-artifact@v7\n"
+            "uses: actions/upload-artifact@v7\n"
+            "uses: actions/upload-artifact@v7\n"
+        )
+        replacements = [
+            {
+                "old": "uses: actions/upload-artifact@v7",
+                "new": "uses: actions/upload-artifact@v7.0.1",
+            },
+            {
+                "old": "uses: actions/upload-artifact@v7",
+                "new": "uses: actions/upload-artifact@v7.0.1",
+            },
+            {
+                "old": "uses: actions/upload-artifact@v7",
+                "new": "uses: actions/upload-artifact@v7.0.1",
+            },
+        ]
+        plan = self._make_plan(text, replacements)
+        apply_workflow_updates([plan])
+        result = plan["path"].read_text()
+        plan["path"].unlink()
+        self.assertNotIn("v7.0.1.0.1", result)
+        self.assertEqual(result.count("actions/upload-artifact@v7.0.1"), 3)
+
+    def test_distinct_replacements_still_applied(self):
+        text = "uses: actions/checkout@v3\n" "uses: actions/upload-artifact@v4\n"
+        replacements = [
+            {"old": "uses: actions/checkout@v3", "new": "uses: actions/checkout@v4"},
+            {
+                "old": "uses: actions/upload-artifact@v4",
+                "new": "uses: actions/upload-artifact@v5",
+            },
+        ]
+        plan = self._make_plan(text, replacements)
+        apply_workflow_updates([plan])
+        result = plan["path"].read_text()
+        plan["path"].unlink()
+        self.assertIn("actions/checkout@v4", result)
+        self.assertIn("actions/upload-artifact@v5", result)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Fix the corrupted `actions/upload-artifact@v7.0.1.0.1.0.1.0.1.0.1` tag in the daily automation workflow and the underlying bug that caused it.

## Why

The `repository-automation-daily.yml` workflow has been failing for **43 consecutive days** (since April 13) because all 5 jobs fail at "Set up job" — GitHub Actions cannot resolve the invalid tag `v7.0.1.0.1.0.1.0.1.0.1`.

This was introduced by PR #767 (auto-generated by the workflow-updater on Apr 12, merged via Trunk queue). The intended update was `@v7` → `@v7.0.1`, but a cascading `str.replace()` bug corrupted it.

## How

**Root cause**: `apply_workflow_updates()` iterated over all regex matches and called `str.replace()` for each one. When 5 matches in the same file shared the same old/new pair, the first `str.replace()` handled all occurrences. Subsequent calls re-matched the old string (`@v7`) as a substring of the already-replaced new string (`@v7.0.1`), cascading the replacement: `v7` → `v7.0.1` → `v7.0.1.0.1` → `v7.0.1.0.1.0.1` → `v7.0.1.0.1.0.1.0.1` → `v7.0.1.0.1.0.1.0.1.0.1`.

Four changes:
1. **Workflow YAML**: Replace corrupted tag with `actions/upload-artifact@v7.0.1` (5 lines)
2. **`apply_workflow_updates()`**: Deduplicate replacement entries per file so each unique old→new pair is applied exactly once
3. **`tag_exists()`**: Remove MCP placeholder that returned `True` unconditionally without validating; replace bare `import mcp` with `importlib.util.find_spec` (fixes ruff F401)
4. **Tests**: Add regression tests covering the multi-occurrence substring replacement scenario

## Testing

- `python3 -m unittest tests.test_repository_automation_tasks -v` — 6/6 pass (including 2 new tests)
- `python3 -m unittest tests.test_repository_automation_common -v` — 6/6 pass
- `make lint-errors` — no violations
- `trunk check --upstream` — no new issues

## Security

No security impact. The `tag_exists()` MCP placeholder removal is a security improvement — the unconditional `return True` would have bypassed tag validation if `USE_MCP_GITHUB` were ever enabled.

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [ ] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

Closes ABH-905

Link to Devin session: https://app.devin.ai/sessions/7276aa57af8a4a1d9730efcfc55ec9e3
Requested by: @abhimehro