### PR TITLE
🧹 Code Health: Remove unused `defaultdict` import in scratch_inventory.py

### DIFF
--- a/scratch_inventory.py
+++ b/scratch_inventory.py
@@ -2,7 +2,6 @@ import datetime
 import concurrent.futures
 import json
 import subprocess
-from collections import defaultdict
 
 from spreadsheet_safety import escape_spreadsheet_formula
 


### PR DESCRIPTION
🎯 **What:** Removed an unused import of `defaultdict` from `collections`.
💡 **Why:** Cleans up code health by removing an unused standard library import, which prevents linter warnings and improves code readability.
✅ **Verification:** Verified via `python -m py_compile scratch_inventory.py` and ran existing test suite (`pytest tests/test_scratch_inventory.py`).
✨ **Result:** The codebase is cleaner and maintainability is improved without any functional changes.

---
*PR created automatically by Jules for task [10760497341924224082](https://jules.google.com/task/10760497341924224082) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->