### PR TITLE
🧪 [testing improvement] Add explicit test for returncode not zero in parse_inventory.py

### DIFF
--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -196,5 +196,16 @@ class TestParseInventory(unittest.TestCase):
         self.assertIsNone(run_gh("repoA", 123))
 
 
+
+    @patch("parse_inventory._load_gh_token_env", return_value={})
+    @patch("parse_inventory.subprocess.run")
+    def test_run_gh_returncode_not_zero(self, mock_run, _mock_env):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = '{"files": []}'
+        mock_run.return_value = mock_result
+        self.assertIsNone(run_gh("repoA", 123))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added missing error test for `run_gh` in `parse_inventory.py` to specifically test the `returncode != 0` block.

📊 **Coverage:** The test explicitly mocks `subprocess.run` to return a `returncode` of `1` and verifies `run_gh` returns `None`.

✨ **Result:** Test coverage for `parse_inventory.py` improves robustness and satisfies testing gap requirements without regressions.

---
*PR created automatically by Jules for task [16961204561224177893](https://jules.google.com/task/16961204561224177893) started by @abhimehro*