### PR TITLE
🔒 Fix Bash Eval Injection in smart_scheduler.sh

### DIFF
--- a/maintenance/bin/smart_scheduler.sh
+++ b/maintenance/bin/smart_scheduler.sh
@@ -44,11 +44,11 @@ spinner_wait() {
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; '"${old_int_trap:-trap - INT}"'; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; '"${old_term_trap:-trap - TERM}"'; kill -TERM "$$"' TERM
 
 		local interval=0.5
 		iterations=$(echo "$duration / $interval" | bc -l | cut -d. -f1)
@@ -61,8 +61,8 @@ spinner_wait() {
 
 		# Restore cursor and original traps
 		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
-		eval "${old_int_trap:-trap - INT}"
-		eval "${old_term_trap:-trap - TERM}"
+		if [ -n "$old_int_trap" ]; then eval "$old_int_trap"; else trap - INT; fi
+		if [ -n "$old_term_trap" ]; then eval "$old_term_trap"; else trap - TERM; fi
 	else
 		# Fallback for non-TTY environments (CI, screen readers)
 		log_info "$msg (waiting ${duration}s)..."


### PR DESCRIPTION
🎯 **What:** Fixed Bash Eval injection vulnerability in `smart_scheduler.sh` traps on lines 47 and 51, and removed unsafe dynamic evaluation in trap restoration on lines 64 and 65.
⚠️ **Risk:** The previous implementation evaluated variables inside the trap execution logic using `eval`. If a local or global variable with the same name was overridden or controlled maliciously when the signal was received, the `eval` command would execute arbitrary code.
🛡️ **Solution:** Removed the runtime `eval` from the `INT` and `TERM` trap definitions, injecting the safe, escaped `trap -p` output at definition time instead. Changed trap restoration logic to conditionally evaluate existing traps, preventing execution of default fallback arguments.

---
*PR created automatically by Jules for task [15857737579739098756](https://jules.google.com/task/15857737579739098756) started by @abhimehro*