### PR TITLE
secops: harden AI engine + fix launchd PATH (vibe-first)

### DIFF
--- a/launch-agents/com.speedybee.secops.phase1.plist
+++ b/launch-agents/com.speedybee.secops.phase1.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.speedybee.secops.phase1</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/speedybee/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/speedybee/secops/phase1-workflow-updater.sh</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase1.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase1.err</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+        <key>Weekday</key>
+        <integer>1</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/launch-agents/com.speedybee.secops.phase2.plist
+++ b/launch-agents/com.speedybee.secops.phase2.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.speedybee.secops.phase2</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/speedybee/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/speedybee/secops/phase2-mine.sh</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase2.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase2.err</string>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Day</key>
+            <integer>1</integer>
+            <key>Hour</key>
+            <integer>10</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Day</key>
+            <integer>15</integer>
+            <key>Hour</key>
+            <integer>10</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/launch-agents/com.speedybee.secops.phase3.plist
+++ b/launch-agents/com.speedybee.secops.phase3.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.speedybee.secops.phase3</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/speedybee/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/speedybee/secops/phase3-qa-health.sh</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase3.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/speedybee/Library/Logs/maintenance/secops_phase3.err</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/secops/README.md
+++ b/secops/README.md
@@ -1,0 +1,262 @@
+# SecOps Autopilot: Operating & Security Guide
+
+This is a local-first, low-cost workstation maintenance system across three execution phases. It integrates standard system tools, local AI reasoning (via a **tiered, timeout-safe AI CLI engine**), and guards against credential leakage, configuration drift, and unvetted branch changes.
+
+> **Source of truth:** these scripts live in `personal-config/secops/` and are symlinked to `~/secops` by `scripts/sync_all_configs.sh`. The LaunchAgent plists are backed up in `personal-config/launch-agents/` and installed via `secops/install.sh`. History logs (`~/.*-history.log`) stay local and are gitignored.
+
+## Shared System Configurations & Directory Structure
+
+```
+~/secops/  ->  personal-config/secops/   (symlink)
+├── phase1-workflow-updater.sh     # Weekly GHA version pinning & locks check
+├── phase2-mine.sh                 # Bi-weekly structural technical debt miner kickoff
+├── phase3-qa-health.sh            # Daily local test runner & drift detection
+├── lib/
+│   └── ai_engine.sh               # Shared tiered AI diagnostic engine + hard timeout
+├── install.sh                     # Install/load (or --uninstall) the LaunchAgents
+└── README.md                      # This operating guide
+```
+
+| Detail | Rule / Path |
+| --- | --- |
+| **Repos Managed** | `personal-config`, `ctrld-sync`, `email-security-pipeline`, `Seatek_Analysis`, `Hydrograph_Versus_Seatek_Sensors_Project`, `series_correction_project_updated` |
+| **Repos Root** | `/Users/speedybee/dev/` |
+| **Append-Only History Logs** | `~/.workflow-updater-history.log`, `~/.backlog-miner-history.log`, `~/.qa-health-history.log` |
+| **LaunchAgents Dir** | `~/Library/LaunchAgents/` (`com.speedybee.secops.phase1/2/3.plist`) |
+| **Diagnostic Inputs Temp Paths** | `/tmp/test_run_<repo>.log`, `/tmp/drift_audit.log` |
+
+---
+
+## The Three Automation Phases
+
+### Phase 1: GitHub Actions Workflow Updater
+* **Purpose:** Keeps GitHub Actions dependencies current and locked to secure, immutable commit SHAs. It compiles and validates changes before committing, keeping your cloud runs fast, secure, and cost-effective.
+* **Cadence:** Weekly, Mondays at 9:00 AM (via `com.speedybee.secops.phase1.plist`).
+* **Tool Required:** `gh-aw` (GitHub CLI Action Lockfile extension).
+* **Security Safeguards:**
+  1. Never commits compiled `.lock.yml` files (only `.github/aw/actions-lock.json`).
+  2. A dry-run compile validation gate (`gh aw compile --validate`) must pass successfully before any commit is written.
+  3. Skips non-GHA repositories or missing tooling gracefully to avoid breaking the execution loop.
+
+### Phase 2: Backlog Triage & Technical Debt Mining
+* **Purpose:** Complements your active PR review and consolidation agents. While those handle inbound PR branches, Phase 2 systematically scans the *existing* codebase for tech debt, outdated patterns, security hygiene gaps, and performance bottlenecks, logging structural status.
+* **Cadence:** Bi-weekly, 1st and 15th of each month at 10:00 AM (via `com.speedybee.secops.phase2.plist`).
+* **Tool Required:** Windsurf Cascade, Cursor Agent, or Gemini CLI + Repo Prompt (Local MCP).
+* **Security Safeguards:**
+  1. Strictly restricted to generating structured markdown tasks. **Never** commits or writes direct code changes.
+  2. Scope is capped to 1-2 directories or modules per run to control context limits.
+  3. Always checks `tasks/lessons.md` first to honor established codebase rules.
+  4. Limits output to a maximum of 3 highly actionable tasks.
+
+### Phase 3: QA Health Check & System Drift Detection
+* **Purpose:** Verifies build and test paths across active repos, audits macOS local configurations, and logs results. Passes log anomalies to a local AI CLI for diagnostics.
+* **Cadence:** Daily at 8:00 AM (via `com.speedybee.secops.phase3.plist`).
+* **Tool Required:** A working AI CLI for headless diagnostic summaries — resolved automatically by `lib/ai_engine.sh` (see **AI Diagnostic Engine** below). No single tool is mandatory; the engine degrades to dumping the raw log.
+* **Test convention:** Phase 3 runs each repo's *own* declared tests — `make test-all`/`make test` when a Makefile target exists, `npm run test` only when a `test` script is declared, otherwise the repo's `.venv/bin/pytest` (or `pytest` on PATH). Repos with no recognized test path are **skipped, not failed**.
+* **Security Safeguards:**
+  1. Fail-secure design: alerts via macOS notifications on test failures.
+  2. **Audit Only:** Never attempts to auto-repair delicate system infrastructure (DNS, LaunchAgents, SSH key permissions). Report and alert only.
+  3. Integrates with the `verify_ssh_config.sh` and standard `scutil --dns` checks to surface anomalies.
+  4. Every per-repo test run and every AI call is wrapped in a hard wall-clock timeout so a hung suite or hung AI CLI can never wedge the daemon.
+
+---
+
+## Google Jules: Cooperative Integration & Safekeeping
+
+### Understanding Google Jules
+Google Jules is a highly capable agent at surfacing code fixes and proactively generating PRs. However, because it works autonomously, it can occasionally:
+- Duplicate changes or submit multiple alternative PRs addressing the same issue (e.g., overlapping optimizations).
+- Attempt multiple credential verifications, touching identical files.
+- Commit using human credentials (e.g., pushing branches authored by `abhimehro` rather than `jules[bot]`).
+
+To prevent Jules' proactive contributions from creating friction or technical debt, we coordinate Jules alongside our **PR Review, Consolidation, and Salvage Agent Workflow**:
+
+```
+ ┌─────────────────┐       ┌────────────────────────────┐       ┌───────────────────────────────┐
+ │  Google Jules   │ ────> │ PR Review / Consolidation  │ ────> │       PR Salvage Agent        │
+ │ Proactive PRs / │       │     (Immediate Triage)     │       │      (Late-Day Review)        │
+ │ Fix Recommendations     │   Filter, review, squash/  │       │  Identifies merge anomalies,  │
+ └─────────────────┘       │   close duplicates/stale   │       │  stale branches, and salvage  │
+                           └────────────────────────────┘       └───────────────────────────────┘
+```
+
+### Integration Guidelines for AI & Human Agents
+1. **Deduplication:** When reviewing open PRs, look for the Jules task link in the description body (since Jules pushes as `abhimehro`). Instantly close duplicate or overlapping Jules PRs in favor of a single consolidated PR (using squash merges).
+2. **Exclusion of Ordinary Human Work:** Strictly preserve true human-authored PRs. Only automate reviews and closes on branches exhibiting clear automation signals (such as Jules/Sentinel branches, specific bot footers, or the `google-labs-jules` bootstrap comment).
+3. **Task Definition Verification:** Check `tasks/todo.md` and `tasks/lessons.md` before approving Jules-suggested code patterns. If Jules suggests patterns that violate active rules (such as missing `set -euo pipefail` in shell templates or bare `except:` blocks in Python), reject the PR and write a custom lesson in `tasks/lessons.md` to prevent recurrence.
+
+---
+
+## Instructions for AI Agents Running Task Mining
+
+When you are asked to run a Phase 2 Mining session on this directory, copy and paste the prompt block below into your terminal context:
+
+```markdown
+# SYSTEMATIC REFACTORING & BACKLOG MINER
+
+## Role
+You are the Code Quality Improvement Agent. Active PR agents already handle
+incoming changes. Your job is the opposite direction: scan the existing
+codebase for technical debt, outdated patterns, and missed optimizations that
+have quietly sat on the back burner.
+
+## Discovery
+1. Use Repo Prompt to pull the directory structure and file contents of the
+   target module only (1-2 directories per run).
+2. Read tasks/lessons.md to honor historical patterns, mistakes, and rules.
+
+## Analysis Criteria
+- Outdated patterns: shell scripts missing `set -euo pipefail`, Python using
+  bare `except:`, deprecated APIs.
+- Security hygiene: hardcoded config, loose permissions, missing input
+  sanitization.
+- Performance: redundant file I/O, unoptimized loops, heavy synchronous work.
+
+## Output Rules
+- Do not write or modify code.
+- Generate at most 3 specific, actionable tasks.
+- If nothing is worth filing, say so and stop.
+- Append each task to tasks/todo.md using exactly this structure:
+
+### [Refactor] <Short, Descriptive Title>
+- **Objective:** <Single-sentence goal>
+- **Files Affected:** <Specific paths and line ranges>
+- **Rationale:** <Security, performance, maintainability, or reliability reason>
+- **Suggested Approach:**
+  - <Step 1>
+  - <Step 2>
+  - <Step 3, optional>
+- **Acceptance Criteria:**
+  - [ ] <Verifiable condition>
+  - [ ] <Verifiable condition>
+```
+
+---
+
+## AI Diagnostic Engine (`lib/ai_engine.sh`)
+
+Phase 1 and Phase 3 source this shared library. It provides two things:
+
+- `run_timeout <seconds> <cmd...>` — a portable hard wall-clock cap (stock macOS
+  has no `timeout`/`gtimeout`; this uses a `perl` `alarm` + `fork`/`exec`).
+- `ai_diagnose <prompt>` — reads a log on **stdin**, embeds it into the prompt,
+  and asks the first working AI CLI to analyze it. It **never hangs** (each
+  attempt is time-boxed) and **never fails the caller** (always returns 0).
+
+### Engine order (configurable)
+
+Default chain = **only engines verified to work headlessly on this machine**
+(2026-05-31 audit):
+
+| Tier | Engine | Invocation                                  | Status |
+|------|--------|---------------------------------------------|--------|
+| 1    | `vibe` | `vibe -p "<prompt>" --agent auto-approve --output text` | **PRIMARY** — verified working; clean text; `[ara-pyshim]` line stripped |
+| 2    | `raw`  | dumps the log                               | always works |
+
+```bash
+: "${SECOPS_AI_ENGINE:=vibe raw}"   # default in lib/ai_engine.sh
+```
+
+Override via env vars (also settable in the plists' `EnvironmentVariables`):
+
+```bash
+SECOPS_AI_ENGINE="vibe raw"     # default
+SECOPS_AI_TIMEOUT=45            # per-attempt seconds (default 60)
+```
+
+### ⚠️ Critical: launchd PATH must include `~/.local/bin`
+
+`vibe` (and `cursor-agent`, `devin`) install to **`~/.local/bin`**, which is
+**not** on the default login PATH that launchd uses. The three plists therefore
+prepend `/Users/speedybee/.local/bin` in `EnvironmentVariables → PATH`. Without
+this, the now-primary `vibe` engine is invisible to the daemons and every
+`ai_diagnose` call silently degrades to `raw`. If you regenerate the plists,
+**keep `~/.local/bin` first in PATH.**
+
+### Opt-in / disabled engines (each has a known headless failure here)
+
+These are still implemented in `lib/ai_engine.sh` but are **not** in the default
+chain. Re-enable explicitly (e.g. `SECOPS_AI_ENGINE="vibe cursor-agent raw"`)
+once the underlying issue is fixed:
+
+- **`copilot`** — *broken install.* The pinned package index
+  `~/Library/Caches/copilot/pkg/darwin-arm64/1.0.56/index.js` is missing, so
+  every invocation prints `ERR_MODULE_NOT_FOUND`. The engine now guards against
+  this (treats the error as "unavailable" so it can't poison a diagnosis).
+  Reinstall the GitHub Copilot CLI to restore. *User also deprioritizes Copilot
+  due to recent quality/quota changes.*
+- **`cursor-agent`** — logged in (`abhimehrotra@bears.mybrcc.edu`), correct flag
+  is `-f`/`--force` (**not** `--trust`, which doesn't exist), but headless print
+  mode returns empty and spawns child `node` processes that outlive a single-PID
+  kill. The hardened `run_timeout` (process-group kill, see below) now contains
+  these, but the engine still produces no usable output — needs investigation.
+- **`gemini`** — `oauth-personal` auth path **blocks indefinitely** in a
+  non-TTY / launchd context and the configured model has 404'd. Confirmed still
+  hanging in the 2026-05-31 audit. Opt-in only via `_ai_try_gemini`
+  (`SECOPS_GEMINI_MODEL`, default `gemini-2.5-flash`).
+
+### Hardened `run_timeout` (process-group kill)
+
+The old `run_timeout` killed only the immediate child PID, so node/python
+helpers spawned by an AI CLI could survive and wedge the daemon (root cause of
+multi-minute hangs). It now runs the child in its own process group
+(`setpgid`) and sends `kill(-9, …)` to the **whole group** on timeout, then
+reaps any stragglers. Stock-macOS portable (perl `alarm` + `fork`/`exec`, no
+coreutils).
+
+---
+
+## Operations
+
+### Install / load the LaunchAgents
+```bash
+bash ~/secops/install.sh            # install + (re)load all three agents
+bash ~/secops/install.sh --uninstall
+```
+
+### Manual dry runs
+```bash
+# Phase 3 with a cheap, fast AI (no premium cost) to validate test logic:
+SECOPS_AI_ENGINE="raw" bash ~/secops/phase3-qa-health.sh
+
+# Phase 3 with real diagnostics:
+bash ~/secops/phase3-qa-health.sh
+
+# Phase 1 is network + git-write; inspect before letting it push.
+```
+
+### Status & logs
+```bash
+launchctl list | grep secops            # loaded? last exit code (col 2)
+tail ~/.qa-health-history.log           # START / PASS / SKIP / FAIL / SUCCESS
+tail ~/.workflow-updater-history.log
+tail ~/.backlog-miner-history.log
+tail ~/Library/Logs/maintenance/secops_phase3.{out,err}
+```
+
+A `launchctl list` second column of `-` means "not currently running"; the third
+column is the **last exit code** (`0` = healthy). Each phase now logs a `START`
+line so you can always confirm it fired.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Phase 3 "fails" on `personal-config` | repo has `package.json` but no `test` script; it uses a Makefile | Fixed: runner now prefers `make test`/`make test-all`. |
+| Phase 3 "fails" on a Python repo | ran system `python3` (missing deps) or collected legacy/broken tests | Fixed: runner prefers the repo's `.venv/bin/pytest`. |
+| Daemon hangs for many minutes | AI CLI (esp. Gemini) blocked with no timeout | Fixed: all AI + test calls are time-boxed via `run_timeout`. |
+| `~/.workflow-updater-history.log` missing | Phase 1 never fired (weekly; or load failed) | `START` logging added; verify with `launchctl list | grep phase1`, or run manually. |
+| AI summary shows raw log only | no AI engine produced output (all timed out / absent) | Confirm at least one of `copilot`/`cursor-agent`/`vibe` works headlessly. |
+
+## Changelog
+
+- **2026-05-31:** Replaced Gemini-only AI path with a tiered, timeout-safe engine
+  (`lib/ai_engine.sh`: copilot → cursor-agent → vibe → raw). Fixed Phase 3 test
+  runner to honor each repo's real test convention (Makefile / npm-if-declared /
+  venv-pytest) and to skip (not fail) repos with no test path. Added hard
+  timeouts to all AI and test/network calls. Added `START` logging to all phases.
+  Moved authoritative scripts into `personal-config/secops/` (symlinked to
+  `~/secops`), backed up plists to `launch-agents/`, added `install.sh`, and
+  wired the symlink into `scripts/sync_all_configs.sh`.

--- a/secops/install.sh
+++ b/secops/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# SecOps Autopilot — installer / loader
+# ==============================================================================
+# Installs (symlinks) the three LaunchAgents and (re)loads them via launchctl.
+# Idempotent: safe to run repeatedly. Run from anywhere.
+#
+#   bash ~/secops/install.sh            # install + load
+#   bash ~/secops/install.sh --uninstall  # bootout + remove symlinks
+# ==============================================================================
+set -euo pipefail
+
+REPO_SECOPS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # resolves through ~/secops symlink
+LA_DIR="$HOME/Library/LaunchAgents"
+REPO_PLIST_DIR="$REPO_SECOPS/../launch-agents"
+LABELS=(com.speedybee.secops.phase1 com.speedybee.secops.phase2 com.speedybee.secops.phase3)
+UID_NUM="$(id -u)"
+
+mkdir -p "$HOME/Library/Logs/maintenance"
+
+uninstall() {
+	for label in "${LABELS[@]}"; do
+		launchctl bootout "gui/$UID_NUM/$label" 2>/dev/null || true
+		rm -f "$LA_DIR/$label.plist"
+		echo "removed $label"
+	done
+	echo "SecOps Autopilot uninstalled."
+}
+
+install() {
+	for label in "${LABELS[@]}"; do
+		src="$REPO_PLIST_DIR/$label.plist"
+		dst="$LA_DIR/$label.plist"
+		if [ ! -f "$src" ]; then
+			echo "WARN: missing $src, skipping"
+			continue
+		fi
+		# Keep a real copy in ~/Library/LaunchAgents (launchd does not follow some symlinks reliably).
+		cp -f "$src" "$dst"
+		launchctl bootout "gui/$UID_NUM/$label" 2>/dev/null || true
+		launchctl bootstrap "gui/$UID_NUM" "$dst" 2>/dev/null || true
+		echo "loaded $label"
+	done
+	echo
+	echo "Installed. Current status:"
+	launchctl list | grep secops || true
+}
+
+case "${1-}" in
+--uninstall) uninstall ;;
+*) install ;;
+esac

