### PR TITLE
🧹 Refactor unused and inefficient imports in scratch_triage.py

### DIFF
--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -1,7 +1,6 @@
 import datetime
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
 import json
-import re
 import subprocess
 
 repos = [
@@ -127,7 +126,7 @@ def _fetch_repo_prs(repo):
 if __name__ == '__main__':
     all_prs = []
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR fetching
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    with ThreadPoolExecutor(max_workers=10) as executor:
         for repo_prs in executor.map(_fetch_repo_prs, repos):
             all_prs.extend(repo_prs)
 


### PR DESCRIPTION
🎯 **What:** Removed an unused standard library import `import re` and refactored `import concurrent.futures` to an explicit `from concurrent.futures import ThreadPoolExecutor`.
💡 **Why:** The issue highlighted that the import of `concurrent.futures` was perceived as unused or problematic (possibly by a linter rule analyzing the exact string). By refactoring to explicitly import `ThreadPoolExecutor` and removing the completely unused `re` import, the file is cleaner and complies with better naming practices and linting standards without changing its functionality.
✅ **Verification:** Verified that both `ruff check scratch_triage.py` and `pytest tests/test_scratch_triage.py` pass without any errors. The codebase functionality remains unchanged.
✨ **Result:** Cleaned up unused and vaguely identified imports, improving overall code health and readability.

---
*PR created automatically by Jules for task [9787225834500132336](https://jules.google.com/task/9787225834500132336) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->