### PR TITLE
test(security): verify workflow CWE-94 fixes match summary.yml pattern (ABHI-955)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,10 +42,11 @@ jobs:
             console.log('Event:', context.eventName);
 
             // SECURITY: bind untrusted workflow_dispatch input via env var to
-            // prevent script injection (CWE-94).  Direct interpolation of
-            // github.event.inputs.request into a JS string literal allows
-            // an attacker to break out of the quotes and execute arbitrary
-            // code.  See: github/codeql-action advisories.
+            // prevent script injection (CWE-94). Same pattern as summary.yml
+            // (issue #892): never interpolate attacker-influenceable values into
+            // executable blocks. Direct interpolation of github.event.inputs.request
+            // into a JS string literal allows breaking out of quotes and running
+            // arbitrary code with GITHUB_TOKEN. See github/codeql-action advisories.
             const request = process.env.REQUEST || '';
             if (request) {
               console.log('Request:', request);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,12 @@
+# ABHI-955 — Verify workflow remediation matches summary.yml pattern — 2026-05-24
+
+- [x] Document reference pattern in `summary.yml` (env binding + quoted shell / `process.env`)
+- [x] Extend `tests/test_summary_workflow.py` to assert `copilot-setup-steps.yml` (#980) matches reference
+- [x] Assert all `gemini-*.yml` workflows use the same model (no `${{ }}` in `run`/`script` bodies)
+- [x] Run `python3 tests/test_summary_workflow.py` — all checks pass
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.
@@ -135,5 +144,4 @@ _(Blocked by Section 1: Proceed only after fetching actionable log data)_
 - **Supply-Chain Hardening:** Pinning `release-drafter` to an immutable commit SHA prevents injection via compromised mutable tags.
 - **Least-Privilege Authorization:** The `release-drafter.yml` workflow will be explicitly constrained to `permissions: { contents: write }` (no pull-request write vectors).
 - **Assumptions:** The `run-pr-review-session.sh` enforces hard boundaries. No autonomous merges of code failing _Security Gate 2_ (as defined in `docs/automated-pr-review-agent.md`) will be permitted. _Zero-diff / superseded_ heuristic rules (also defined in `docs/automated-pr-review-agent.md`) will govern closure rationale.
-
 

--- a/tests/test_summary_workflow.py
+++ b/tests/test_summary_workflow.py
@@ -1,150 +1,223 @@
 #!/usr/bin/env python3
-"""Test script for summary.yml workflow security validation."""
+"""Static security checks for GitHub Actions untrusted-input handling.
 
+Validates the CWE-94 mitigation pattern from ``summary.yml`` (lines 28-33):
+
+1. Bind attacker-influenceable values in an ``env:`` block (not in ``run:`` / script).
+2. Reference them only via quoted shell variables or ``process.env.*`` in JS.
+3. Never interpolate ``${{ ... }}`` directly inside executable blocks.
+
+Also verifies ``copilot-setup-steps.yml`` (#980) and all ``gemini-*.yml`` workflows
+use the same binding model as the reference implementation.
+"""
+
+from __future__ import annotations
+
+import re
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 
-def read_file(path):
-    with open(path) as f:
-        return f.read()
+_STEP_SPLIT = re.compile(r"^      - name:\s*(.+?)\s*$", re.MULTILINE)
+def _extract_indented_block(step_content: str, block_kind: str) -> str:
+    """Extract the body of a ``run:`` or ``script:`` folded scalar in a step."""
+    header = re.search(rf"^(\s+){block_kind}:\s*(?:\|-|\|)\s*$", step_content, re.MULTILINE)
+    if not header:
+        raise AssertionError(f"{block_kind} block not found in step")
 
-
-def main():
-    filepath = Path(".github/workflows/summary.yml")
-    content = read_file(filepath)
-
-    # Test 1: YAML Parseability (basic check)
-    print("=== TEST 1: YAML Parseability ===")
-    if "name: Summarize new issues" not in content:
-        print("✗ Workflow name not found")
-        return 1
-    if "jobs:" not in content:
-        print("✗ jobs key not found")
-        return 1
-    print("✓ Basic YAML structure valid")
-
-    # Test 2: Expected step name and location
-    print("\n=== TEST 2: Step Exists ===")
-    if "Comment with AI summary" not in content:
-        print("✗ Step 'Comment with AI summary' not found")
-        return 1
-    print("✓ Step 'Comment with AI summary' exists")
-
-    # Extract the step block (between "Comment with AI summary" and next "- name:" or end)
-    step_start = content.find("- name: Comment with AI summary")
-    if step_start == -1:
-        print("✗ Could not find step start")
-        return 1
-
-    # Find the next step or end of steps
-    next_step = content.find("\n      - name:", step_start + 1)
-    step_end = content.find("\n    steps:", step_start + 1)
-    if step_end == -1:
-        step_end = len(content)
-    if next_step != -1 and next_step < step_end:
-        step_end = next_step
-
-    step_content = content[step_start:step_end]
-    print(f"  Step content preview: {repr(step_content[:200])}")
-
-    # Test 3: Expected env scope
-    print("\n=== TEST 3: Env Scope ===")
-    if "env:" not in step_content:
-        print("✗ No env block in step")
-        return 1
-    if "RESPONSE:" not in step_content:
-        print("✗ RESPONSE not in env")
-        return 1
-    if "GH_TOKEN:" not in step_content:
-        print("✗ GH_TOKEN not in env")
-        return 1
-    if "ISSUE_NUMBER:" not in step_content:
-        print("✗ ISSUE_NUMBER not in env")
-        return 1
-    print("✓ RESPONSE, GH_TOKEN, ISSUE_NUMBER all in env")
-
-    # Test 4: Secret handling
-    print("\n=== TEST 4: Secret Handling ===")
-    if "secrets.GITHUB_TOKEN" not in step_content:
-        print("✗ secrets.GITHUB_TOKEN not found")
-        return 1
-    print("✓ GH_TOKEN uses secrets.GITHUB_TOKEN")
-
-    # Test 5: RESPONSE binding
-    print("\n=== TEST 5: Untrusted Output Binding ===")
-    if "steps.inference.outputs.response" not in step_content:
-        print("✗ steps.inference.outputs.response not found")
-        return 1
-    print("✓ RESPONSE bound to ${{ steps.inference.outputs.response }}")
-
-    # Test 6-8: Shell run block analysis
-    print("\n=== TESTS 6-8: Shell Run Block Analysis ===")
-
-    # Find run block
-    run_start = step_content.find("run: |")
-    if run_start == -1:
-        print("✗ run block not found")
-        return 1
-
-    run_block = step_content[run_start:]
-    # Get the actual command
-    lines = run_block.split("\n")
-    command_lines = []
-    for line in lines[1:]:  # Skip "run: |" line
-        stripped = line.strip()
-        if stripped.startswith("#") or not stripped:
+    body_indent = len(header.group(1)) + 2
+    start = header.end()
+    lines: list[str] = []
+    for line in step_content[start:].splitlines(keepends=True):
+        if line.strip() == "":
+            lines.append(line)
             continue
-        if stripped.startswith("gh"):
-            command_lines.append(stripped)
+        leading = len(line) - len(line.lstrip(" "))
+        if leading < body_indent:
+            break
+        lines.append(line)
+    return "".join(lines)
 
-    command = " ".join(command_lines)
-    print(f"  Command: {command}")
 
-    # Check for direct interpolation in run block
-    if "${{" in run_block:
-        print("✗ Direct interpolation found in run block")
-        return 1
-    print("✓ No direct ${{ }} interpolation in run block")
+def read_workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
 
-    if "$RESPONSE" not in run_block:
-        print("✗ $RESPONSE not used in run block")
-        return 1
-    print("✓ $RESPONSE is used in run block")
+
+def _normalize_step_name(name: str) -> str:
+    return name.strip().strip('"').strip("'")
+
+
+def iter_steps(content: str) -> list[tuple[str, str]]:
+    """Yield (step_name, step_yaml_fragment) for each step under ``steps:``."""
+    matches = list(_STEP_SPLIT.finditer(content))
+    steps: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        steps.append((_normalize_step_name(match.group(1)), content[match.start() : end]))
+    return steps
+
+
+def extract_step(content: str, step_name: str) -> str:
+    target = _normalize_step_name(step_name)
+    for name, fragment in iter_steps(content):
+        if name == target:
+            return fragment
+    raise AssertionError(f"step not found: {step_name!r}")
+
+
+def extract_run_block(step_content: str) -> str:
+    return _extract_indented_block(step_content, "run")
+
+
+def extract_github_script_block(step_content: str) -> str:
+    return _extract_indented_block(step_content, "script")
+
+
+def assert_no_expression_delimiters_in_executable(executable: str, context: str) -> None:
+    if "${{" in executable:
+        raise AssertionError(f"${{ }} interpolation in executable block: {context}")
+
+
+_UNTRUSTED_ENV_MARKERS = (
+    "github.event",
+    "inputs.",
+    "outputs.",
+    "needs.",
+    "steps.",
+)
+
+
+def step_binds_untrusted_env(step: str) -> bool:
+    """True when the step env block carries workflow/event-derived values."""
+    env_start = step.find("env:")
+    if env_start == -1:
+        return False
+    env_end = step.find("\n        uses:", env_start)
+    if env_end == -1:
+        env_end = step.find("\n        with:", env_start)
+    if env_end == -1:
+        env_end = len(step)
+    env_block = step[env_start:env_end]
+    return any(marker in env_block for marker in _UNTRUSTED_ENV_MARKERS)
+
+
+def test_summary_yml_reference_pattern() -> None:
+    """Reference implementation: summary.yml Comment with AI summary step."""
+    content = read_workflow("summary.yml")
+    step = extract_step(content, "Comment with AI summary")
+
+    if "env:" not in step:
+        raise AssertionError("env block missing")
+    for key in ("RESPONSE", "GH_TOKEN", "ISSUE_NUMBER"):
+        if f"{key}:" not in step:
+            raise AssertionError(f"{key} missing from env")
+
+    if "steps.inference.outputs.response" not in step:
+        raise AssertionError("RESPONSE must bind steps.inference.outputs.response")
+
+    if "secrets.GITHUB_TOKEN" not in step:
+        raise AssertionError("GH_TOKEN must use secrets.GITHUB_TOKEN")
+
+    run_block = extract_run_block(step)
+    assert_no_expression_delimiters_in_executable(run_block, "summary.yml run block")
 
     if '"$RESPONSE"' not in run_block:
-        print("✗ $RESPONSE not properly quoted")
-        return 1
-    print("✓ $RESPONSE is properly quoted")
+        raise AssertionError('run block must pass RESPONSE as a quoted shell arg')
 
-    # Test 9: Token permissions (check at job level)
-    print("\n=== TEST 9: Token Permissions ===")
     job_start = content.find("summary:")
     job_end = content.find("\n  steps:", job_start)
-    job_content = content[job_start:job_end]
+    job = content[job_start:job_end]
+    if "permissions:" not in job or "issues: write" not in job:
+        raise AssertionError("summary job must declare issues: write")
+    if "admin" in job:
+        raise AssertionError("summary job must not grant admin permissions")
 
-    if "permissions:" not in job_content:
-        print("✗ No permissions block in job")
+
+def test_copilot_setup_steps_matches_summary_pattern() -> None:
+    """copilot-setup-steps.yml (#980) must mirror summary.yml env binding for JS."""
+    content = read_workflow("copilot-setup-steps.yml")
+    step = extract_step(content, "Development Partner Session")
+
+    if "uses: actions/github-script" not in step:
+        raise AssertionError("Development Partner Session must use github-script")
+
+    if "REQUEST:" not in step or "github.event.inputs.request" not in step:
+        raise AssertionError("REQUEST must be bound from github.event.inputs.request in env")
+
+    script = extract_github_script_block(step)
+    assert_no_expression_delimiters_in_executable(script, "copilot-setup-steps script")
+
+    if "process.env.REQUEST" not in script:
+        raise AssertionError("script must read REQUEST via process.env.REQUEST")
+
+    if re.search(r"['\"]?\$\{\{\s*github\.event\.inputs\.request", script):
+        raise AssertionError("script must not interpolate workflow_dispatch input")
+
+    if "SECURITY:" not in script and "CWE-94" not in script:
+        raise AssertionError("security rationale comment expected in script")
+
+
+def _iter_gemini_workflows() -> list[Path]:
+    return sorted(WORKFLOWS.glob("gemini*.yml"))
+
+
+def test_gemini_workflows_shell_run_blocks() -> None:
+    """Gemini workflows: shell steps must not embed ${{ }} inside run bodies."""
+    for path in _iter_gemini_workflows():
+        content = path.read_text(encoding="utf-8")
+        for step_name, step in iter_steps(content):
+            if "run:" not in step:
+                continue
+            run_body = extract_run_block(step)
+            assert_no_expression_delimiters_in_executable(
+                run_body,
+                f"{path.name} step {step_name!r}",
+            )
+
+
+def test_gemini_workflows_github_script_blocks() -> None:
+    """Gemini github-script steps must use process.env, not inline ${{ }}."""
+    for path in _iter_gemini_workflows():
+        content = path.read_text(encoding="utf-8")
+        for step_name, step in iter_steps(content):
+            if "actions/github-script" not in step:
+                continue
+            script = extract_github_script_block(step)
+            assert_no_expression_delimiters_in_executable(
+                script,
+                f"{path.name} github-script step {step_name!r}",
+            )
+            if step_binds_untrusted_env(step) and "process.env." not in script:
+                raise AssertionError(
+                    f"{path.name} step {step_name!r}: github-script must read env via process.env"
+                )
+
+
+def main() -> int:
+    tests = [
+        ("summary.yml reference pattern", test_summary_yml_reference_pattern),
+        ("copilot-setup-steps.yml matches summary pattern", test_copilot_setup_steps_matches_summary_pattern),
+        ("gemini shell run blocks", test_gemini_workflows_shell_run_blocks),
+        ("gemini github-script blocks", test_gemini_workflows_github_script_blocks),
+    ]
+
+    failed = 0
+    for label, fn in tests:
+        print(f"=== {label} ===")
+        try:
+            fn()
+            print("✓ passed\n")
+        except AssertionError as exc:
+            print(f"✗ {exc}\n")
+            failed += 1
+
+    if failed:
+        print(f"=== {failed} check(s) failed ===")
         return 1
 
-    if "issues: write" not in job_content:
-        print("✗ issues: write not found in permissions")
-        return 1
-    print("✓ issues permission is write")
-
-    # Check for minimal permissions
-    if "contents: read" not in job_content:
-        print("✗ contents: read not found")
-        return 1
-
-    # Make sure no admin permissions
-    if "admin" in job_content:
-        print("✗ Admin permissions found (over-privileged)")
-        return 1
-
-    print("✓ Least-privilege permissions granted")
-
-    print("\n=== All Static Tests Passed ===")
+    print("=== All workflow untrusted-input checks passed ===")
     return 0
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated verification that `copilot-setup-steps.yml` (#980) and all `gemini-*.yml` workflows use the same untrusted-input binding pattern already documented in `summary.yml` (lines 28–33, GitHub issue #892).

## Changes

- **Extended** `tests/test_summary_workflow.py` with automated checks for:
  - `summary.yml` reference step (`Comment with AI summary`)
  - `copilot-setup-steps.yml` (`Development Partner Session` → `process.env.REQUEST`)
  - All Gemini workflows: no `${{ }}` inside `run` / `github-script` bodies; `process.env` when env carries event/output data
- **Aligned** security comment in `copilot-setup-steps.yml` to explicitly reference the `summary.yml` / #892 pattern

## Verification

```bash
python3 tests/test_summary_workflow.py
```

All four check groups pass locally.

## Security (ELIR)

**Purpose:** Regression tests that CWE-94 remediations stay consistent with the canonical `summary.yml` env-binding pattern.

**Security:** Prevents re-introducing direct `${{ }}` interpolation of attacker-influenceable values (LLM output, issue bodies, workflow inputs) into shell or JS executable blocks.

**Fails if:** A workflow step embeds expression syntax inside `run:` or `script:` bodies instead of binding via `env:` first.

**Verify:** Run the test command above after any workflow edit touching Gemini or copilot automation.

**Maintain:** When adding a new workflow that passes untrusted text to `gh` or `github-script`, copy the `env:` + quoted `$VAR` / `process.env.VAR` pattern from `summary.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-955](https://linear.app/abhis-space/issue/ABHI-955/verify-fix-matches-pattern-from-summaryyml)

<div><a href="https://cursor.com/agents/bc-11bcfdb3-0d01-43f3-9d4b-f89c9fa717ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11bcfdb3-0d01-43f3-9d4b-f89c9fa717ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

