### PR TITLE
Fix unselecting all items bug in menu_paginated.sh

### DIFF
--- a/configs/.config/mole/lib/ui/menu_paginated.sh
+++ b/configs/.config/mole/lib/ui/menu_paginated.sh
@@ -873,27 +873,8 @@ paginated_multi_select() {
                 handle_filter_char "${key#CHAR:}" || true
                 ;;
             "ENTER")
-                # Smart Enter behavior
-                # 1. Check if any items are already selected
-                local has_selection=false
-                for ((i = 0; i < total_items; i++)); do
-                    if [[ ${selected[i]} == true ]]; then
-                        has_selection=true
-                        break
-                    fi
-                done
-
-                # 2. If nothing selected, auto-select current item
-                if [[ $has_selection == false ]]; then
-                    local idx=$((top_index + cursor_pos))
-                    if [[ $idx -lt ${#view_indices[@]} ]]; then
-                        local real="${view_indices[idx]}"
-                        selected[real]=true
-                        selected_count=$((selected_count + 1))
-                    fi
-                fi
-
-                # 3. Confirm and exit with current selections
+                # Allow empty selection - don't auto-select cursor position
+                # This fixes the bug where unselecting all items would still select the last cursor position
                 local -a selected_indices=()
                 for ((i = 0; i < total_items; i++)); do
                     if [[ ${selected[i]} == true ]]; then

--- a/configs/.config/mole/lib/ui/menu_simple.sh
+++ b/configs/.config/mole/lib/ui/menu_simple.sh
@@ -296,7 +296,6 @@ paginated_multi_select() {
                 done
 
                 # Allow empty selection - don't auto-select cursor position
-                # This fixes the bug where unselecting all items would still select the last cursor position
                 local final_result=""
                 if [[ ${#selected_indices[@]} -gt 0 ]]; then
                     local IFS=','


### PR DESCRIPTION
Fixes a bug in the paginated multi-select menu where deselecting all items and hitting Enter still forcefully submitted the item under the cursor. This logic aligns the behavior of `menu_paginated.sh` with `menu_simple.sh`.

---
*PR created automatically by Jules for task [6954780724508931507](https://jules.google.com/task/6954780724508931507) started by @abhimehro*