### PR TITLE
autofix(): PR #992 (cycle 1) -- Wrap execution logic in scratch_triage.py inside main block

### DIFF
--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -18,44 +18,6 @@ def run_cmd(cmd):
     return res.returncode == 0, res.stdout, res.stderr
 
 
-all_prs = []
-for repo in repos:
-    success, stdout, _ = run_cmd(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            "100",
-            "--json",
-            "number,title,author,headRefName,mergeStateStatus,state,createdAt",
-        ]
-    )
-    if success:
-        prs = json.loads(stdout)
-        for pr in prs:
-            # ⚡ Bolt Optimization: Use rpartition() over split() to avoid intermediate list allocation overhead
-            pr["repo"] = repo.rpartition("/")[2]
-            pr["full_repo"] = repo
-            all_prs.append(pr)
-
-merged = []
-closed = []
-escalated = []
-
-triage_md = [
-    f"# PR triage — backlog cleanup test ({datetime.date.today().isoformat()})\n",
-    "**Policy:** squash merge, stale_days 30, auto-fix enabled, mode review-and-merge. **No force-push.**\n",
-    "## Duplicate / supersede groups\n",
-    "| Keep (canonical) | Close as duplicate / superseded | Rationale |",
-    "| --- | --- | --- |",
-]
-
-
 def _find_matching_prs(all_prs, repo, title_keywords):
     lower_kws = tuple(kw.lower() for kw in title_keywords)
     return [
@@ -80,7 +42,7 @@ def _process_pr_group(matches, repo, rationale, groups):
         keep["status_action"] = "KEEP"
 
 
-def group_prs():
+def group_prs(all_prs, triage_md):
     # manual grouping logic based on patterns
     groups = []
 
@@ -135,106 +97,144 @@ def group_prs():
         )
 
 
