### PR TITLE
security(ABHI-918): credential hygiene — env-only GH token + verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,13 @@ patch.sh
 *token*
 *_key
 
+# Credential helper modules (no secrets; env-var only)
+!gh_token_env.py
+!scripts/ensure_gh_token.sh
+!scripts/verify_security_issue1.sh
+!tests/test_gh_token_env.py
+!GH_TOKEN.env.example
+
 # But allow documentation about these topics
 !*secret*.md
 !*private*.md

--- a/GH_TOKEN.env.example
+++ b/GH_TOKEN.env.example
@@ -1,0 +1,10 @@
+# Example only — do not store live tokens in the repository root.
+#
+# Recommended layout:
+#   1. Export GH_TOKEN in your shell profile, or
+#   2. Keep a private file outside this repo, e.g. ~/.config/personal-config/gh-token.env
+#      and set:  export GH_TOKEN_ENV_FILE="$HOME/.config/personal-config/gh-token.env"
+#
+# After rotating a compromised PAT, revoke the old token in GitHub Settings → Developer settings.
+
+export GH_TOKEN='replace-with-rotated-token'

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,41 +1,9 @@
 import json
 import os
 import subprocess
-from functools import lru_cache
 import concurrent.futures
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_subprocess_env as _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/close_more.sh
+++ b/close_more.sh
@@ -1,4 +1,5 @@
-source ../email-security-pipeline/GH_TOKEN.env
+# shellcheck source=scripts/ensure_gh_token.sh
+source "$(dirname "$0")/scripts/ensure_gh_token.sh"
 
 close_pr() {
   local repo=$1

--- a/close_prs.sh
+++ b/close_prs.sh
@@ -1,4 +1,5 @@
-source ../email-security-pipeline/GH_TOKEN.env
+# shellcheck source=scripts/ensure_gh_token.sh
+source "$(dirname "$0")/scripts/ensure_gh_token.sh"
 
 close_pr() {
   local repo=$1

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -3,38 +3,8 @@ import json
 import os
 import subprocess
 from collections import defaultdict
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line or line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_subprocess_env as _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/fix_drafts.sh
+++ b/fix_drafts.sh
@@ -1,4 +1,5 @@
-source ../email-security-pipeline/GH_TOKEN.env
+# shellcheck source=scripts/ensure_gh_token.sh
+source "$(dirname "$0")/scripts/ensure_gh_token.sh"
 
 fix_and_merge() {
   local repo=$1

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -1,0 +1,56 @@
+"""GitHub token environment helpers for local ``gh`` subprocess calls.
+
+SECURITY: Never read token files from fixed paths inside this repository.
+Use ``GH_TOKEN`` / ``GITHUB_TOKEN``, ``gh auth token``, or an explicit
+``GH_TOKEN_ENV_FILE`` pointing to a user-managed file outside the repo tree.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+
+def _parse_env_line(line: str, env_dict: dict[str, str]) -> None:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return
+    if line.startswith("export "):
+        line = line[7:].strip()
+    key, sep, val = line.partition("=")
+    if not sep:
+        return
+    env_dict[key] = val.strip("'\"")
+
+
+def _token_env_file_path() -> Path | None:
+    explicit = os.environ.get("GH_TOKEN_ENV_FILE", "").strip()
+    if not explicit:
+        return None
+    return Path(explicit).expanduser()
+
+
+@lru_cache(maxsize=None)
+def _get_parsed_env_vars() -> dict[str, str]:
+    parsed_vars: dict[str, str] = {}
+    path = _token_env_file_path()
+    if path is None:
+        return parsed_vars
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                _parse_env_line(line, parsed_vars)
+    except FileNotFoundError:
+        pass
+    return parsed_vars
+
+
+def load_gh_subprocess_env() -> dict[str, str]:
+    """Return a copy of ``os.environ`` suitable for ``subprocess`` ``gh`` calls."""
+    env = os.environ.copy()
+    for key, value in _get_parsed_env_vars().items():
+        env.setdefault(key, value)
+    if not env.get("GH_TOKEN") and env.get("GITHUB_TOKEN"):
+        env["GH_TOKEN"] = env["GITHUB_TOKEN"]
+    return env

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -2,41 +2,8 @@ import json
 import os
 import subprocess
 from datetime import datetime, timezone
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_subprocess_env as _load_gh_token_env
 
 
 def run_gh(repo, pr):

--- a/run_merges.py
+++ b/run_merges.py
@@ -2,41 +2,8 @@ import json
 import os
 import subprocess
 import time
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_subprocess_env as _load_gh_token_env
 
 
 def run_gh(cmd_list):

--- a/scripts/ensure_gh_token.sh
+++ b/scripts/ensure_gh_token.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SECURITY: Do not source GH_TOKEN.env from repo paths; use env or gh auth.
+set -euo pipefail
+
+if [[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+	export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+	exit 0
+fi
+
+if command -v gh >/dev/null 2>&1; then
+	token="$(gh auth token 2>/dev/null || true)"
+	if [[ -n "${token}" ]]; then
+		export GH_TOKEN="${token}"
+		exit 0
+	fi
+fi
+
+if [[ -n "${GH_TOKEN_ENV_FILE:-}" && -f "${GH_TOKEN_ENV_FILE}" ]]; then
+	# shellcheck disable=SC1090
+	set -a
+	# NOTE: File must live outside the repo; set GH_TOKEN_ENV_FILE explicitly.
+	source "${GH_TOKEN_ENV_FILE}"
+	set +a
+	if [[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+		export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+		exit 0
+	fi
+fi
+
+echo "ERROR: Set GH_TOKEN, GITHUB_TOKEN, GH_TOKEN_ENV_FILE, or run 'gh auth login'." >&2
+exit 1

--- a/scripts/verify_security_issue1.sh
+++ b/scripts/verify_security_issue1.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Acceptance checks for ABHI-918 / security remediation issue 1.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+failures=0
+
+echo "==> grep: WebDAV curl examples use placeholders only"
+if grep -R 'curl -u "infuse:' media-streaming 2>/dev/null | grep -v '\${MEDIA_WEBDAV_PASS}'; then
+	echo "FAIL: found curl -u infuse examples without MEDIA_WEBDAV_PASS placeholder" >&2
+	failures=$((failures + 1))
+else
+	echo "OK"
+fi
+
+echo "==> grep: no GH_TOKEN.env reads under repo-relative email-security path"
+bad_gh_token_path="$(
+	grep -R '../email-security-pipeline/GH_TOKEN.env' \
+		--include='*.py' --include='*.sh' . 2>/dev/null \
+		| grep -v 'scripts/verify_security_issue1.sh' || true
+)"
+if [[ -n "${bad_gh_token_path}" ]]; then
+	echo "${bad_gh_token_path}" >&2
+	echo "FAIL: scripts still reference ../email-security-pipeline/GH_TOKEN.env" >&2
+	failures=$((failures + 1))
+else
+	echo "OK"
+fi
+
+echo "==> trufflehog: verified secrets scan"
+TRUFFLEHOG="${TRUFFLEHOG:-}"
+if [[ -z "${TRUFFLEHOG}" ]]; then
+	if command -v trufflehog >/dev/null 2>&1; then
+		TRUFFLEHOG="$(command -v trufflehog)"
+	elif [[ -x /tmp/bin/trufflehog ]]; then
+		TRUFFLEHOG=/tmp/bin/trufflehog
+	fi
+fi
+if [[ -z "${TRUFFLEHOG}" ]]; then
+	echo "SKIP: trufflehog not installed (install from https://github.com/trufflesecurity/trufflehog)" >&2
+else
+	if "${TRUFFLEHOG}" filesystem . --only-verified 2>&1 | tee /tmp/trufflehog-issue1.log | grep -q 'verified_secrets": 0'; then
+		echo "OK"
+	else
+		echo "FAIL: trufflehog reported verified secrets (see log)" >&2
+		failures=$((failures + 1))
+	fi
+fi
+
+if [[ "${failures}" -gt 0 ]]; then
+	echo "${failures} check(s) failed" >&2
+	exit 1
+fi
+echo "All automated ABHI-918 checks passed."

--- a/tasks/security-remediation-plan-2026-05-01.md
+++ b/tasks/security-remediation-plan-2026-05-01.md
@@ -22,6 +22,12 @@ Priority: P0
 - Rotate/revoke the GitHub PAT in GitHub settings.
 - Rotate the WebDAV password in 1Password/media-server configuration.
 - Decide whether repository history needs purging for the old WebDAV password.
+- Move any local `GH_TOKEN.env` out of the repository root; use `GH_TOKEN` / `GH_TOKEN_ENV_FILE` (see `GH_TOKEN.env.example`).
+
+### Repo automation (2026-05-24)
+
+- Added `gh_token_env.py` and `scripts/ensure_gh_token.sh` so PR helper scripts no longer read `../email-security-pipeline/GH_TOKEN.env`.
+- Added `scripts/verify_security_issue1.sh` for acceptance checks.
 
 ### Acceptance criteria
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,15 @@
+# ABHI-918 — Rotate credentials & remove WebDAV examples — 2026-05-24
+
+- [x] Confirm `grep -R 'curl -u "infuse:' media-streaming` uses `${MEDIA_WEBDAV_PASS}` placeholders only.
+- [x] Run `trufflehog filesystem . --only-verified` (0 verified secrets in CI workspace).
+- [x] Remove repo-relative `GH_TOKEN.env` reads from PR automation scripts; add `gh_token_env.py` + `scripts/ensure_gh_token.sh`.
+- [x] Add `scripts/verify_security_issue1.sh` and `tests/test_gh_token_env.py`.
+- [ ] **Manual:** Revoke/rotate GitHub PAT exposed in local `GH_TOKEN.env`.
+- [ ] **Manual:** Rotate WebDAV password in 1Password / media-server.
+- [ ] **Manual:** Decide on git history purge for old WebDAV password in commits.
+
+---
+
 # Security Fix: Cleartext Password Logging in infuse-media-server.py — 2026-05-14
 
 - [x] Replace auto-generated password printing with `getpass.getpass()` interactive prompt in `media-streaming/archive/scripts/infuse-media-server.py`.

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -1,0 +1,42 @@
+"""Tests for gh_token_env (ABHI-918 credential hygiene)."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from gh_token_env import _get_parsed_env_vars, load_gh_subprocess_env
+
+
+class TestGhTokenEnv(unittest.TestCase):
+    def setUp(self) -> None:
+        _get_parsed_env_vars.cache_clear()
+
+    def test_prefers_environment_over_file(self) -> None:
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".env") as handle:
+            handle.write("GH_TOKEN='file-token'\n")
+            path = handle.name
+        self.addCleanup(lambda: os.unlink(path))
+        with patch.dict(
+            os.environ,
+            {"GH_TOKEN": "env-token", "GH_TOKEN_ENV_FILE": path},
+            clear=False,
+        ):
+            env = load_gh_subprocess_env()
+        self.assertEqual(env["GH_TOKEN"], "env-token")
+
+    def test_github_token_alias(self) -> None:
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "github-actions-token"}, clear=True):
+            result = load_gh_subprocess_env()
+        self.assertEqual(result["GH_TOKEN"], "github-actions-token")
+
+    def test_no_repo_relative_default_path(self) -> None:
+        import gh_token_env as module
+
+        with open(module.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn("email-security-pipeline/GH_TOKEN.env", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -7,8 +7,8 @@ from unittest.mock import patch, MagicMock
 # Ensure the project root is in the path so we can import parse_inventory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from gh_token_env import _parse_env_line
 from parse_inventory import (
-    _parse_env_line,
     parse_inventory_lines,
     _is_pr_stale,
     _get_pr_category,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the **repository-side** work for Issue 1 — rotate live local credentials and remove committed WebDAV examples.

### Already satisfied (verified in this workspace)

- `trufflehog filesystem . --only-verified` → **0 verified secrets**
- `grep -R 'curl -u "infuse:' media-streaming` → only `${MEDIA_WEBDAV_PASS}` placeholders
- No `GH_TOKEN.env` file tracked at repo root

### Changes in this PR

- **`gh_token_env.py`** — shared loader for PR automation scripts; uses `GH_TOKEN` / `GITHUB_TOKEN`, optional `GH_TOKEN_ENV_FILE` (user path outside repo), never `../email-security-pipeline/GH_TOKEN.env`
- **`scripts/ensure_gh_token.sh`** — shell equivalent for `fix_drafts.sh`, `close_prs.sh`, `close_more.sh`
- **`scripts/verify_security_issue1.sh`** — automated acceptance checks for this issue
- **`GH_TOKEN.env.example`** — documents moving tokens outside the repo root
- **`.gitignore`** — allowlist for credential-helper files blocked by `*token*`

### Manual actions still required (cannot be done in CI)

1. **Revoke/rotate** the GitHub PAT that TruffleHog flagged in local `GH_TOKEN.env`
2. **Rotate** WebDAV password in 1Password / media-server
3. **Decide** whether to purge git history for the old WebDAV password in past commits

After rotation, keep secrets outside the repo: `export GH_TOKEN=…` or `export GH_TOKEN_ENV_FILE=~/.config/.../gh-token.env`

## Verification

```bash
bash scripts/verify_security_issue1.sh
python3 -m unittest tests.test_gh_token_env tests.test_vulnerability_fix tests.test_parse_inventory
```

## ELIR

**PURPOSE:** Remove repo-relative token file reads and add repeatable checks so WebDAV docs stay placeholder-only and TruffleHog stays clean.

**SECURITY:** Prevents accidental reintroduction of `../email-security-pipeline/GH_TOKEN.env` sourcing; env vars take precedence over optional external file.

**FAILS IF:** Scripts are reverted to hardcoded paths or docs regain literal WebDAV passwords.

**VERIFY:** Run `scripts/verify_security_issue1.sh` locally after merging; confirm PAT/WebDAV rotation in GitHub + 1Password.

**MAINTAIN:** Use `gh_token_env.load_gh_subprocess_env()` / `scripts/ensure_gh_token.sh` for any new `gh` automation—do not add new `source …/GH_TOKEN.env` lines.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-918](https://linear.app/abhis-space/issue/ABHI-918/issue-1-rotate-live-local-credentials-and-remove-committed-webdav)

<div><a href="https://cursor.com/agents/bc-7f4a6eda-9d04-4236-b75b-96f5b7365500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f4a6eda-9d04-4236-b75b-96f5b7365500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

