### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix AppleScript Injection (CWE-74) in Media Scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -255,3 +255,8 @@
 **Vulnerability:** AppleScript Injection (CWE-74) existed in `configs/.config/mole/lib/core/sudo.sh` where `osascript` was executing a string containing user-controlled variable `${MOLE_SUDO_PROMPT:-Admin access required}`.
 **Learning:** Using inline string interpolation in AppleScript code executed via `osascript` allows an attacker to inject arbitrary AppleScript commands if they control the variable.
 **Prevention:** Use `osascript -e 'on run argv'` and pass dynamic variables safely as command-line arguments (e.g. `(item 1 of argv)`).
+
+## 2026-05-29 - AppleScript Injection Risk via osascript and string interpolation
+**Vulnerability:** AppleScript Injection ([CWE-74](https://cwe.mitre.org/data/definitions/74.html)) existed in `media-streaming/scripts/mount-media.sh` and `media-streaming/scripts/rename-media.sh` where `osascript` was executing a string containing user-controlled variables. Even though the scripts attempted to escape double quotes (`${title//\"/\\\"}`), this could be bypassed using backslashes (e.g. `\" & do shell script \"...\" & \"`).
+**Learning:** Using inline string interpolation in AppleScript code executed via `osascript` allows an attacker to inject arbitrary AppleScript commands if they control the variable, even if quotes are escaped.
+**Prevention:** Use `osascript -e 'on run argv'` and pass dynamic variables safely as command-line arguments (e.g. `(item 1 of argv)`).

--- a/media-streaming/scripts/mount-media.sh
+++ b/media-streaming/scripts/mount-media.sh
@@ -29,9 +29,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		local esc_title="${title//\"/\\\"}"
-		local esc_message="${message//\"/\\\"}"
-		osascript -e "display notification \"$esc_message\" with title \"$esc_title\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -29,9 +29,7 @@ notify() {
 	if command -v terminal-notifier >/dev/null 2>&1; then
 		terminal-notifier -title "$t" -message "$m" -sound default
 	elif command -v osascript >/dev/null 2>&1; then
-		local esc_t="${t//\"/\\\"}"
-		local esc_m="${m//\"/\\\"}"
-		osascript -e "display notification \"$esc_m\" with title \"$esc_t\"" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$m" "$t" 2>/dev/null || true
 	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: AppleScript Injection (CWE-74) via string interpolation in `osascript` calls within the `notify` functions of `mount-media.sh` and `rename-media.sh`. Although the scripts attempted to escape double quotes, attackers could bypass this using backslashes to break out of the string context and execute arbitrary code (e.g. `do shell script`).
🎯 Impact: Local or remote arbitrary code execution, as `rename-media.sh` logs and notifies user-controlled file names dynamically.
🔧 Fix: Refactored `osascript` invocations to use the `on run argv` handler, passing shell variables securely as command-line arguments `(item 1 of argv)` instead of interpolating them directly into the AppleScript string.
✅ Verification: Tested syntax validity using `bash -n`, ran the `make test-all` suite to ensure no regressions, and verified the changes cleanly separate code and data in the `osascript` calls.

---
*PR created automatically by Jules for task [9247095800218095253](https://jules.google.com/task/9247095800218095253) started by @abhimehro*