### PR TITLE
🔒 [security] Fix Bash Eval Injection in windscribe-connect.sh trap

### DIFF
--- a/scripts/windscribe-connect.sh
+++ b/scripts/windscribe-connect.sh
@@ -39,16 +39,16 @@ spinner_wait() {
 		local c=0
 
 		# Hide cursor gracefully in TTY
-		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
+		if [ -t 1 ] && [ -z "${CI-}" ]; then tput civis 2>/dev/null || true; fi
 
 		# Save original traps and set temporary ones
 		local old_int_trap
 		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
+		trap 'if [ -t 1 ] && [ -z "${CI-}" ]; then tput cnorm 2>/dev/null || true; fi; printf "\r\033[K"; '"${old_int_trap:-trap - INT}"'; kill -INT "$$"' INT
 
 		local old_term_trap
 		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		trap 'if [ -t 1 ] && [ -z "${CI-}" ]; then tput cnorm 2>/dev/null || true; fi; printf "\r\033[K"; '"${old_term_trap:-trap - TERM}"'; kill -TERM "$$"' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r${BLUE}[%c]${NC} %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -58,7 +58,7 @@ spinner_wait() {
 		printf "\r\033[K" # Clear line
 
 		# Restore cursor and original traps
-		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
+		if [ -t 1 ] && [ -z "${CI-}" ]; then tput cnorm 2>/dev/null || true; fi
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else


### PR DESCRIPTION
🎯 **What:** Fixed a Bash Eval Injection vulnerability within the `spinner_wait` function's signal trap handling in `scripts/windscribe-connect.sh`.
⚠️ **Risk:** The script used `eval` combined with variable expansion inside a trap definition string (`trap '... eval "$old_int_trap" ...' INT`). Since trap strings are evaluated when triggered, if the local variable scoping was circumvented or if an attacker had control of the variable before the local definition, it allowed for arbitrary command execution when the trap fired.
🛡️ **Solution:** Removed the runtime `eval` from the trap definition entirely. The script now safely expands the saved trap string at definition time using proper quote interpolation (`trap '... '"${old_int_trap:-trap - INT}"' ...' INT`). This ensures the exact command previously generated by `trap -p` is statically baked into the new trap, rendering any dynamic injection impossible. Also converted several `[ condition ] && cmd || true` checks into proper `if` blocks to resolve Shellcheck SC2015 warnings.

---
*PR created automatically by Jules for task [6713883420349829476](https://jules.google.com/task/6713883420349829476) started by @abhimehro*