### PR TITLE
fix(security): copilot-setup-steps env binding (CWE-94)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      # SECURITY: bind untrusted workflow_dispatch input via step env (REQUEST),
+      # not direct interpolation inside actions/github-script `script:` blocks.
+      # Same env-var pattern as summary.yml (issue #892); CWE-94 / ABHI-963.
       - name: Development Partner Session
         uses: actions/github-script@v9.0.0
         env:
@@ -41,11 +44,6 @@ jobs:
             console.log('Repository:', context.repo.owner + '/' + context.repo.repo);
             console.log('Event:', context.eventName);
 
-            // SECURITY: bind untrusted workflow_dispatch input via env var to
-            // prevent script injection (CWE-94).  Direct interpolation of
-            // github.event.inputs.request into a JS string literal allows
-            // an attacker to break out of the quotes and execute arbitrary
-            // code.  See: github/codeql-action advisories.
             const request = process.env.REQUEST || '';
             if (request) {
               console.log('Request:', request);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Confirms and documents the CWE-94 fix in `.github/workflows/copilot-setup-steps.yml`: `workflow_dispatch` input is bound to a step-level `REQUEST` env var and read via `process.env.REQUEST`, matching the pattern in `summary.yml`.

## Why

Tracks script-injection hardening for the Development Partner workflow. The functional fix landed in #980; this PR adds step-level SECURITY documentation aligned with `summary.yml` (#892) for audit traceability.

## How

- **Before (vulnerable):** `const request = '${{ github.event.inputs.request }}';` inside `actions/github-script` `script:` — attacker-controlled input could break out of the JS string literal.
- **After (secure):** step `env.REQUEST` + `process.env.REQUEST || ''` in the script block.
- **This PR:** moves the SECURITY rationale to YAML comments above the step (same style as `summary.yml`) and removes the duplicated in-script comment block.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml'))"` — YAML parses cleanly.
- Verified no `${{ github.event.inputs.request }}` remains inside the `script:` block.

## Security

**Threat:** CWE-94 script injection via malicious `workflow_dispatch` input breaking out of interpolated JS string literals on the Actions runner (with `GITHUB_TOKEN` scopes: contents:read, pull-requests:write, issues:write).

**Mitigation:** Env-var binding at step level; read via `process.env` inside github-script. No direct `${{ }}` interpolation of untrusted input in executable script context.

---

## ELIR Handoff

**PURPOSE:** Prevent script injection when logging optional `workflow_dispatch` request input in the Development Partner workflow.

**SECURITY:** Binds untrusted input to `REQUEST` env var instead of interpolating into JS — prevents quote-breakout / arbitrary code execution on the runner.

**FAILS IF:** Someone re-introduces `${{ github.event.inputs.request }}` (or similar) inside the `script:` block or a comment that GitHub Actions re-evaluates.

**VERIFY:** Grep the workflow for `inputs.request` — should appear only in the step `env:` block, not in `script:`.

**MAINTAIN:** Follow the `summary.yml` pattern for any new untrusted workflow inputs used in `run:` or `github-script` steps.

---

## Checklist

- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated (YAML SECURITY comment)
- [x] Branch name follows convention
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-963](https://linear.app/abhis-space/issue/ABHI-963/fix-copilot-setup-stepsyml-bind-input-to-env-variable)

<div><a href="https://cursor.com/agents/bc-79d7e460-95e2-43f4-bce3-0c08b24e3126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d7e460-95e2-43f4-bce3-0c08b24e3126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