--- a/secops/install.sh
+++ b/secops/install.sh
@@ -2,13 +2,15 @@
 # ==============================================================================
 # SecOps Autopilot — installer / loader
 # ==============================================================================
-# Installs (symlinks) the three LaunchAgents and (re)loads them via launchctl.
+# Installs (copies) the three LaunchAgents into ~/Library/LaunchAgents and
+# (re)loads them via launchctl. We copy rather than symlink because launchd
+# does not follow some symlinks reliably (see inline comment in install()).
 # Idempotent: safe to run repeatedly. Run from anywhere.
 #
 #   bash ~/secops/install.sh            # install + load
-#   bash ~/secops/install.sh --uninstall  # bootout + remove symlinks
+#   bash ~/secops/install.sh --uninstall  # bootout + remove plists
 # ==============================================================================
-set -euo pipefail
+set -Eeuo pipefail
 
 REPO_SECOPS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # resolves through ~/secops symlink
 LA_DIR="$HOME/Library/LaunchAgents"

--- a/secops/lib/ai_engine.sh
+++ b/secops/lib/ai_engine.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# SHARED: AI DIAGNOSTIC ENGINE (tiered, timeout-safe)
+# ==============================================================================
+# Part of SecOps Autopilot. Sourced by phase scripts.
+#
+# Provides:
+#   run_timeout <seconds> <cmd...>   - hard wall-clock cap (macOS has no `timeout`)
+#   ai_diagnose <prompt>             - reads a log on stdin, asks an AI CLI to
+#                                      analyze it, NEVER hangs, NEVER fails the
+#                                      caller. Falls back through engines and
+#                                      finally to the raw log.
+#
+# Engine order (most→least reliable headless, configurable via SECOPS_AI_ENGINE):
+#   1. vibe         (Mistral Vibe: `vibe -p "<prompt>"`)      -- PRIMARY. Verified
+#                   working headlessly on this machine; returns clean text.
+#   2. raw          (cat the log)                             -- always works
+#
+# OPT-IN engines (NOT in the default chain — each has a known headless failure
+# on this machine; enable explicitly via SECOPS_AI_ENGINE if/when fixed):
+#   - copilot       (`copilot -p`)        Broken install: the pinned package
+#                   index (~/Library/Caches/copilot/pkg/.../index.js) is missing
+#                   → ERR_MODULE_NOT_FOUND on every invocation. Reinstall the
+#                   GitHub Copilot CLI to restore. User also deprioritizes it.
+#   - cursor-agent  (`cursor-agent -p --output-format text -f`) Logged in, but
+#                   print/headless mode returns empty and spawns child node
+#                   procs that outlive a kill of the immediate child (escapes
+#                   the timeout). Needs investigation before re-enabling.
+#   - gemini        (`gemini -m <model> -p`) OAuth-personal path blocks
+#                   indefinitely in a non-TTY/launchd context and the configured
+#                   model has 404'd; previously wedged Phase 3 for 40+ min.
+#
+# NOTE: cursor-agent uses `-f`/`--force` (a.k.a. `--yolo`), NOT `--trust`.
+# vibe takes the prompt as the argument to `-p` directly: `vibe -p "<prompt>"`.
+# ==============================================================================
+
+# Hard timeout using perl alarm (portable on stock macOS; no coreutils needed).
+# Runs the child in its OWN process group (setpgid) and kills the WHOLE group on
+# timeout, so node/python helpers spawned by the AI CLI can't survive and wedge
+# the daemon. This was the root cause of multi-minute hangs (cursor-agent,
+# gemini) escaping the old single-PID kill.
+run_timeout() {
+	local secs="$1"
+	shift
+	perl -e '
+    use POSIX qw(setpgid);
+    my $t = shift @ARGV;
+    my $pid = fork();
+    if (!defined $pid) { exit 127; }
+    if ($pid == 0) { setpgid(0, 0); exec @ARGV; exit 127; }
+    setpgid($pid, $pid);
+    local $SIG{ALRM} = sub { kill(-9, $pid); waitpid $pid, 0; exit 124; };
+    alarm $t;
+    waitpid $pid, 0;
+    my $rc = $? >> 8;
+    kill(-9, $pid);   # reap any lingering group members
+    exit($rc);
+  ' "$secs" "$@"
+}
+
+# Per-call wall-clock budget for any single AI engine attempt.
+: "${SECOPS_AI_TIMEOUT:=60}"
+# Default chain = only engines verified to work headlessly here. Override to
+# re-enable others once fixed, e.g. SECOPS_AI_ENGINE="vibe cursor-agent raw"
+: "${SECOPS_AI_ENGINE:=vibe raw}"
+
+_ai_try_copilot() {
+	local prompt="$1" log="$2"
+	command -v copilot &>/dev/null || return 2
+	local out
+	out="$(run_timeout "$SECOPS_AI_TIMEOUT" copilot -p \
+		"${prompt}
+
+--- LOG START ---
+$(cat "$log")
+--- LOG END ---" 2>/dev/null)"
+	# Guard: a broken install prints ERR_MODULE_NOT_FOUND / "Failed to load
+	# package index" to stdout. Treat that as "not available" so the chain falls
+	# through instead of accepting an error string as a diagnosis.
+	case "$out" in
+	*ERR_MODULE_NOT_FOUND* | *"Failed to load package index"*) return 2 ;;
+	esac
+	printf '%s\n' "$out"
+}
+
+_ai_try_cursor-agent() {
+	local prompt="$1" log="$2"
+	command -v cursor-agent &>/dev/null || return 2
+	# NOTE: cursor-agent has no --trust flag; -f/--force is the non-interactive
+	# "allow all" switch. Prompt is the trailing positional.
+	run_timeout "$SECOPS_AI_TIMEOUT" cursor-agent -p --output-format text -f \
+		"${prompt}
+
+--- LOG START ---
+$(cat "$log")
+--- LOG END ---" 2>/dev/null
+}
+
+_ai_try_vibe() {
+	local prompt="$1" log="$2"
+	command -v vibe &>/dev/null || return 2
+	# vibe takes the prompt as the argument to -p DIRECTLY. Passing other flags
+	# between -p and the prompt makes vibe see no prompt ("No prompt provided for
+	# programmatic mode"). --agent auto-approve = non-interactive. Strip the
+	# pyshim warning line from output.
+	run_timeout "$SECOPS_AI_TIMEOUT" vibe -p "${prompt}
+
+--- LOG START ---
+$(cat "$log")
+--- LOG END ---" --agent auto-approve --output text 2>/dev/null | grep -v '^\[ara-pyshim\]'
+}
+
+_ai_try_gemini() {
+	local prompt="$1" log="$2"
+	command -v gemini &>/dev/null || return 2
+	local model="${SECOPS_GEMINI_MODEL:-gemini-2.5-flash}"
+	run_timeout "$SECOPS_AI_TIMEOUT" gemini -m "$model" -p \
+		"${prompt}
+
+--- LOG START ---
+$(cat "$log")
+--- LOG END ---" 2>/dev/null
+}
+
+_ai_try_raw() {
+	local prompt="$1" log="$2"
+	echo "[ai_diagnose] No AI engine available; raw log follows:"
+	cat "$log"
+}
+
+# ai_diagnose <prompt>   (reads log from stdin)
+ai_diagnose() {
+	local prompt="$1"
+	local tmp
+	tmp="$(mktemp "${TMPDIR:-/tmp}/secops_ai.XXXXXX")"
+	cat - >"$tmp"
+
+	local engine out rc
+	for engine in $SECOPS_AI_ENGINE; do
+		out="$("_ai_try_${engine}" "$prompt" "$tmp")"
+		rc=$?
+		# rc 2 = engine not installed; 124 = timed out; skip to next.
+		if [ "$rc" -eq 2 ] || [ "$rc" -eq 124 ]; then
+			[ "$rc" -eq 124 ] && echo "[ai_diagnose] engine '$engine' timed out after ${SECOPS_AI_TIMEOUT}s, falling back." >&2
+			continue
+		fi
+		# Accept the first engine that produced non-empty output.
+		if [ -n "${out//[[:space:]]/}" ]; then
+			echo "[ai_diagnose] engine: $engine"
+			echo "$out"
+			rm -f "$tmp"
+			return 0
+		fi
+	done
+
+	rm -f "$tmp"
+	return 0
+}