-group_prs()
-
-# Process Actions
-for pr in sorted(all_prs, key=lambda x: (x["repo"], -x["number"])):
-    repo = pr["full_repo"]
-    num = pr["number"]
-
-    if pr.get("status_action") == "CLOSE":
-        print(f"Closing {repo}#{num} (duplicate)")
-        run_cmd(
+if __name__ == '__main__':
+    all_prs = []
+    for repo in repos:
+        success, stdout, _ = run_cmd(
             [
                 "gh",
                 "pr",
-                "close",
-                str(num),
+                "list",
                 "--repo",
                 repo,
-                "--comment",
-                "Closing as superseded/duplicate of newer PR.",
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,author,headRefName,mergeStateStatus,state,createdAt",
             ]
         )
-        closed.append(pr)
-    elif pr["mergeStateStatus"] == "CLEAN" or pr["mergeStateStatus"] == "HAS_HOOKS":
-        print(f"Merging {repo}#{num}")
-        success, out, err = run_cmd(
-            ["gh", "pr", "merge", str(num), "--repo", repo, "--squash", "--admin"]
-        )
         if success:
-            merged.append(pr)
+            prs = json.loads(stdout)
+            for pr in prs:
+                # ⚡ Bolt Optimization: Use rpartition() over split() to avoid intermediate list allocation overhead
+                pr["repo"] = repo.rpartition("/")[2]
+                pr["full_repo"] = repo
+                all_prs.append(pr)
+
+    merged = []
+    closed = []
+    escalated = []
+
+    triage_md = [
+        f"# PR triage — backlog cleanup test ({datetime.date.today().isoformat()})\n",
+        "**Policy:** squash merge, stale_days 30, auto-fix enabled, mode review-and-merge. **No force-push.**\n",
+        "## Duplicate / supersede groups\n",
+        "| Keep (canonical) | Close as duplicate / superseded | Rationale |",
+        "| --- | --- | --- |",
+    ]
+
+    group_prs(all_prs, triage_md)
+
+    # Process Actions
+    for pr in sorted(all_prs, key=lambda x: (x["repo"], -x["number"])):
+        repo = pr["full_repo"]
+        num = pr["number"]
+
+        if pr.get("status_action") == "CLOSE":
+            print(f"Closing {repo}#{num} (duplicate)")
+            run_cmd(
+                [
+                    "gh",
+                    "pr",
+                    "close",
+                    str(num),
+                    "--repo",
+                    repo,
+                    "--comment",
+                    "Closing as superseded/duplicate of newer PR.",
+                ]
+            )
+            closed.append(pr)
+        elif pr["mergeStateStatus"] == "CLEAN" or pr["mergeStateStatus"] == "HAS_HOOKS":
+            print(f"Merging {repo}#{num}")
+            success, out, err = run_cmd(
+                ["gh", "pr", "merge", str(num), "--repo", repo, "--squash", "--admin"]
+            )
+            if success:
+                merged.append(pr)
+            else:
+                print(f"Failed to merge: {err}")
+                escalated.append(pr)
         else:
-            print(f"Failed to merge: {err}")
+            print(f"Holding {repo}#{num} ({pr['mergeStateStatus']})")
             escalated.append(pr)
-    else:
-        print(f"Holding {repo}#{num} ({pr['mergeStateStatus']})")
-        escalated.append(pr)
 
-triage_md.extend(
-    [
-        "\n## Escalate / defer (no autonomous merge)\n",
-        "| PR | Reason |",
-        "| --- | --- |",
-    ]
-)
-for p in escalated:
-    triage_md.append(
-        f"| {p['repo']} **#{p['number']}** | {p['mergeStateStatus']} status - requires human review or CI fix |"
+    triage_md.extend(
+        [
+            "\n## Escalate / defer (no autonomous merge)\n",
+            "| PR | Reason |",
+            "| --- | --- |",
+        ]
+    )
+    for p in escalated:
+        triage_md.append(
+            f"| {p['repo']} **#{p['number']}** | {p['mergeStateStatus']} status - requires human review or CI fix |"
+        )
+
+    triage_md.extend(
+        [
+            "\n## Outcomes\n",
+            f"- **Executed:** {len(closed)} duplicate closures, {len(merged)} squash merges.",
+            f"- **Deferred:** {len(escalated)} held.",
+        ]
     )
 
-triage_md.extend(
-    [
-        "\n## Outcomes\n",
-        f"- **Executed:** {len(closed)} duplicate closures, {len(merged)} squash merges.",
-        f"- **Deferred:** {len(escalated)} held.",
+    with open("tasks/pr-triage.md", "w") as f:
+        f.write("\n".join(triage_md) + "\n")
+
+    # Session Report
+    report_md = [
+        f"\n## Run — {datetime.date.today().isoformat()} (backlog cleanup E2E, review-and-merge)\n",
+        "### Repos processed\n",
     ]
-)
+    for i, r in enumerate(repos, 1):
+        report_md.append(f"{i}. `{r}`")
 
-with open("tasks/pr-triage.md", "w") as f:
-    f.write("\n".join(triage_md) + "\n")
-
-# Session Report
-report_md = [
-    f"\n## Run — {datetime.date.today().isoformat()} (backlog cleanup E2E, review-and-merge)\n",
-    "### Repos processed\n",
-]
-for i, r in enumerate(repos, 1):
-    report_md.append(f"{i}. `{r}`")
-
-report_md.extend(
-    [
-        "\n### Metrics\n",
-        "| Metric | Count |",
-        "| --- | ---: |",
-        f"| PRs inventoried (open) | {len(all_prs)} |",
-        f"| PRs merged (squash) | {len(merged)} |",
-        f"| PRs closed (duplicate) | {len(closed)} |",
-        f"| PRs escalated / held | {len(escalated)} |\n",
-        "### Merged (squash)\n",
-    ]
-)
-
-current_repo = None
-for p in merged:
-    if p["repo"] != current_repo:
-        report_md.append(f"\n**{p['repo']}**\n")
-        current_repo = p["repo"]
-    report_md.append(f"- https://github.com/{p['full_repo']}/pull/{p['number']}")
-
-report_md.append("\n### Closed (duplicate / superseded / zero-diff)\n")
-for p in closed:
-    report_md.append(f"- https://github.com/{p['full_repo']}/pull/{p['number']}")
-
-report_md.append("\n### Held open / escalated\n")
-for p in escalated:
-    report_md.append(
-        f"- https://github.com/{p['full_repo']}/pull/{p['number']} — {p['mergeStateStatus']}"
+    report_md.extend(
+        [
+            "\n### Metrics\n",
+            "| Metric | Count |",
+            "| --- | ---: |",
+            f"| PRs inventoried (open) | {len(all_prs)} |",
+            f"| PRs merged (squash) | {len(merged)} |",
+            f"| PRs closed (duplicate) | {len(closed)} |",
+            f"| PRs escalated / held | {len(escalated)} |\n",
+            "### Merged (squash)\n",
+        ]
     )
 
-with open("tasks/pr-review-session-reports.md", "a") as f:
-    f.write("\n".join(report_md) + "\n")
+    current_repo = None
+    for p in merged:
+        if p["repo"] != current_repo:
+            report_md.append(f"\n**{p['repo']}**\n")
+            current_repo = p["repo"]
+        report_md.append(f"- https://github.com/{p['full_repo']}/pull/{p['number']}")
 
-print(
-    f"Done. Merged: {len(merged)}, Closed: {len(closed)}, Escalated: {len(escalated)}"
-)
+    report_md.append("\n### Closed (duplicate / superseded / zero-diff)\n")
+    for p in closed:
+        report_md.append(f"- https://github.com/{p['full_repo']}/pull/{p['number']}")
+
+    report_md.append("\n### Held open / escalated\n")
+    for p in escalated:
+        report_md.append(
+            f"- https://github.com/{p['full_repo']}/pull/{p['number']} — {p['mergeStateStatus']}"
+        )
+
+    with open("tasks/pr-review-session-reports.md", "a") as f:
+        f.write("\n".join(report_md) + "\n")
+
+    print(
+        f"Done. Merged: {len(merged)}, Closed: {len(closed)}, Escalated: {len(escalated)}"
+    )


### PR DESCRIPTION
**Jules Daily QA & Agentic Review**

### Findings
During the daily QA verification for `personal-config`, testing of `test_scratch_triage.py` failed due to side-effects executing upon import of `scratch_triage.py`. 

### Resolution
- Wrapped all executable execution logic inside `scratch_triage.py` inside a standard `if __name__ == '__main__':` execution block.
- Updated the `group_prs()` function signature to explicitly accept arguments instead of relying on module-level global variables.

### Verification
- `make test-all` successfully passed without `ImportError` or `NameError` failures.
- `make lint-errors` returned no violations.

---
*PR created automatically by Jules for task [4788660264164479497](https://jules.google.com/task/4788660264164479497) started by @abhimehro*