### PR TITLE
fix(maintenance): fix logic flaw where script continued if LOCK_DIR wasn't a directory

### DIFF
--- a/maintenance/bin/monthly_maintenance.sh
+++ b/maintenance/bin/monthly_maintenance.sh
@@ -31,6 +31,12 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
 			echo "$(date '+%Y-%m-%d %H:%M:%S') [WARNING] Another instance is already running (lock: $LOCK_DIR, age: $((LOCK_AGE / 60)) min)"
 			exit 0
 		fi
+	elif [[ -e $LOCK_DIR ]]; then
+		echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to acquire lock (path exists but is not a directory): $LOCK_DIR"
+		exit 1
+	else
+		echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to acquire lock (permission denied or other error): $LOCK_DIR"
+		exit 1
 	fi
 fi
 trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM

--- a/maintenance/bin/run_all_maintenance.sh
+++ b/maintenance/bin/run_all_maintenance.sh
@@ -94,9 +94,12 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
 			echo "Another instance is already running (age: $((LOCK_AGE / 60)) min)"
 			exit 0
 		fi
-	else
+	elif [[ -e $LOCK_DIR ]]; then
 		# 🛡️ Sentinel: Fix logic flaw where script continued if LOCK_DIR existed but wasn't a directory
-		echo "ERROR: Failed to acquire lock (path exists but is not a directory or permission denied): $LOCK_DIR"
+		echo "ERROR: Failed to acquire lock (path exists but is not a directory): $LOCK_DIR"
+		exit 1
+	else
+		echo "ERROR: Failed to acquire lock (permission denied or other error): $LOCK_DIR"
 		exit 1
 	fi
 fi

--- a/maintenance/bin/weekly_maintenance.sh
+++ b/maintenance/bin/weekly_maintenance.sh
@@ -31,6 +31,12 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
 			echo "$(date '+%Y-%m-%d %H:%M:%S') [WARNING] Another instance is already running (lock: $LOCK_DIR, age: $((LOCK_AGE / 60)) min)"
 			exit 0
 		fi
+	elif [[ -e $LOCK_DIR ]]; then
+		echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to acquire lock (path exists but is not a directory): $LOCK_DIR"
+		exit 1
+	else
+		echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to acquire lock (permission denied or other error): $LOCK_DIR"
+		exit 1
 	fi
 fi
 trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM


### PR DESCRIPTION
T3 — Debug: root cause analysis ➔ fix.

========== ELIR ==========
PURPOSE: Fix logic flaw in maintenance scripts where `mkdir $LOCK_DIR` failure fell back to a generic branch without checking if the existing entity was a file vs a directory, causing lock-checking to mistakenly continue or report false permission issues.
SECURITY: Avoids silent failure overrides on invalid state locking files, ensuring proper exclusivity.
FAILS IF: A non-directory file is created as the lock directory, which fails `mkdir` but previously skipped the valid error exit if it wasn't a directory.
VERIFY: Tested `test_run_all_maintenance.sh` passes successfully. `monthly` and `weekly` scripts are similarly patched.
MAINTAIN: Ensure all lock scripts utilize `elif [[ -e $LOCK_DIR ]]` rather than just `if [[ -d $LOCK_DIR ]]` to prevent overlapping edge-cases for locking.

---
*PR created automatically by Jules for task [9378759231181450840](https://jules.google.com/task/9378759231181450840) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->