### PR TITLE
docs(security): verify ABHI-966 copilot-setup-steps CWE-94 fix

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,12 @@
+# ABHI-966: copilot-setup-steps.yml script injection (CWE-94) — 2026-05-24
+
+- [x] Verify `.github/workflows/copilot-setup-steps.yml` uses `env.REQUEST` + `process.env.REQUEST` (not direct `${{ }}` in `with.script`).
+- [x] Confirm fix landed on `main` via `4972970` / PR #980 (2026-05-19).
+- [x] YAML syntax check passed locally.
+- [x] No code change required — issue already resolved on default branch.
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Linear **ABHI-966** asked to replace direct `${{ github.event.inputs.request }}` interpolation in `.github/workflows/copilot-setup-steps.yml` with the environment-variable pattern to prevent script injection (CWE-94).

That remediation is **already on `main`** (commit `4972970`, PR #980, 2026-05-19). This PR only records verification in `tasks/todo.md`; no workflow file changes.

## Secure pattern (current on `main`)

```yaml
env:
  REQUEST: ${{ github.event.inputs.request }}
with:
  script: |
    const request = process.env.REQUEST || '';
```

**Before (vulnerable):** `const request = '${{ github.event.inputs.request }}';` inside `with.script` — attacker-controlled input could break out of the string literal and run arbitrary JS with `GITHUB_TOKEN` scopes.

## Verification

- [x] No `${{ github.event.inputs.request }}` inside `with.script` (only in `env:` block)
- [x] Security comment avoids `${{ }}` delimiters inside the script block (re-evaluation risk)
- [x] YAML parses locally
- [x] Matches pattern used in `gemini-dispatch.yml` and related workflows

## ELIR

**Purpose:** Close the loop on ABHI-966 by documenting that the CWE-94 fix is present on the default branch.

**Security:** Trust boundary is `workflow_dispatch` input from users with workflow dispatch rights. Env binding prevents expression injection into generated JavaScript.

**Fails if:** Someone reverts to string interpolation inside `github-script` `script:` blocks.

**Verify:** Open `.github/workflows/copilot-setup-steps.yml` on `main` and confirm `process.env.REQUEST` usage.

**Maintain:** Always pass untrusted Actions inputs via `env:` + `process.env`, never embed `${{ }}` inside inline scripts.

## Linear

Resolves ABHI-966
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-966](https://linear.app/abhis-space/issue/ABHI-966/fix-copilot-setup-stepsyml-replace-direct-interpolation-with-env)

<div><a href="https://cursor.com/agents/bc-a78952f5-2e4b-4b39-bece-d0abe6264e0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a78952f5-2e4b-4b39-bece-d0abe6264e0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

