### PR TITLE
security(ABHI-950): Security remediation master tracker and CWE-1236 hardening

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python Environment
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Development Partner Session
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           REQUEST: ${{ github.event.inputs.request }}
         with:
@@ -53,7 +53,7 @@ jobs:
 
       - name: PR Review Assistant
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/docs/SECURITY_PATTERNS.md
+++ b/docs/SECURITY_PATTERNS.md
@@ -10,6 +10,7 @@ This document outlines security patterns and defensive coding practices used thr
 4. [Command Injection Prevention](#command-injection-prevention)
 5. [Path Traversal Protection](#path-traversal-protection)
 6. [Credential Security](#credential-security)
+7. [Spreadsheet Formula Injection](#spreadsheet-formula-injection)
 
 ---
 
@@ -327,6 +328,38 @@ source /etc/app/secrets.env
 3. **Avoid command-line args**: Never pass secrets via CLI flags
 4. **Restrict config files**: Ensure secret files are mode 600
 5. **Mask in logs**: Use `::add-mask::` in GitHub Actions
+
+---
+
+## Spreadsheet Formula Injection
+
+### Problem: [CWE-1236](https://cwe.mitre.org/data/definitions/1236.html) - Improper Neutralization of Formula Elements in CSV Files
+
+When tabular exports (CSV, or markdown tables copied into Excel) contain attacker-controlled text that begins with `=`, `+`, `-`, `@`, tab, or carriage return, spreadsheet software may interpret the cell as a formula and reach out to external resources or execute logic.
+
+### Vulnerable Pattern ❌
+
+```python
+# BAD: PR title from GitHub API written directly into a report row
+writer.writerow([pr["title"], pr["author"]["login"]])
+```
+
+### Secure Pattern ✅
+
+```python
+from spreadsheet_safety import escape_spreadsheet_formula
+
+writer.writerow([
+    escape_spreadsheet_formula(pr["title"]),
+    escape_spreadsheet_formula(pr["author"]["login"]),
+])
+```
+
+**Key principles:**
+
+1. Treat all GitHub metadata (titles, branch names, labels) as untrusted.
+2. Escape before writing any export that may be opened in a spreadsheet.
+3. Prefer `csv.writer` with proper quoting; still prefix dangerous leading characters.
 
 ---
 

--- a/handoff.md
+++ b/handoff.md
@@ -1,39 +1,31 @@
-# ELIR Handoff - 2026-03-09
+# ELIR Handoff — ABHI-950 Security Remediation Master Tracker (2026-05-24)
 
 ## Purpose
 
-This change repairs the PR-review session preflight so it can safely read repository lists from `tasks/pr-review-agent.config.yaml`, then refreshes the session artifacts for today's automated bot-PR triage run. The resulting inventory and triage docs capture the current queue, the blocking security findings, and the one merge-ready PR that remains unexecuted because this environment does not expose GitHub write tooling for other repositories.
+This batch establishes a living security remediation status board for Linear **ABHI-950**, closes two concrete gaps called out on the master issue (CWE-94 supply-chain follow-up on `copilot-setup-steps.yml` and CWE-1236 formula injection in PR inventory exports), and links them to the existing May remediation plan.
 
 ## Security
 
-- The preflight parser now scans only the top-level `repos:` list and stops at the next top-level key, which prevents later YAML lists like `bot_authors:` from being misread as repository targets.
-- The triage artifacts explicitly block merging PRs that unpin workflow actions or reduce scan coverage, preserving the repo's supply-chain and review-depth safeguards.
-- Trust boundary reminder: GitHub bodies, comments, labels, checks, and diffs are treated as untrusted data and only used after explicit validation.
+- **CWE-94 / supply chain:** `copilot-setup-steps.yml` now pins `actions/setup-python` and `actions/github-script` to immutable commit SHAs (workflow already bound `workflow_dispatch` input via env for script injection).
+- **CWE-1236 / formula injection:** `spreadsheet_safety.escape_spreadsheet_formula()` neutralizes attacker-controlled PR titles, branch names, and author logins before they are written into `tasks/pr-inventory.md` tables that may be opened in Excel.
+- **Trust boundary:** GitHub PR/issue metadata is treated as untrusted in export paths.
 
 ## Failure Modes
 
-| Condition                                                      | Consequence                                                     | Mitigation                                                                                               |
-| -------------------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Config parser regresses again                                  | Preflight aborts before triage, or worse, scans the wrong repos | `tests/test_preflight_gh_pr_automation.sh` now includes a config-loading regression case                 |
-| Jules keeps disguising authorship via delegated human accounts | Bot PRs are missed during inventory                             | Inventory/triage now rely on the Jules footer plus the `google-labs-jules` bootstrap comment             |
-| Test-only PRs include workflow/security churn                  | Unsafe CI changes could slip through under a benign title       | Today's triage docs treat workflow unpinning and scanner-scope reduction as security blockers            |
-| Reviewer assumes `MERGE` means already merged                  | Queue state becomes ambiguous                                   | `tasks/pr-inventory.md` and `tasks/pr-triage.md` explicitly distinguish disposition from executed action |
+| Condition | Consequence | Mitigation |
+| --- | --- | --- |
+| New export script skips escaping | Formula injection if malicious PR title is merged | Reuse `spreadsheet_safety`; add test cases for new exporters |
+| Tracker drifts from reality | False sense of completion on ABHI-950 | Update `tasks/SECURITY_REMEDIATION_TRACKER.md` when closing Linear sub-tasks |
+| P0 credential rotation deferred | Live tokens remain valid after exposure | Operator checklist in tracker (manual) |
 
 ## Review Checklist
 
-- [ ] Confirm `bash tests/test_preflight_gh_pr_automation.sh` still passes.
-- [ ] Confirm `bash scripts/run-pr-review-session.sh --config tasks/pr-review-agent.config.yaml` still passes.
-- [ ] Review `tasks/pr-triage.md` to verify the escalations for `[REDACTED]-config#626` and `#627` match the evidence.
-- [ ] Review `tasks/pr-review-2026-03-09.md` to verify the documented blocker about missing GitHub write tooling is acceptable for this automation run.
+- [ ] Read `tasks/SECURITY_REMEDIATION_TRACKER.md` and confirm P0–P3 statuses match your Linear sub-issues.
+- [ ] Run `python3 -m unittest tests.test_spreadsheet_safety tests.test_scratch_inventory`.
+- [ ] Confirm `copilot-setup-steps.yml` action SHAs match intended `v6.2.0` / `v9.0.0` releases.
+- [ ] Spot-check a generated `tasks/pr-inventory.md` row whose title starts with `=` — cell should show a leading `'` in the Notes column.
 
 ## Maintenance
 
-- If the session environment later gains GitHub write tooling, the first operational step should be to execute the documented merge command for `ctrld-sync#628` and then re-run inventory because the queue may have changed.
-- Keep the delegated-author heuristic in sync with Jules behavior; if Jules changes either the footer format or bootstrap comment, inventory detection will need a follow-up update.
-- Do not weaken the workflow-pin review standard: mutable action tags in bot PRs are currently the highest-risk false-positive pattern for "small test fix" tasks.
-  ═════ ELIR ═════
-  PURPOSE: Extracted smaller helper functions out of the monolithic `monitor_controld` function in `maintenance/controld_monitor.sh`.
-  SECURITY: Maintained exact same process calls, checks, log targets, and return values.
-  FAILS IF: If any variables were incorrectly bound to parent shell scope (which none were, they were explicitly re-declared or simply returned error codes for orchestration).
-  VERIFY: Verify the original function flow matches the new flow and that log outputs are unchanged in normal circumstances.
-  MAINTAIN: New `verify_*` functions should return `0` (success) or `1` (failure) to feed into the `all_checks_passed` orchestration. Some don't fail the whole check (like upstream connectivity or mdns), these were preserved exactly.
+- Master tracker path: `tasks/SECURITY_REMEDIATION_TRACKER.md` (link from Linear ABHI-950).
+- Remaining P1 supply-chain work: `rg 'uses:.*@v[0-9]' .github/workflows` — many Gemini workflows are ratcheted; `code-quality.yml` / automation workflows still use version tags.

--- a/scratch_inventory.py
+++ b/scratch_inventory.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 from collections import defaultdict
 
+from spreadsheet_safety import escape_spreadsheet_formula
+
 
 def fetch_prs(repos):
     all_prs = []
@@ -74,8 +76,13 @@ def generate_markdown(all_prs):
         conflicts = "yes" if pr["mergeStateStatus"] == "DIRTY" else "none"
         date_str = pr.get("createdAt", datetime.date.today().isoformat())[:10]
 
+        # SECURITY: PR metadata is untrusted; escape formula injection if the
+        # inventory table is opened in Excel/Sheets (CWE-1236).
+        author = escape_spreadsheet_formula(pr["author"]["login"])
+        branch = escape_spreadsheet_formula(pr["headRefName"])
+        title = escape_spreadsheet_formula(pr["title"])
         out_md.append(
-            f"| {pr['repo']} | {pr['number']} | {pr['author']['login']} | {pr['headRefName']} | {cat} | {ci} | {conflicts} | {date_str} | {pr['title']} |"
+            f"| {pr['repo']} | {pr['number']} | {author} | {branch} | {cat} | {ci} | {conflicts} | {date_str} | {title} |"
         )
     return out_md
 

--- a/spreadsheet_safety.py
+++ b/spreadsheet_safety.py
@@ -1,0 +1,21 @@
+"""Defenses against spreadsheet formula injection in exported tabular data."""
+
+from __future__ import annotations
+
+# SECURITY: Values starting with these characters may execute as formulas when a
+# markdown/CSV table is opened in Excel, LibreOffice Calc, or Google Sheets
+# (CWE-1236). Prefix with a single quote to force literal interpretation.
+_FORMULA_PREFIX_CHARS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def escape_spreadsheet_formula(value: str) -> str:
+    """Return *value* safe for spreadsheet cells sourced from untrusted text.
+
+    PR titles, branch names, and author logins are attacker-influenceable via
+    GitHub and must not be emitted into inventory tables without escaping.
+    """
+    if not value:
+        return value
+    if value[0] in _FORMULA_PREFIX_CHARS:
+        return "'" + value
+    return value

--- a/tasks/SECURITY_REMEDIATION_TRACKER.md
+++ b/tasks/SECURITY_REMEDIATION_TRACKER.md
@@ -1,0 +1,100 @@
+# Security Remediation Master Tracker (ABHI-950)
+
+**Linear:** [ABHI-950](https://linear.app/abhis-space/issue/ABHI-950/security-remediation-master-tracker)  
+**Project:** Security Remediation Sprint  
+**Last updated:** 2026-05-24  
+**Source plan:** [`tasks/security-remediation-plan-2026-05-01.md`](security-remediation-plan-2026-05-01.md)
+
+This document is the repo-local status board for cross-cutting security work. Sub-issues in Linear should link here; update checkboxes when evidence lands on `main`.
+
+## Theme status
+
+| Theme | CWE / class | Repo scope | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| GitHub Actions script injection | CWE-94 | `personal-config` | **Mitigated** | `copilot-setup-steps.yml` binds `workflow_dispatch` input via `REQUEST` env; Gemini workflows use env binding |
+| Spreadsheet formula injection | CWE-1236 | `personal-config` | **Mitigated** | `spreadsheet_safety.escape_spreadsheet_formula()` used by `scratch_inventory.py` |
+| Command injection (shell) | CWE-78 | `personal-config` | **Mostly mitigated** | PR automation uses argv lists (`tests/test_vulnerability_fix.py`); mole/maintenance eval hardening ongoing |
+| Supply-chain (unpinned actions) | — | `personal-config` | **In progress** | Many workflows ratcheted; `copilot-setup-steps.yml` pinned in this batch |
+| Credential exposure | CWE-214 | `personal-config` | **In progress** | WebDAV examples use env placeholders; rotation is manual (P0) |
+
+## P0–P3 checklist (personal-config)
+
+### P0 — Rotate live credentials (manual)
+
+- [x] Remove committed WebDAV password examples (`${MEDIA_WEBDAV_PASS}` placeholders)
+- [ ] Rotate/revoke exposed GitHub PAT (local `GH_TOKEN.env`, not tracked)
+- [ ] Rotate WebDAV password in 1Password / media-server config
+- [ ] Decide whether git history purge is required for old WebDAV secret
+
+**Verify:** `trufflehog filesystem . --only-verified` reports no verified secrets.
+
+### P1 — GitHub Actions supply chain
+
+- [x] `permissions: contents: read` on mac-audit / shellcheck workflows
+- [x] Pin `actions/checkout` on key workflows
+- [x] Pin `actions/setup-python` + `actions/github-script` on `copilot-setup-steps.yml` (2026-05-24)
+- [ ] Pin remaining `uses: owner/action@vN` references repo-wide (see `rg 'uses:.*@v[0-9]' .github/workflows`)
+- [ ] Pin MCP Docker images to digests
+- [ ] Fix malformed artifact action versions in automation workflows
+- [ ] Add consistent `retention-days` on artifacts
+
+**Verify:** `actionlint .github/workflows/*.yml` passes.
+
+### P1 — Docker / dependency reproducibility
+
+- [x] Remove broad passwordless sudo from Dockerfile
+- [x] Healthcheck fails when `network-mode-manager.sh` missing
+- [ ] Pin `ubuntu:24.04` to digest
+- [ ] Resolve `copilot-demo` single lockfile strategy (npm vs pnpm)
+
+### P1 — Hardcoded personal paths
+
+- [x] Replace active AdGuard / MCP / windscribe hardcoded paths
+- [ ] CI guard blocking new `/Users/<name>/` outside allowlisted archives
+
+### P2 — Symlink / launchd hardening
+
+- [ ] Symlink ownership checks in config sync
+- [ ] Post-create symlink verification
+- [ ] LaunchAgent hardening keys (`StandardInputPath`, `ProcessType`, etc.)
+
+### P2 — Maintenance safety
+
+- [ ] `--dry-run` on destructive cleanup paths
+- [ ] Validate sourced config ownership before `source`
+- [ ] Replace `eval` trap restoration where feasible (`smart_scheduler.sh`, `performance_optimizer.sh`)
+
+### P2 — Media credential handling
+
+- [x] No hardcoded `curl -u user:pass` in docs
+- [ ] `umask 0077` before credential file creation (audit media scripts)
+- [ ] Prefer env / 1Password over CLI credential flags for rclone
+
+### P3 — AdGuard robustness
+
+- [ ] JSON schema validation before nested key access
+- [ ] Source-list license attribution in generated lists
+
+## Cross-repo items (tracked in Linear, implemented elsewhere)
+
+| Item | Repo | Notes |
+| --- | --- | --- |
+| CWE-94 `workflow_dispatch` hardening | `email-security-pipeline` | See PR #881 in session notes |
+| Broader Sentinel automation | multiple | Salvage branches under `cursor-agent/salvage-*` |
+
+## Verification commands (this repo)
+
+```bash
+make test-quick
+make lint-errors
+python3 -m unittest tests.test_spreadsheet_safety tests.test_vulnerability_fix tests.test_scratch_inventory
+rg 'uses:.*@v[0-9]' .github/workflows --glob '*.yml' | rg -v 'ratchet:|# v'
+```
+
+## Change log
+
+| Date | Change | PR / commit |
+| --- | --- | --- |
+| 2026-05-01 | Initial remediation plan | `tasks/security-remediation-plan-2026-05-01.md` |
+| 2026-05-19 | CWE-94 fix in `copilot-setup-steps.yml` | #980 |
+| 2026-05-24 | Master tracker + formula injection + pin copilot workflow actions | (this batch) |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,16 @@
+# ABHI-950 Security Remediation Master Tracker — 2026-05-24
+
+- [x] Publish repo-local master tracker: `tasks/SECURITY_REMEDIATION_TRACKER.md`
+- [x] CWE-1236: `spreadsheet_safety.escape_spreadsheet_formula()` + `scratch_inventory.py` hardening
+- [x] Supply chain: pin `actions/setup-python` / `actions/github-script` SHAs on `copilot-setup-steps.yml`
+- [x] Document CWE-1236 pattern in `docs/SECURITY_PATTERNS.md`
+- [x] Regression tests: `tests/test_spreadsheet_safety.py`
+- [ ] P0 manual credential rotation (operator)
+- [ ] P1 repo-wide workflow action SHA pinning (remaining `@vN` uses)
+- [ ] P2 symlink/launchd + maintenance `--dry-run` items (see tracker)
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.

--- a/tests/test_scratch_inventory.py
+++ b/tests/test_scratch_inventory.py
@@ -5,7 +5,7 @@ import os
 # Ensure the project root is in the path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scratch_inventory import get_category
+from scratch_inventory import generate_markdown, get_category
 
 class TestScratchInventory(unittest.TestCase):
     def test_get_category_security(self):
@@ -49,6 +49,24 @@ class TestScratchInventory(unittest.TestCase):
         self.assertEqual(get_category("Add new widget", "main"), "FEATURE")
         self.assertEqual(get_category("Implement dark mode", "feature/dark-mode"), "FEATURE")
         self.assertEqual(get_category("", ""), "FEATURE")
+
+    def test_generate_markdown_escapes_formula_injection(self):
+        prs = [
+            {
+                "repo": "personal-config",
+                "number": 1,
+                "author": {"login": "+evil"},
+                "headRefName": "=branch",
+                "title": "=HYPERLINK(\"http://evil\")",
+                "mergeStateStatus": "CLEAN",
+                "createdAt": "2026-05-24T00:00:00Z",
+            }
+        ]
+        md = "\n".join(generate_markdown(prs))
+        self.assertIn("'+evil", md)
+        self.assertIn("'=branch", md)
+        self.assertIn("'=HYPERLINK", md)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spreadsheet_safety.py
+++ b/tests/test_spreadsheet_safety.py
@@ -1,0 +1,35 @@
+"""Regression tests for spreadsheet formula injection defenses (CWE-1236)."""
+
+import unittest
+
+from spreadsheet_safety import escape_spreadsheet_formula
+
+
+class TestSpreadsheetSafety(unittest.TestCase):
+    def test_escapes_formula_prefixes(self) -> None:
+        cases = (
+            ("=1+1", "'=1+1"),
+            ("+cmd", "'+cmd"),
+            ("-2+3", "'-2+3"),
+            ("@SUM(A1)", "'@SUM(A1)"),
+            ("\tcmd", "'\tcmd"),
+            ("\rcmd", "'\rcmd"),
+        )
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(escape_spreadsheet_formula(raw), expected)
+
+    def test_leaves_safe_values_unchanged(self) -> None:
+        self.assertEqual(escape_spreadsheet_formula("normal title"), "normal title")
+        self.assertEqual(escape_spreadsheet_formula(""), "")
+        self.assertEqual(escape_spreadsheet_formula("feature/foo"), "feature/foo")
+
+    def test_malicious_pr_title_vector(self) -> None:
+        malicious = '=HYPERLINK("http://evil.example","click")'
+        escaped = escape_spreadsheet_formula(malicious)
+        self.assertTrue(escaped.startswith("'"))
+        self.assertIn("HYPERLINK", escaped)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Advances Linear **ABHI-950** (Security Remediation Master Tracker) with a repo-local status board plus two concrete fixes called out on the master issue: spreadsheet formula injection in PR inventory exports and supply-chain pinning on the Copilot setup workflow.

## Changes

### Master tracker
- Added [`tasks/SECURITY_REMEDIATION_TRACKER.md`](tasks/SECURITY_REMEDIATION_TRACKER.md) — living checklist for CWE-94, CWE-1236, and P0–P3 items from [`tasks/security-remediation-plan-2026-05-01.md`](tasks/security-remediation-plan-2026-05-01.md).
- Updated [`tasks/todo.md`](tasks/todo.md) with ABHI-950 completion notes.

### CWE-1236 — Formula injection
- New [`spreadsheet_safety.py`](spreadsheet_safety.py) with `escape_spreadsheet_formula()`.
- [`scratch_inventory.py`](scratch_inventory.py) escapes untrusted PR title, branch, and author fields before writing inventory tables.
- Documented pattern in [`docs/SECURITY_PATTERNS.md`](docs/SECURITY_PATTERNS.md).
- Tests: [`tests/test_spreadsheet_safety.py`](tests/test_spreadsheet_safety.py), extended [`tests/test_scratch_inventory.py`](tests/test_scratch_inventory.py).

### Supply chain (CWE-94 follow-up)
- Pinned `actions/setup-python@a309ff8b…` and `actions/github-script@d746ffe3…` on [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml) (env-var binding for `workflow_dispatch` was already merged in #980).

## Verification

```bash
python3 -m unittest tests.test_spreadsheet_safety tests.test_scratch_inventory
make test-quick
```

## Reviewer notes

- **P0 credential rotation** remains manual — see tracker checklist.
- **Remaining P1** work: repo-wide pinning of other `@vN` workflow actions (`rg 'uses:.*@v[0-9]' .github/workflows`).

## ELIR

**Purpose:** Centralize remediation status for ABHI-950 and close formula-injection + copilot workflow pinning gaps in this repo.

**Security:** Treats GitHub PR metadata as untrusted in exports; reduces supply-chain drift on the Copilot workflow.

**Fails if:** New exporters skip `spreadsheet_safety`, or the tracker is not updated when Linear sub-tasks close.

**Verify:** Malicious PR title `=HYPERLINK(...)` appears with a leading `'` in generated inventory markdown.

**Maintain:** Link Linear ABHI-950 to `tasks/SECURITY_REMEDIATION_TRACKER.md`; reuse `escape_spreadsheet_formula()` for any future CSV/Excel exports.

Linear: ABHI-950
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-950](https://linear.app/abhis-space/issue/ABHI-950/security-remediation-master-tracker)

<div><a href="https://cursor.com/agents/bc-87e0c855-a060-47a3-bd8a-806923bab4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e0c855-a060-47a3-bd8a-806923bab4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

