### PR TITLE
🎨 Palette: Improve interactive prompts and terminal spinners UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -128,3 +128,7 @@
 ## 2024-05-19 - Accessible Spinners for Wait States
 **Learning:** Hardcoded sleeps without visual feedback create uncertainty; users don't know if a script is frozen or just taking time.
 **Action:** Replace arbitrary `sleep` commands with accessible spinners (e.g., `spinner_wait` function) to provide clear visual feedback during wait periods, ensuring they safely handle interrupts and only render in interactive terminals (e.g., checking `[ -t 1 ] && -z ${CI-}`) to avoid polluting logs.
+
+## 2026-05-29 - Improve Interactive Prompts and Spinner UX
+**Learning:** Using `read -p` without the `-r` flag allows backslashes to escape characters, which can lead to unexpected behavior in interactive prompts. Additionally, using `tput civis` and `tput cnorm` to hide/show the cursor during spinners without checking if the output is an interactive terminal (`[ -t 1 ]`) or if it's running in CI (`[ -z "${CI-}" ]`) causes unnecessary log pollution and cursor state bugs in automated environments.
+**Action:** Always use `read -r -p` for interactive confirmations, and guard cursor manipulation commands with `[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true`.

--- a/configs/.config/mole/bin/touchid.sh
+++ b/configs/.config/mole/bin/touchid.sh
@@ -91,7 +91,7 @@ enable_touchid() {
     # First check if system supports Touch ID
     if ! supports_touchid; then
         log_warning "This Mac may not support Touch ID"
-        read -rp "Continue anyway? [y/N] " confirm
+        read -r -p "Continue anyway? [y/N] " confirm
         if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
             echo -e "${YELLOW}Cancelled${NC}"
             return 1

--- a/configs/.config/mole/install.sh
+++ b/configs/.config/mole/install.sh
@@ -22,7 +22,7 @@ start_line_spinner() {
     # shellcheck disable=SC1003
     [[ -z "$chars" ]] && chars='|/-\\'
     local i=0
-    tput civis 2>/dev/null || true
+    [ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
     (while true; do
         c="${chars:$((i % ${#chars})):1}"
         printf "\r${BLUE}%s${NC} %s" "$c" "$msg"
@@ -35,7 +35,7 @@ stop_line_spinner() { if [[ -n "$_SPINNER_PID" ]]; then
     kill "$_SPINNER_PID" 2> /dev/null || true
     wait "$_SPINNER_PID" 2> /dev/null || true
     _SPINNER_PID=""
-    tput cnorm 2>/dev/null || true
+    [ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
     printf "\r\033[K"
 fi; }
 

--- a/configs/.config/mole/lib/core/ui.sh
+++ b/configs/.config/mole/lib/core/ui.sh
@@ -349,7 +349,7 @@ start_inline_spinner() {
             local i=0
 
             # Hide cursor to prevent flicker
-            tput civis 2>/dev/null || true
+            [ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
             # Clear line on first output to prevent text remnants from previous messages
             printf "\r\033[2K" >&2 || true
@@ -364,7 +364,7 @@ start_inline_spinner() {
             done
 
             # Clean up stop file and restore cursor before exiting
-            tput cnorm 2>/dev/null || true
+            [ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
             rm -f "$stop_file" 2> /dev/null || true
             exit 0
         ) &
@@ -403,7 +403,7 @@ stop_inline_spinner() {
 
         # Clear the line and restore cursor
         if [[ -t 1 ]]; then
-            tput cnorm 2>/dev/null || true
+            [ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
             printf "\r\033[2K" >&2 || true
         fi
     fi

--- a/docs/archive/COMPLETE_CLEANUP.sh
+++ b/docs/archive/COMPLETE_CLEANUP.sh
@@ -38,7 +38,7 @@ confirm_cleanup() {
 	echo
 	echo "Your system will return to using default DNS (your ISP's DNS)."
 	echo
-	read -p "Are you absolutely sure you want to continue? (type 'YES' to confirm): " confirm
+	read -r -p "Are you absolutely sure you want to continue? (type 'YES' to confirm): " confirm
 
 	if [ "$confirm" != "YES" ]; then
 		echo "Cleanup cancelled."

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -40,16 +40,16 @@ spinner_wait() {
 		local c=0
 
 		# Hide cursor gracefully in TTY
-		[ -t 1 ] && tput civis 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r\033[0;34m[%c]\033[0m %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -59,7 +59,7 @@ spinner_wait() {
 		printf "\r\033[K" # Clear line
 
 		# Restore cursor and original traps
-		[ -t 1 ] && tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else

--- a/maintenance/bin/run_all_maintenance.sh
+++ b/maintenance/bin/run_all_maintenance.sh
@@ -134,10 +134,10 @@ spinner() {
 	# Also disable in CI environments to prevent log clutter
 	if [ -t 1 ] && [ -z "${CI-}" ]; then
 		# Hide cursor
-		tput civis 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 		# Trap to restore cursor if interrupted
-		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; exit' INT TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; exit' INT TERM
 
 		local start_time
 		start_time=$(date +%s)
@@ -161,7 +161,7 @@ spinner() {
 		done
 
 		# Restore cursor
-		tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 
 		# Clear spinner line completely
 		printf "\r\033[K"
@@ -184,8 +184,8 @@ wait_for_pids() {
 	local num_chars=${#SPIN_CHARS[@]}
 
 	if [ -t 1 ] && [ -z "${CI-}" ]; then
-		tput civis 2>/dev/null || true
-		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT TERM; kill -s INT $$' INT TERM
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT TERM; kill -s INT $$' INT TERM
 
 		local start_time
 		start_time=$(date +%s)
@@ -226,7 +226,7 @@ wait_for_pids() {
 			sleep $delay
 		done
 
-		tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		printf "\r\033[K"
 		trap - INT TERM
 

--- a/maintenance/bin/smart_scheduler.sh
+++ b/maintenance/bin/smart_scheduler.sh
@@ -39,16 +39,16 @@ spinner_wait() {
 		local c=0
 
 		# Hide cursor
-		tput civis 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		local interval=0.5
 		iterations=$(echo "$duration / $interval" | bc -l | cut -d. -f1)
@@ -60,7 +60,7 @@ spinner_wait() {
 		printf "\r\033[K" # Clear line
 
 		# Restore cursor and original traps
-		tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else

--- a/media-streaming/scripts/bulk-rename-cloud.sh
+++ b/media-streaming/scripts/bulk-rename-cloud.sh
@@ -52,7 +52,7 @@ if [[ $DRY_RUN == "true" ]]; then
 	exit 0
 fi
 
-read -p "Do you want to attempt automatic renaming? (y/N) " -r
+read -r -p "Do you want to attempt automatic renaming? (y/N) "
 REPLY=${REPLY:-N}
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	log "User cancelled"

--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -28,13 +28,13 @@ spinner_wait() {
 		local iterations=$((duration * 10))
 		local c=0
 
-		[ -t 1 ] && tput civis 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 		local old_int_trap old_term_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r   %s [%c]" "$msg" "${sp:i++%${#sp}:1}"
@@ -43,7 +43,7 @@ spinner_wait() {
 		done
 		printf "\r\033[K"
 
-		[ -t 1 ] && tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else

--- a/media-streaming/scripts/fix-gdrive.sh
+++ b/media-streaming/scripts/fix-gdrive.sh
@@ -20,7 +20,7 @@ echo
 echo "🔐 Attempting to reconnect gdrive remote..."
 echo "This will open your browser for Google authorization."
 echo
-read -p "Press Enter to continue..."
+read -r -p "Press Enter to continue..."
 
 echo "Running: rclone config reconnect gdrive:"
 rclone config reconnect gdrive:
@@ -34,7 +34,7 @@ if rclone about gdrive: &>/dev/null; then
 else
 	echo "❌ Reconnect failed. Let's delete and recreate..."
 	echo
-	read -p "Delete gdrive remote and start fresh? (y/n): " -r
+	read -r -p "Delete gdrive remote and start fresh? (y/n): "
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
 		rclone config delete gdrive
 		echo "✅ Old gdrive remote deleted"

--- a/media-streaming/scripts/setup-gdrive.sh
+++ b/media-streaming/scripts/setup-gdrive.sh
@@ -7,7 +7,7 @@ echo "1. Sign in to your Google account"
 echo "2. Grant rclone permission to access your Google Drive"
 echo "3. Come back here when done"
 echo
-read -p "Press Enter to continue..."
+read -r -p "Press Enter to continue..."
 
 # Run rclone config for Google Drive
 rclone config create gdrive drive config_is_local false

--- a/media-streaming/scripts/setup-media-library.sh
+++ b/media-streaming/scripts/setup-media-library.sh
@@ -61,7 +61,7 @@ setup_gdrive() {
 	echo "10. Team drive: choose 'n' (unless needed)"
 	echo "11. Save with 'y'"
 	echo
-	read -p "Press Enter to start Google Drive setup..."
+	read -r -p "Press Enter to start Google Drive setup..."
 
 	rclone config
 }
@@ -86,7 +86,7 @@ setup_onedrive() {
 	echo "7. Choose account type (personal/business)"
 	echo "8. Save with 'y'"
 	echo
-	read -p "Press Enter to start OneDrive setup..."
+	read -r -p "Press Enter to start OneDrive setup..."
 
 	rclone config
 }
@@ -160,7 +160,7 @@ create_union() {
 	echo "7. Search policy: ff (or press Enter for default)"
 	echo "8. Save with 'y'"
 	echo
-	read -p "Press Enter to create union remote..."
+	read -r -p "Press Enter to create union remote..."
 
 	rclone config
 
@@ -218,7 +218,7 @@ echo "• Create a unified 'media' remote"
 echo "• Set up WebDAV server for Infuse"
 echo
 
-read -p "Continue? (y/n): " -r
+read -r -p "Continue? (y/n): "
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	echo "Setup cancelled."
 	exit 1

--- a/scripts/bootstrap_fish_plugins.sh
+++ b/scripts/bootstrap_fish_plugins.sh
@@ -22,7 +22,7 @@ warn() { echo -e "${YELLOW}⚠️  [WARN]${NC}  $*"; }
 err() { echo -e "${RED}❌ [ERR]${NC}   $*" >&2; }
 
 # Restore cursor on exit/interrupt
-trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"' EXIT INT TERM
+trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"' EXIT INT TERM
 
 # Spinner function (Palette 🎨 UX enhanced)
 spinner() {
@@ -53,7 +53,7 @@ spinner() {
 	pid=$!
 
 	# Hide cursor gracefully in TTY
-	[ -t 1 ] && tput civis 2>/dev/null || true
+	[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 	local elapsed=0
 	local count=0
@@ -70,7 +70,7 @@ spinner() {
 	local exit_code=$?
 
 	# Restore cursor gracefully in TTY
-	[ -t 1 ] && tput cnorm 2>/dev/null || true
+	[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 	printf "\r\033[K"
 
 	if [ $exit_code -eq 0 ]; then

--- a/scripts/setup-controld.sh
+++ b/scripts/setup-controld.sh
@@ -52,7 +52,7 @@ fi
 
 if [[ -f $CONTROLD_MANAGER_DEST ]]; then
 	warn "controld-manager already installed at $CONTROLD_MANAGER_DEST"
-	read -p "Overwrite? (y/N): " -r
+	read -r -p "Overwrite? (y/N): "
 	REPLY=${REPLY:-N}
 	if [[ ! $REPLY =~ ^([Yy][Ee][Ss]|[Yy])$ ]]; then
 		log "Skipping controld-manager installation"

--- a/scripts/windscribe-connect.sh
+++ b/scripts/windscribe-connect.sh
@@ -39,16 +39,16 @@ spinner_wait() {
 		local c=0
 
 		# Hide cursor gracefully in TTY
-		[ -t 1 ] && tput civis 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r${BLUE}[%c]${NC} %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -58,7 +58,7 @@ spinner_wait() {
 		printf "\r\033[K" # Clear line
 
 		# Restore cursor and original traps
-		[ -t 1 ] && tput cnorm 2>/dev/null || true
+		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -62,7 +62,7 @@ if [[ -z $URL ]] && [[ -t 0 ]]; then
 		# Simple heuristic for YouTube URLs
 		if [[ $CLIP_CONTENT =~ ^https?://(www\.)?(youtube\.com|youtu\.be)/ ]]; then
 			printf "${YELLOW}${E_SEARCH} Found in clipboard: ${BOLD}%s${NC}" "$CLIP_CONTENT"
-			read -p "Use this URL? [Y/n] " -r REPLY
+			read -r -p "Use this URL? [Y/n] " REPLY
 			REPLY=${REPLY:-Y}
 			if [[ -z $REPLY ]] || [[ $REPLY =~ ^([Yy][Ee][Ss]|[Yy])$ ]]; then
 				URL="$CLIP_CONTENT"

--- a/setup.sh
+++ b/setup.sh
@@ -192,7 +192,7 @@ main() {
 		echo
 		printf "%b⚠️  This will modify configuration files in your home directory.%b\n" "${YELLOW}" "${NC}"
 		echo
-		read -p "Ready to proceed? (y/N) " -r
+		read -r -p "Ready to proceed? (y/N) "
 		REPLY=${REPLY:-N}
 		if [[ ! $REPLY =~ ^([Yy][Ee][Ss]|[Yy])$ ]]; then
 			log_info "Bootstrap cancelled by user."


### PR DESCRIPTION
🎨 Palette: Improve interactive prompts and terminal spinners UX

### What
1. Standardized `read -p` to `read -r -p` globally in shell scripts for interactive confirmation prompts.
2. Guarded `tput civis` and `tput cnorm` cursor manipulation commands in wait spinners with `[ -t 1 ] && [ -z "${CI-}" ]` conditional checks.

### Why
1. Using `read` without `-r` allows users to inadvertently escape characters with backslashes during prompts.
2. Executing `tput` cursor manipulations unconditionally causes terminal state bugs and pollutes logs with escape sequences in non-interactive environments and CI runners.

### Accessibility
Prevents screen readers and CI logs from reading out cursor manipulation ANSI codes, leaving only the accessible fallback text.

---
*PR created automatically by Jules for task [18425980875709854390](https://jules.google.com/task/18425980875709854390) started by @abhimehro*