### PR TITLE
🧪 [Testing] Add edge case tests for allowlist domain extraction

### DIFF
--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 project_root = Path(__file__).resolve().parent.parent
 sys.path.append(str(project_root))
 
-from adguard.scripts.extract_domains import extract_domains_from_file
+from adguard.scripts.extract_domains import extract_domains_from_file, extract_allowlist_domains_from_file, _is_allowlist_rule
 
 
 class TestExtractDomainsFromFile(unittest.TestCase):
@@ -126,6 +126,80 @@ class TestExtractDomainsFromFile(unittest.TestCase):
 
         try:
             result = extract_domains_from_file(temp_path)
+            self.assertEqual(result, [])
+            mock_print.assert_called_once()
+            self.assertIn(f"Error reading {temp_path}", mock_print.call_args[0][0])
+        finally:
+            os.remove(temp_path)
+
+
+
+
+class TestIsAllowlistRule(unittest.TestCase):
+    def test_valid_allowlist_rule(self):
+        rule = {"PK": "example.com", "action": {"do": 1}}
+        self.assertTrue(_is_allowlist_rule(rule))
+
+    def test_missing_pk(self):
+        rule = {"action": {"do": 1}}
+        self.assertFalse(_is_allowlist_rule(rule))
+
+    def test_missing_action(self):
+        rule = {"PK": "example.com"}
+        self.assertFalse(_is_allowlist_rule(rule))
+
+    def test_action_not_dict(self):
+        # Edge case: action is present but not a dictionary
+        self.assertFalse(_is_allowlist_rule({"PK": "example.com", "action": 1}))
+        self.assertFalse(_is_allowlist_rule({"PK": "example.com", "action": "allow"}))
+        self.assertFalse(_is_allowlist_rule({"PK": "example.com", "action": []}))
+        self.assertFalse(_is_allowlist_rule({"PK": "example.com", "action": None}))
+
+    def test_missing_do(self):
+        rule = {"PK": "example.com", "action": {"other": 1}}
+        self.assertFalse(_is_allowlist_rule(rule))
+
+    def test_do_not_one(self):
+        rule = {"PK": "example.com", "action": {"do": 0}}
+        self.assertFalse(_is_allowlist_rule(rule))
+
+
+class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
+    def test_happy_path(self):
+        json_data = json.dumps({
+            "rules": [
+                {"PK": "example.com", "action": {"do": 1}},
+                {"PK": "test.com", "action": {"do": 0}},
+                {"PK": "anotherexample.com", "action": {"do": 1}}
+            ]
+        })
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as tf:
+            tf.write(json_data)
+            temp_path = tf.name
+
+        try:
+            result = extract_allowlist_domains_from_file(temp_path)
+            self.assertEqual(result, ["example.com", "anotherexample.com"])
+        finally:
+            os.remove(temp_path)
+
+    @patch("builtins.print")
+    def test_missing_file(self, mock_print):
+        missing_path = "nonexistent_file_12345.json"
+        result = extract_allowlist_domains_from_file(missing_path)
+        self.assertEqual(result, [])
+        mock_print.assert_called_once()
+        self.assertIn(f"Error reading {missing_path}", mock_print.call_args[0][0])
+
+    @patch("builtins.print")
+    def test_invalid_json(self, mock_print):
+        invalid_json = "this is not json"
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as tf:
+            tf.write(invalid_json)
+            temp_path = tf.name
+
+        try:
+            result = extract_allowlist_domains_from_file(temp_path)
             self.assertEqual(result, [])
             mock_print.assert_called_once()
             self.assertIn(f"Error reading {temp_path}", mock_print.call_args[0][0])


### PR DESCRIPTION
🎯 **What:** The `_is_allowlist_rule` helper function in `extract_domains.py` lacked tests verifying its defensive behavior when the `action` key was not a dictionary. This PR closes that testing gap and adds comprehensive tests for the `extract_allowlist_domains_from_file` function.
📊 **Coverage:** Scenarios added:
- Action key exists but is not a dict (e.g., int, string, list, None)
- Missing PK key
- Missing action key
- Action is a dict but missing 'do'
- Action is a dict but 'do' is not 1
- `extract_allowlist_domains_from_file` happy path
- `extract_allowlist_domains_from_file` sad paths (invalid JSON, missing file)
✨ **Result:** Enhanced test coverage guarantees regression prevention and correct extraction behavior for allowlists, increasing confidence in the `adguard/scripts` processing pipeline.

---
*PR created automatically by Jules for task [1986385377258495693](https://jules.google.com/task/1986385377258495693) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->