### PR TITLE
fix(auth-hygiene): ignore 1Password arg in media-streaming docs

### DIFF
--- a/scripts/verify-repo-auth-hygiene.sh
+++ b/scripts/verify-repo-auth-hygiene.sh
@@ -105,6 +105,7 @@ run_password_grep() {
 		*media-streaming/configs/media-credentials.example* | \
 		*media-streaming/archive/scripts/start-media-server*.sh* | \
 		*media-streaming/archive/scripts/start-media-server-fast.sh* | \
+		*media-streaming/BACKUP_RECOVERY.md* | \
 		*.agents/skills/firebase-auth-basics/*)
 			continue
 			;;


### PR DESCRIPTION
## Jules Daily QA & Agentic Review: personal-config

**Domain Priorities:** Configuration correctness, script reliability, no hardcoded secrets, environment variable hygiene

### 1. Verification Summary

- **Tests:** `make test-all` passed successfully.
- **Code Quality:** `make lint-errors` confirms zero SC2155/SC2145 Bash violations.
- **Secrets:** `make verify-credentials` initially failed due to a false positive but now passes after the fix. Trufflehog reports zero verified secrets.

### 2. Actionable Insights

- **Bug Fixed:** `scripts/verify-repo-auth-hygiene.sh` was failing on a false positive in `media-streaming/BACKUP_RECOVERY.md` due to the `op item edit MediaServer --vault Personal --generate-password='letters,digits,32'` command.
- **Action Taken:** Whitelisted `BACKUP_RECOVERY.md` in the auth hygiene script.
- **Bash commands used:**
  - `make test-all`
  - `make lint-errors`
  - `make verify-credentials` (along with manual installation of `trufflehog`)
  - `git branch --show-current`

### 3. Closure

- The bug causing the credential verification check to fail has been fixed. The repository is healthy, tests pass, and there are no hardcoded secrets or critical linting issues.

---
*PR created automatically by Jules for task [14140813879669962057](https://jules.google.com/task/14140813879669962057) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->