### PR TITLE
test(security): ABHI-929 CWE-94 regression guard for copilot-setup-steps

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,11 @@
+# ABHI-929: CWE-94 script injection in copilot-setup-steps.yml — 2026-05-24
+
+- [x] Confirm PR #980 remediation on `main` (`REQUEST` env + `process.env.REQUEST`).
+- [x] Add static regression test: `tests/test_copilot_setup_steps_workflow.py`.
+- [x] Run regression test locally (pass).
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.

--- a/tests/test_copilot_setup_steps_workflow.py
+++ b/tests/test_copilot_setup_steps_workflow.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Static checks for copilot-setup-steps.yml CWE-94 hardening (ABHI-929)."""
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/copilot-setup-steps.yml")
+STEP_MARKER = "- name: Development Partner Session"
+
+
+def read_workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def extract_step_block(content: str) -> str:
+    start = content.find(STEP_MARKER)
+    if start == -1:
+        raise ValueError(f"Step not found: {STEP_MARKER!r}")
+
+    next_step = content.find("\n      - name:", start + len(STEP_MARKER))
+    end = len(content) if next_step == -1 else next_step
+    return content[start:end]
+
+
+def extract_script_block(step_content: str) -> str:
+    script_match = re.search(r"script:\s*\|\s*\n(.*)", step_content, re.DOTALL)
+    if not script_match:
+        raise ValueError("github-script script block not found")
+    return script_match.group(1)
+
+
+def main() -> int:
+    if not WORKFLOW.is_file():
+        print(f"✗ Missing workflow file: {WORKFLOW}")
+        return 1
+
+    content = read_workflow()
+    step_content = extract_step_block(content)
+    script_block = extract_script_block(step_content)
+
+    print("=== TEST 1: workflow_dispatch request input ===")
+    if "workflow_dispatch:" not in content:
+        print("✗ workflow_dispatch trigger not found")
+        return 1
+    if "request:" not in content:
+        print("✗ request input not defined")
+        return 1
+    print("✓ workflow_dispatch request input present")
+
+    print("\n=== TEST 2: env binding for untrusted input ===")
+    if "env:" not in step_content:
+        print("✗ env block missing on Development Partner Session step")
+        return 1
+    if "REQUEST: ${{ github.event.inputs.request }}" not in step_content:
+        print("✗ REQUEST not bound from github.event.inputs.request")
+        return 1
+    print("✓ REQUEST bound via env")
+
+    print("\n=== TEST 3: script reads env, not interpolated expression ===")
+    if "process.env.REQUEST" not in script_block:
+        print("✗ script does not read process.env.REQUEST")
+        return 1
+    if re.search(
+        r"const\s+request\s*=\s*['\"]\$\{\{\s*github\.event\.inputs\.request",
+        script_block,
+    ):
+        print("✗ vulnerable direct interpolation in JS string literal")
+        return 1
+    if "${{" in script_block:
+        print("✗ expression delimiter found inside github-script script block")
+        return 1
+    print("✓ script uses process.env.REQUEST without inline ${{ }}")
+
+    print("\n=== TEST 4: security documentation ===")
+    if "CWE-94" not in step_content:
+        print("✗ CWE-94 security note missing from step")
+        return 1
+    print("✓ CWE-94 security note present")
+
+    print("\n=== All Static Tests Passed ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **ABHI-929** ([Medium] Script Injection in `copilot-setup-steps.yml`, CWE-94).

The runtime fix was already merged in **#980** on `main`: `workflow_dispatch` `request` is bound to `env.REQUEST` and read via `process.env.REQUEST` in `actions/github-script`, matching `summary.yml` and the Gemini workflows.

This PR adds a **static regression test** so direct `${{ }}` interpolation inside the `github-script` `script:` block cannot be reintroduced.

## Changes

- `tests/test_copilot_setup_steps_workflow.py` — asserts env binding, `process.env.REQUEST` usage, no `${{` in script body, CWE-94 comment present
- `tasks/todo.md` — ABHI-929 verification checklist

## Verification

```bash
python3 tests/test_copilot_setup_steps_workflow.py
```

All four static checks pass.

## ELIR

**Purpose:** Lock in the #980 remediation with an automated guard aligned with `tests/test_summary_workflow.py`.

**Security:** Prevents CWE-94 script injection from returning via `const request = '${{ github.event.inputs.request }}'` in `github-script`.

**Trust boundary:** Untrusted `workflow_dispatch` input must never be embedded in JS source at workflow compile time.

**Review checklist:**
- [ ] Confirm `copilot-setup-steps.yml` still uses `env.REQUEST` + `process.env.REQUEST`
- [ ] Run `python3 tests/test_copilot_setup_steps_workflow.py`

**Maintenance:** Any new `github-script` step that consumes `github.event.inputs.*` must use the same env-var pattern; extend this test if the step name or structure changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-929](https://linear.app/abhis-space/issue/ABHI-929/medium-script-injection-in-copilot-setup-stepsyml-cwe-94)

<div><a href="https://cursor.com/agents/bc-39721e62-ee8e-4247-9df4-0cbde5fdf0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39721e62-ee8e-4247-9df4-0cbde5fdf0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

