### PR TITLE
test(security): CWE-94 regression guard for copilot-setup-steps (ABHI-943)

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,11 @@
+# Security Fix: CWE-94 copilot-setup-steps.yml (ABHI-943) — 2026-05-24
+
+- [x] Confirm remediation on `main` (PR #980): env `REQUEST` + `process.env.REQUEST`
+- [x] Add regression tests in `tests/test_copilot_setup_steps_workflow.py`
+- [x] Run `python3 -m unittest tests.test_copilot_setup_steps_workflow -v`
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.

--- a/tests/test_copilot_setup_steps_workflow.py
+++ b/tests/test_copilot_setup_steps_workflow.py
@@ -1,0 +1,76 @@
+"""Regression tests for CWE-94 in copilot-setup-steps.yml (ABHI-943).
+
+workflow_dispatch inputs must not be interpolated into github-script ``script:``
+blocks as JavaScript string literals. Binding via step ``env:`` and reading
+``process.env`` prevents script injection from breaking out of quotes.
+
+Merged fix: PR #980 (commit 4972970). Related: email-security-pipeline#881.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github/workflows/copilot-setup-steps.yml"
+
+STEP_MARKER = "- name: Development Partner Session"
+VULNERABLE_PATTERN = re.compile(
+    r"const\s+request\s*=\s*['\"]\$\{\{\s*github\.event\.inputs\.request\s*\}\}['\"]"
+)
+INPUT_EXPR = "${{ github.event.inputs.request }}"
+
+
+class TestCopilotSetupStepsWorkflowSecurity(unittest.TestCase):
+    """Static guards for github-script input handling."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.content = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_file_exists(self) -> None:
+        self.assertTrue(WORKFLOW.is_file())
+
+    def test_development_partner_step_present(self) -> None:
+        self.assertIn(STEP_MARKER, self.content)
+
+    def _step_block(self) -> str:
+        start = self.content.index(STEP_MARKER)
+        next_step = self.content.find("\n      - name:", start + 1)
+        end = next_step if next_step != -1 else len(self.content)
+        return self.content[start:end]
+
+    def test_request_bound_via_env_not_script_literal(self) -> None:
+        block = self._step_block()
+        self.assertIn("uses: actions/github-script@", block)
+        self.assertIn("env:", block)
+        self.assertIn("REQUEST:", block)
+        self.assertIn(INPUT_EXPR, block)
+        self.assertRegex(block, r"const\s+request\s*=\s*process\.env\.REQUEST")
+        self.assertIsNone(
+            VULNERABLE_PATTERN.search(block),
+            "workflow_dispatch request must not be interpolated into a JS string literal",
+        )
+
+    def test_no_input_expression_inside_script_block(self) -> None:
+        block = self._step_block()
+        script_start = block.index("script: |")
+        script_body = block[script_start:]
+        self.assertNotIn(
+            INPUT_EXPR,
+            script_body,
+            "github.event.inputs.request must not appear inside script: (env binding only)",
+        )
+
+    def test_malicious_payload_would_not_match_safe_pattern(self) -> None:
+        """Document attacker payload that the fix neutralizes."""
+        payload = "'; require('child_process').execSync('id'); //"
+        safe_usage = f"const request = process.env.REQUEST || '';\n// {payload}"
+        self.assertIn("process.env.REQUEST", safe_usage)
+        self.assertNotRegex(safe_usage, VULNERABLE_PATTERN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **Linear ABHI-943** — CWE-94 script injection via `workflow_dispatch` input in `copilot-setup-steps.yml`.

The vulnerable pattern was already remediated on `main` in **#980** (commit `4972970`): `github.event.inputs.request` is bound through step `env.REQUEST` and read via `process.env.REQUEST`, not interpolated into a JavaScript string literal inside `actions/github-script`.

This PR adds **regression tests** so the injection vector cannot be reintroduced silently.

## Security (ELIR)

**Purpose:** Static unittest guards assert the Development Partner Session step never embeds `${{ github.event.inputs.request }}` inside the `script:` block and always uses `process.env.REQUEST`.

**Security:** Prevents CWE-94 reintroduction — direct `${{ }}` interpolation in `github-script` allows breaking out of string literals and arbitrary runner code execution (including `GITHUB_TOKEN` abuse).

**Trust boundary:** Assumes only users with `workflow_dispatch` + write access can supply `request`; env binding treats that input as untrusted data, not code.

**Verify:** Run `python3 -m unittest tests.test_copilot_setup_steps_workflow -v` — all 5 tests must pass.

**Related:** email-security-pipeline#881 (same class of fix in sibling repo).

## Changes

- `tests/test_copilot_setup_steps_workflow.py` — regression tests (pattern mirrors `tests/test_summary_workflow.py`)
- `tasks/todo.md` — track ABHI-943 completion

## Review checklist

- [ ] Confirm `.github/workflows/copilot-setup-steps.yml` still has `env.REQUEST` + `process.env.REQUEST` (no `${{ github.event.inputs.request }}` in `script:`)
- [ ] CI `test-python` / `make test-all` includes new tests
- [ ] Close Linear ABHI-943 after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-943](https://linear.app/abhis-space/issue/ABHI-943/security-script-injection-via-workflow-dispatch-input-in-copilot-setup)

<div><a href="https://cursor.com/agents/bc-228e2cc9-8b06-4bb7-9ae2-d5c1137cd16f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-228e2cc9-8b06-4bb7-9ae2-d5c1137cd16f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