--- a/secops/lib/ai_engine.sh
+++ b/secops/lib/ai_engine.sh
@@ -52,6 +52,7 @@ run_timeout() {
     local $SIG{ALRM} = sub { kill(-9, $pid); waitpid $pid, 0; exit 124; };
     alarm $t;
     waitpid $pid, 0;
+    alarm 0;          # cancel pending alarm to close the race between waitpid returning and exit($rc) below
     my $rc = $? >> 8;
     kill(-9, $pid);   # reap any lingering group members
     exit($rc);
@@ -137,8 +138,12 @@ ai_diagnose() {
 
 	local engine out rc
 	for engine in $SECOPS_AI_ENGINE; do
-		out="$("_ai_try_${engine}" "$prompt" "$tmp")"
-		rc=$?
+		# Self-enforcing fail-safe: capture rc via `|| rc=$?` so a non-zero
+		# engine result (rc=2 missing, rc=124 timeout, etc.) never trips
+		# `set -e` in a caller that forgot to guard the call site. The `||`
+		# branch preserves the real exit code for the fallback dispatch below.
+		rc=0
+		out="$("_ai_try_${engine}" "$prompt" "$tmp")" || rc=$?
 		# rc 2 = engine not installed; 124 = timed out; skip to next.
 		if [ "$rc" -eq 2 ] || [ "$rc" -eq 124 ]; then
 			[ "$rc" -eq 124 ] && echo "[ai_diagnose] engine '$engine' timed out after ${SECOPS_AI_TIMEOUT}s, falling back." >&2

--- a/secops/phase1-workflow-updater.sh
+++ b/secops/phase1-workflow-updater.sh
@@ -82,8 +82,16 @@ update_repo() {
 	git diff -- "$LOCKFILE"
 
 	git add "$LOCKFILE"
-	git commit -m "chore(deps): update GitHub Actions versions [$(date '+%Y-%m-%d')]"
-	run_timeout "$SECOPS_GH_TIMEOUT" git push origin "$BRANCH"
+	if ! git commit -m "chore(deps): update GitHub Actions versions [$(date '+%Y-%m-%d')]"; then
+		echo "  git commit failed."
+		log "FAIL - $repo git commit failed."
+		return 1
+	fi
+	if ! run_timeout "$SECOPS_GH_TIMEOUT" git push origin "$BRANCH"; then
+		echo "  git push failed/timed out."
+		log "FAIL - $repo git push failed or timed out."
+		return 1
+	fi
 
 	echo "  done."
 	log "SUCCESS - $repo updated action lockfile."

--- a/secops/phase1-workflow-updater.sh
+++ b/secops/phase1-workflow-updater.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# PHASE 1: GITHUB ACTIONS WORKFLOW UPDATER
+# ==============================================================================
+# Part of SecOps Autopilot
+# Cadence: Weekly (Mondays at 9:00 AM)
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/ai_engine.sh
+source "$SCRIPT_DIR/lib/ai_engine.sh" # provides run_timeout
+
+DEV_ROOT="$HOME/dev"
+REPOS=(
+	"personal-config"
+	"ctrld-sync"
+	"email-security-pipeline"
+	"Seatek_Analysis"
+	"Hydrograph_Versus_Seatek_Sensors_Project"
+	"series_correction_project_updated"
+)
+LOCKFILE=".github/aw/actions-lock.json"
+LOG_FILE="$HOME/.workflow-updater-history.log"
+BRANCH="main"
+: "${SECOPS_GH_TIMEOUT:=300}" # network ops cap
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >>"$LOG_FILE"; }
+
+update_repo() {
+	local repo="$1"
+	local dir="$DEV_ROOT/$repo"
+
+	if [ ! -d "$dir/.git" ]; then
+		echo "skip: $repo (not a git repo)"
+		log "SKIP - $repo not a git repo."
+		return 0
+	fi
+
+	echo "==> $repo"
+	cd "$dir"
+
+	# Only act if this repo actually uses gh-aw lockfiles.
+	if [ ! -f "$LOCKFILE" ]; then
+		echo "  skip: no $LOCKFILE"
+		log "SKIP - $repo has no $LOCKFILE."
+		return 0
+	fi
+
+	if ! command -v gh &>/dev/null || ! gh extension list | grep -q "gh-aw"; then
+		echo "  warn: gh-aw not available, skipping update."
+		log "SKIP - $repo gh-aw unavailable."
+		return 0
+	fi
+
+	echo "  updating actions via gh-aw..."
+	if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw update --verbose; then
+		echo "  gh aw update failed/timed out, skipping repo."
+		log "FAIL - $repo gh aw update failed or timed out."
+		return 1
+	fi
+
+	if git diff --quiet -- "$LOCKFILE"; then
+		echo "  up to date."
+		log "NO-OP - $repo workflows up to date."
+		return 0
+	fi
+
+	# Safeguard: never commit compiled lock files.
+	echo "  resetting compiled .lock.yml files..."
+	git checkout -- .github/workflows/*.lock.yml 2>/dev/null || true
+
+	# Dry-run compile validation before committing.
+	echo "  validating compile (dry run)..."
+	if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw compile --validate 2>/dev/null; then
+		echo "  compile validation FAILED, aborting commit."
+		log "FAIL - $repo compile validation failed."
+		return 1
+	fi
+
+	echo "  diff:"
+	git diff -- "$LOCKFILE"
+
+	git add "$LOCKFILE"
+	git commit -m "chore(deps): update GitHub Actions versions [$(date '+%Y-%m-%d')]"
+	run_timeout "$SECOPS_GH_TIMEOUT" git push origin "$BRANCH"
+
+	echo "  done."
+	log "SUCCESS - $repo updated action lockfile."
+}
+
+echo "Starting Phase 1: Workflow Updater..."
+log "START - Phase 1 run begin."
+overall=0
+for repo in "${REPOS[@]}"; do
+	if ! update_repo "$repo"; then
+		overall=1
+	fi
+done
+
+if [ "$overall" -eq 0 ]; then
+	log "SUCCESS - Phase 1 complete."
+else
+	log "PARTIAL - Phase 1 completed with one or more failures."
+fi
+echo "Phase 1 complete. See $LOG_FILE."
+exit "$overall"

--- a/secops/phase1-workflow-updater.sh
+++ b/secops/phase1-workflow-updater.sh
@@ -5,7 +5,7 @@
 # Part of SecOps Autopilot
 # Cadence: Weekly (Mondays at 9:00 AM)
 # ==============================================================================
-set -euo pipefail
+set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/ai_engine.sh
@@ -38,70 +38,83 @@ update_repo() {
 	fi
 
 	echo "==> $repo"
-	cd "$dir"
+	# Run the rest of the function in a subshell so the `cd` is scoped and
+	# never leaks the main process's working directory to the next iteration.
+	# `return` inside a subshell would error, so we use `exit` — the subshell's
+	# exit code is naturally propagated as this function's return code.
+	(
+		cd "$dir"
 
-	# Only act if this repo actually uses gh-aw lockfiles.
-	if [ ! -f "$LOCKFILE" ]; then
-		echo "  skip: no $LOCKFILE"
-		log "SKIP - $repo has no $LOCKFILE."
-		return 0
-	fi
+		# Only act if this repo actually uses gh-aw lockfiles.
+		if [ ! -f "$LOCKFILE" ]; then
+			echo "  skip: no $LOCKFILE"
+			log "SKIP - $repo has no $LOCKFILE."
+			exit 0
+		fi
 
-	if ! command -v gh &>/dev/null || ! gh extension list | grep -q "gh-aw"; then
-		echo "  warn: gh-aw not available, skipping update."
-		log "SKIP - $repo gh-aw unavailable."
-		return 0
-	fi
+		if ! command -v gh &>/dev/null || ! gh extension list | grep -q "gh-aw"; then
+			echo "  warn: gh-aw not available, skipping update."
+			log "SKIP - $repo gh-aw unavailable."
+			exit 0
+		fi
 
-	echo "  updating actions via gh-aw..."
-	if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw update --verbose; then
-		echo "  gh aw update failed/timed out, skipping repo."
-		log "FAIL - $repo gh aw update failed or timed out."
-		return 1
-	fi
+		echo "  updating actions via gh-aw..."
+		if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw update --verbose; then
+			echo "  gh aw update failed/timed out, skipping repo."
+			log "FAIL - $repo gh aw update failed or timed out."
+			exit 1
+		fi
 
-	if git diff --quiet -- "$LOCKFILE"; then
-		echo "  up to date."
-		log "NO-OP - $repo workflows up to date."
-		return 0
-	fi
+		if git diff --quiet -- "$LOCKFILE"; then
+			echo "  up to date."
+			log "NO-OP - $repo workflows up to date."
+			exit 0
+		fi
 
-	# Safeguard: never commit compiled lock files.
-	echo "  resetting compiled .lock.yml files..."
-	git checkout -- .github/workflows/*.lock.yml 2>/dev/null || true
+		# Safeguard: never commit compiled lock files.
+		echo "  resetting compiled .lock.yml files..."
+		git checkout -- .github/workflows/*.lock.yml 2>/dev/null || true
 
-	# Dry-run compile validation before committing.
-	echo "  validating compile (dry run)..."
-	if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw compile --validate 2>/dev/null; then
-		echo "  compile validation FAILED, aborting commit."
-		log "FAIL - $repo compile validation failed."
-		return 1
-	fi
+		# Dry-run compile validation before committing.
+		echo "  validating compile (dry run)..."
+		if ! run_timeout "$SECOPS_GH_TIMEOUT" gh aw compile --validate 2>/dev/null; then
+			echo "  compile validation FAILED, aborting commit."
+			log "FAIL - $repo compile validation failed."
+			exit 1
+		fi
 
-	echo "  diff:"
-	git diff -- "$LOCKFILE"
+		echo "  diff:"
+		git diff -- "$LOCKFILE"
 
-	git add "$LOCKFILE"
-	if ! git commit -m "chore(deps): update GitHub Actions versions [$(date '+%Y-%m-%d')]"; then
-		echo "  git commit failed."
-		log "FAIL - $repo git commit failed."
-		return 1
-	fi
-	if ! run_timeout "$SECOPS_GH_TIMEOUT" git push origin "$BRANCH"; then
-		echo "  git push failed/timed out."
-		log "FAIL - $repo git push failed or timed out."
-		return 1
-	fi
+		git add "$LOCKFILE"
+		if ! git commit -m "chore(deps): update GitHub Actions versions [$(date '+%Y-%m-%d')]"; then
+			echo "  git commit failed."
+			log "FAIL - $repo git commit failed."
+			exit 1
+		fi
+		if ! run_timeout "$SECOPS_GH_TIMEOUT" git push origin "$BRANCH"; then
+			echo "  git push failed/timed out."
+			log "FAIL - $repo git push failed or timed out."
+			exit 1
+		fi
 
-	echo "  done."
-	log "SUCCESS - $repo updated action lockfile."
+		echo "  done."
+		log "SUCCESS - $repo updated action lockfile."
+	)
 }
 
 echo "Starting Phase 1: Workflow Updater..."
 log "START - Phase 1 run begin."
 overall=0
 for repo in "${REPOS[@]}"; do
-	if ! update_repo "$repo"; then
+	# Mirror Phase 3's pattern: bracket the call with set +e / set -e and
+	# capture rc explicitly, so `set -e` semantics inside update_repo are
+	# preserved (the `if ! update_repo` form disables them in the callee).
+	set +e
+	update_repo "$repo"
+	rc=$?
+	set -e
+	if [ "$rc" -ne 0 ]; then
 		overall=1
 	fi
 done

--- a/secops/phase2-mine.sh
+++ b/secops/phase2-mine.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# PHASE 2: BACKLOG MINER ORCHESTRATOR & SUMMARY GENERATOR
+# ==============================================================================
+# Part of SecOps Autopilot
+# Cadence: Bi-weekly / Monthly (1st and 15th at 10:00 AM)
+# ==============================================================================
+set -euo pipefail
+
+DEV_ROOT="$HOME/dev"
+REPOS=(
+	"personal-config"
+	"ctrld-sync"
+	"email-security-pipeline"
+	"Seatek_Analysis"
+	"Hydrograph_Versus_Seatek_Sensors_Project"
+	"series_correction_project_updated"
+)
+LOG_FILE="$HOME/.backlog-miner-history.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >>"$LOG_FILE"; }
+
+echo "=============================================================================="
+echo "Starting Phase 2: Backlog Miner & Triage Orchestrator"
+echo "=============================================================================="
+log "START - Phase 2 run begin."
+
+# This script can serve as the kickoff agent. It checks the presence of 'todo.md' or 'lessons.md'
+# across all repositories and logs a status update of your technical debt files.
+
+for repo in "${REPOS[@]}"; do
+	dir="$DEV_ROOT/$repo"
+	if [ ! -d "$dir/.git" ]; then
+		echo "skip: $repo (not a git repo)"
+		continue
+	fi
+
+	echo "==> Mining repo structure for: $repo"
+
+	tasks_dir="$dir/tasks"
+	lessons_file="$tasks_dir/lessons.md"
+	todo_file="$tasks_dir/todo.md"
+
+	if [ -f "$todo_file" ]; then
+		open_todos=$(grep -c "^- \[ \]" "$todo_file" 2>/dev/null)
+		open_todos=${open_todos:-0}
+		completed_todos=$(grep -c "^- \[x\]" "$todo_file" 2>/dev/null)
+		completed_todos=${completed_todos:-0}
+		echo "  Found tasks/todo.md: $open_todos open, $completed_todos completed tasks."
+		log "INFO - $repo: $open_todos open, $completed_todos completed tasks."
+	else
+		echo "  No tasks/todo.md file exists."
+		log "INFO - $repo: No todo.md found."
+	fi
+
+	if [ -f "$lessons_file" ]; then
+		lessons_count=$(grep -c "^#" "$lessons_file" 2>/dev/null)
+		lessons_count=${lessons_count:-0}
+		echo "  Found tasks/lessons.md: ~$lessons_count rule records / titles."
+	else
+		echo "  No tasks/lessons.md file exists."
+	fi
+done
+
+echo ""
+echo "=============================================================================="
+echo "HOW TO RUN REFACTOR MINING:"
+echo "------------------------------------------------------------------------------"
+echo "To execute a deep-dive scan using Repo Prompt and Windsurf/Cursor, paste the"
+echo "systematic refactoring prompt located in ~/secops/README.md into your active"
+echo "reasoning window. Focus on 1-2 directories inside one of the repos listed above."
+echo "=============================================================================="
+
+log "SUCCESS - Backlog structure audit complete."

--- a/secops/phase2-mine.sh
+++ b/secops/phase2-mine.sh
@@ -54,7 +54,7 @@ for repo in "${REPOS[@]}"; do
 	fi
 
 	if [ -f "$lessons_file" ]; then
-		lessons_count=$(grep -c "^#" "$lessons_file" 2>/dev/null)
+		lessons_count=$(grep -c "^#" "$lessons_file" 2>/dev/null || true)
 		lessons_count=${lessons_count:-0}
 		echo "  Found tasks/lessons.md: ~$lessons_count rule records / titles."
 	else

--- a/secops/phase2-mine.sh
+++ b/secops/phase2-mine.sh
@@ -42,9 +42,9 @@ for repo in "${REPOS[@]}"; do
 	todo_file="$tasks_dir/todo.md"
 
 	if [ -f "$todo_file" ]; then
-		open_todos=$(grep -c "^- \[ \]" "$todo_file" 2>/dev/null)
+		open_todos=$(grep -c "^- \[ \]" "$todo_file" 2>/dev/null || true)
 		open_todos=${open_todos:-0}
-		completed_todos=$(grep -c "^- \[x\]" "$todo_file" 2>/dev/null)
+		completed_todos=$(grep -c "^- \[x\]" "$todo_file" 2>/dev/null || true)
 		completed_todos=${completed_todos:-0}
 		echo "  Found tasks/todo.md: $open_todos open, $completed_todos completed tasks."
 		log "INFO - $repo: $open_todos open, $completed_todos completed tasks."

--- a/secops/phase2-mine.sh
+++ b/secops/phase2-mine.sh
@@ -5,7 +5,7 @@
 # Part of SecOps Autopilot
 # Cadence: Bi-weekly / Monthly (1st and 15th at 10:00 AM)
 # ==============================================================================
-set -euo pipefail
+set -Eeuo pipefail
 
 DEV_ROOT="$HOME/dev"
 REPOS=(

--- a/secops/phase3-qa-health.sh
+++ b/secops/phase3-qa-health.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# PHASE 3: QA, HEALTH CHECK, & DRIFT DETECTION
+# ==============================================================================
+# Part of SecOps Autopilot
+# Cadence: Daily (8:00 AM)
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/ai_engine.sh
+source "$SCRIPT_DIR/lib/ai_engine.sh"
+
+DEV_ROOT="$HOME/dev"
+REPOS=(
+	"personal-config"
+	"ctrld-sync"
+	"email-security-pipeline"
+	"Seatek_Analysis"
+	"Hydrograph_Versus_Seatek_Sensors_Project"
+	"series_correction_project_updated"
+)
+LOG_FILE="$HOME/.qa-health-history.log"
+SSH_ROTATION_PLIST="$HOME/Library/LaunchAgents/com.speedybee.sshkeyrotation.plist"
+SSH_ROTATION_LABEL="com.speedybee.sshkeyrotation"
+
+# Per-repo test wall-clock cap (seconds) so a hung suite can't wedge the daemon.
+: "${SECOPS_TEST_TIMEOUT:=600}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >>"$LOG_FILE"; }
+
+notify() {
+	local msg="$1"
+	osascript -e "display notification \"${msg}\" with title \"SecOps Autopilot\"" 2>/dev/null || true
+}
+
+# Decide and run the repo's OWN declared test command.
+# Returns: 0 pass, 1 fail, 2 no-test-path (skip — not a failure).
+run_project_tests() {
+	local dir="$1"
+	cd "$dir"
+
+	# 1) Makefile is the strongest signal of the repo's real convention.
+	if [ -f "Makefile" ]; then
+		if grep -qE '^test-all:' Makefile; then
+			run_timeout "$SECOPS_TEST_TIMEOUT" make test-all 2>&1
+			return $?
+		elif grep -qE '^test:' Makefile; then
+			run_timeout "$SECOPS_TEST_TIMEOUT" make test 2>&1
+			return $?
+		fi
+	fi
+
+	# 2) Node project — only if a real "test" script is declared.
+	if [ -f "package.json" ]; then
+		if node -e 'process.exit((require("./package.json").scripts||{}).test?0:1)' 2>/dev/null; then
+			run_timeout "$SECOPS_TEST_TIMEOUT" npm run test -- --watchAll=false 2>&1
+			return $?
+		else
+			echo "package.json present but no 'test' script declared — skipping."
+			return 2
+		fi
+	fi
+
+	# 3) Python project — prefer the repo's own venv, then a pytest on PATH.
+	if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "pytest.ini" ]; then
+		if [ -x ".venv/bin/pytest" ]; then
+			run_timeout "$SECOPS_TEST_TIMEOUT" .venv/bin/pytest 2>&1
+			return $?
+		elif command -v pytest &>/dev/null; then
+			run_timeout "$SECOPS_TEST_TIMEOUT" pytest 2>&1
+			return $?
+		else
+			echo "Python project but no .venv/pytest available — skipping."
+			return 2
+		fi
+	fi
+
+	echo "no recognized test path, skipping."
+	return 2
+}
+
+audit_system_drift() {
+	echo "Auditing system configuration drift..."
+
+	if command -v scutil &>/dev/null; then
+		echo "DNS configuration:"
+		scutil --dns | grep -A 5 "nameserver" || true
+	fi
+
+	if [ -f "$DEV_ROOT/personal-config/scripts/verify_ssh_config.sh" ]; then
+		echo "SSH Config Status:"
+		bash "$DEV_ROOT/personal-config/scripts/verify_ssh_config.sh" || true
+	fi
+
+	if [ -f "$SSH_ROTATION_PLIST" ]; then
+		if launchctl list | grep -q "$SSH_ROTATION_LABEL"; then
+			echo "SSH key rotation LaunchAgent: active."
+		else
+			echo "SSH key rotation LaunchAgent: present but inactive."
+		fi
+	else
+		echo "SSH key rotation LaunchAgent: plist missing."
+	fi
+}
+
+echo "Starting Phase 3: QA & Drift Audit..."
+log "START - Phase 3 run begin."
+overall=0
+
+# --- Per-repo build/test verification ---
+for repo in "${REPOS[@]}"; do
+	dir="$DEV_ROOT/$repo"
+	if [ ! -d "$dir/.git" ]; then
+		echo "skip: $repo (not a git repo)"
+		log "SKIP - $repo not a git repo."
+		continue
+	fi
+
+	echo "==> testing $repo"
+	set +e
+	run_project_tests "$dir" >"/tmp/test_run_${repo}.log" 2>&1
+	rc=$?
+	set -e
+
+	case "$rc" in
+	0)
+		echo "  $repo: passed."
+		log "PASS - $repo."
+		;;
+	2)
+		echo "  $repo: no test path, skipped."
+		log "SKIP - $repo no test path."
+		;;
+	124)
+		echo "  $repo: tests TIMED OUT (>${SECOPS_TEST_TIMEOUT}s)."
+		notify "QA timeout in ${repo}."
+		log "TIMEOUT - $repo exceeded ${SECOPS_TEST_TIMEOUT}s."
+		overall=1
+		;;
+	*)
+		echo "  tests FAILED for $repo (rc=$rc), requesting diagnostics..."
+		ai_diagnose "Analyze this test failure log, identify the root cause, and provide a concise step-by-step fix following Security-First Development guidelines. Be brief." \
+			<"/tmp/test_run_${repo}.log" || true
+		notify "QA failed in ${repo}. Diagnostics generated."
+		log "FAIL - $repo test regression (rc=$rc)."
+		overall=1
+		;;
+	esac
+done
+
+# --- System-level Drift Audit ---
+audit_system_drift >/tmp/drift_audit.log 2>&1
+echo "Drift audit summary:"
+ai_diagnose "Review this system configuration log. Are there signs of configuration drift, inactive launch daemons, or DNS leaks? Respond with 'No drift detected' or a short warning list. Do not suggest applying changes automatically. Be brief." \
+	</tmp/drift_audit.log || true
+
+if [ "$overall" -eq 0 ]; then
+	echo "Phase 3 complete. System healthy and aligned."
+	log "SUCCESS - All checks passed or skipped."
+else
+	echo "Phase 3 complete with failures. See $LOG_FILE."
+	log "PARTIAL - One or more repos failed."
+fi
+
+exit "$overall"

--- a/secops/phase3-qa-health.sh
+++ b/secops/phase3-qa-health.sh
@@ -5,7 +5,7 @@
 # Part of SecOps Autopilot
 # Cadence: Daily (8:00 AM)
 # ==============================================================================
-set -euo pipefail
+set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/ai_engine.sh
@@ -38,46 +38,51 @@ notify() {
 # Returns: 0 pass, 1 fail, 2 no-test-path (skip — not a failure).
 run_project_tests() {
 	local dir="$1"
-	cd "$dir"
+	# Run in a subshell so the `cd` is scoped and can't leak the main
+	# process's cwd to the next repo iteration. `exit` codes from the
+	# subshell are naturally propagated as this function's return code.
+	(
+		cd "$dir"
 
-	# 1) Makefile is the strongest signal of the repo's real convention.
-	if [ -f "Makefile" ]; then
-		if grep -qE '^test-all:' Makefile; then
-			run_timeout "$SECOPS_TEST_TIMEOUT" make test-all 2>&1
-			return $?
-		elif grep -qE '^test:' Makefile; then
-			run_timeout "$SECOPS_TEST_TIMEOUT" make test 2>&1
-			return $?
+		# 1) Makefile is the strongest signal of the repo's real convention.
+		if [ -f "Makefile" ]; then
+			if grep -qE '^test-all:' Makefile; then
+				run_timeout "$SECOPS_TEST_TIMEOUT" make test-all 2>&1
+				exit $?
+			elif grep -qE '^test:' Makefile; then
+				run_timeout "$SECOPS_TEST_TIMEOUT" make test 2>&1
+				exit $?
+			fi
 		fi
-	fi
 
-	# 2) Node project — only if a real "test" script is declared.
-	if [ -f "package.json" ]; then
-		if node -e 'process.exit((require("./package.json").scripts||{}).test?0:1)' 2>/dev/null; then
-			run_timeout "$SECOPS_TEST_TIMEOUT" npm run test -- --watchAll=false 2>&1
-			return $?
-		else
-			echo "package.json present but no 'test' script declared — skipping."
-			return 2
+		# 2) Node project — only if a real "test" script is declared.
+		if [ -f "package.json" ]; then
+			if node -e 'process.exit((require("./package.json").scripts||{}).test?0:1)' 2>/dev/null; then
+				run_timeout "$SECOPS_TEST_TIMEOUT" npm run test -- --watchAll=false 2>&1
+				exit $?
+			else
+				echo "package.json present but no 'test' script declared — skipping."
+				exit 2
+			fi
 		fi
-	fi
 
-	# 3) Python project — prefer the repo's own venv, then a pytest on PATH.
-	if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "pytest.ini" ]; then
-		if [ -x ".venv/bin/pytest" ]; then
-			run_timeout "$SECOPS_TEST_TIMEOUT" .venv/bin/pytest 2>&1
-			return $?
-		elif command -v pytest &>/dev/null; then
-			run_timeout "$SECOPS_TEST_TIMEOUT" pytest 2>&1
-			return $?
-		else
-			echo "Python project but no .venv/pytest available — skipping."
-			return 2
+		# 3) Python project — prefer the repo's own venv, then a pytest on PATH.
+		if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "pytest.ini" ]; then
+			if [ -x ".venv/bin/pytest" ]; then
+				run_timeout "$SECOPS_TEST_TIMEOUT" .venv/bin/pytest 2>&1
+				exit $?
+			elif command -v pytest &>/dev/null; then
+				run_timeout "$SECOPS_TEST_TIMEOUT" pytest 2>&1
+				exit $?
+			else
+				echo "Python project but no .venv/pytest available — skipping."
+				exit 2
+			fi
 		fi
-	fi
 
-	echo "no recognized test path, skipping."
-	return 2
+		echo "no recognized test path, skipping."
+		exit 2
+	)
 }
 
 audit_system_drift() {


### PR DESCRIPTION
Root-cause fixes for the failing SecOps Autopilot daemons:

- lib/ai_engine.sh: default chain now "vibe raw" (vibe verified working headlessly; copilot/cursor-agent/gemini moved to opt-in with documented failure modes).
- Harden run_timeout: run child in its own process group and kill(-9) the whole group on timeout so node/python helpers can't survive and wedge the daemon (root cause of 40+ min hangs).
- Fix vibe invocation: prompt must immediately follow -p. Fix cursor-agent flag --trust -> -f (--trust does not exist).
- Guard copilot's broken-install ERR_MODULE_NOT_FOUND so an error string is never accepted as a diagnosis.
- launch-agents/*.plist: prepend /Users/speedybee/.local/bin to PATH so launchd can find vibe (was silently degrading every ai_diagnose to raw).
- README: vibe-first chain, critical ~/.local/bin PATH note, per-engine failure modes, hardened run_timeout.

Verified: bash -n + trunk fmt clean; ai_diagnose selects vibe and returns clean output (pre- and post-format); Phase 2 + Phase 3 dry runs pass; vibe resolvable under restricted launchd PATH; all 3 LaunchAgents reloaded.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- The problem this PR solves, or the motivation behind it. -->

## How

<!-- Brief explanation of the approach. Highlight any non-obvious design decisions. -->

## Testing

<!-- How did you verify this works? Examples:
  - `make test-quick` passed
  - `make test` passed
  - Manual steps: describe what you ran and what you observed
-->

## Security

<!-- Any security implications, trust-boundary changes, or secrets-handling decisions.
     If none, write "No security impact." -->

---

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated if behaviour changed
- [x] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->