### PR TITLE
🧪 test: add unit tests for fetch_pr_info

### DIFF
--- a/tests/test_categorize_ready.py
+++ b/tests/test_categorize_ready.py
@@ -9,7 +9,7 @@ from tests.test_vulnerability_fix import _load_function_only
 
 class TestCategorizeReady(unittest.TestCase):
     def setUp(self):
-        self.mod = _load_function_only("categorize_ready.py", {"run_gh", "_load_gh_token_env"})
+        self.mod = _load_function_only("categorize_ready.py", {"run_gh", "_load_gh_token_env", "fetch_pr_info"})
 
     @patch('subprocess.run')
     def test_run_gh_invalid_json(self, mock_run):
@@ -43,6 +43,45 @@ class TestCategorizeReady(unittest.TestCase):
         result = self.mod.run_gh(['gh', 'pr', 'view', '123'])
 
         self.assertEqual(result, {"title": "test", "state": "open"})
+
+
+    def test_fetch_pr_info_success(self):
+        self.mod.run_gh = MagicMock(return_value={"title": "Test PR", "mergeStateStatus": "CLEAN"})
+        pr_string = "owner/repo#123"
+        pr, info = self.mod.fetch_pr_info(pr_string)
+
+        self.mod.run_gh.assert_called_once_with([
+            "gh",
+            "pr",
+            "view",
+            "123",
+            "-R",
+            "owner/repo",
+            "--json",
+            "title,mergeStateStatus"
+        ])
+
+        self.assertEqual(pr, pr_string)
+        self.assertEqual(info, {"title": "Test PR", "mergeStateStatus": "CLEAN"})
+
+    def test_fetch_pr_info_failure(self):
+        self.mod.run_gh = MagicMock(return_value=None)
+        pr_string = "owner/repo#123"
+        pr, info = self.mod.fetch_pr_info(pr_string)
+
+        self.mod.run_gh.assert_called_once_with([
+            "gh",
+            "pr",
+            "view",
+            "123",
+            "-R",
+            "owner/repo",
+            "--json",
+            "title,mergeStateStatus"
+        ])
+
+        self.assertEqual(pr, pr_string)
+        self.assertIsNone(info)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added unit tests for the previously untested `fetch_pr_info` function in `categorize_ready.py`.
📊 **Coverage:** The tests cover the successful API call path (parsing repo and ID, formatting gh arguments correctly) and the failure path (when `run_gh` returns `None`).
✨ **Result:** Test coverage improved without altering the script's global execution state, adhering to the repository's `_load_function_only` pattern.

---
*PR created automatically by Jules for task [11874039128041745896](https://jules.google.com/task/11874039128041745896) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->