### PR TITLE
fix(ssh): correctly report DNS and unknown errors as errors

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@
 ## 2026-05-31 - [Avoid Redundant title.lower() in conditionals]
 **Learning:** Checking a series of hardcoded substrings sequentially against `.lower()` of a string (`"auth" in title.lower() or "payment" in title.lower()`) inside loops creates unnecessary CPU overhead when the keyword doesn't match and the `or` falls through. In Python, doing `title.lower()` redundantly repeatedly inside an `if` block executes the C-level lowercase string allocation `N` times.
 **Action:** When performing `in` checks against multiple strings using an `or` operation, declare a temporary lowercase string variable (`title_lower = title.lower()`) before the `if` block and compare against it directly to halve the overhead.
+
+## 2024-06-01 - Correctly report other errors instead of reporting success
+**Learning:** SSH connection failures (like DNS failures) were being reported as warnings because the default catch-all in the SSH checking logic used `warn` instead of `error`. This led to failures being treated as non-fatal.
+**Action:** Added an explicit check for `Could not resolve hostname` and converted the default catch-all statement from `warn` to `error`.

--- a/scripts/test_ssh_connections.sh
+++ b/scripts/test_ssh_connections.sh
@@ -60,9 +60,11 @@ for host in "${hosts[@]}"; do
 				error "  SSH: Connection refused (SSH service not running)"
 			elif echo "$result" | grep -q "Connection timed out"; then
 				error "  SSH: Connection timed out"
+			elif echo "$result" | grep -q "Could not resolve hostname"; then
+				error "  SSH: Could not resolve hostname (DNS failure)"
 			else
 				# ⚡ Bolt Fix: correctly report other errors (e.g. DNS failure) instead of reporting success
-				warn "  SSH: $result"
+				error "  SSH: $result"
 			fi
 		fi
 	else


### PR DESCRIPTION
Correctly catch "Could not resolve hostname" to indicate a DNS failure and downgrade unknown failures from generic warnings to proper errors.

---
*PR created automatically by Jules for task [12575685500258863945](https://jules.google.com/task/12575685500258863945) started by @abhimehro*