### PR TITLE
🔒 Sentinel: [HIGH] Bash Eval Injection in spinner_wait

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -264,3 +264,7 @@
 **Vulnerability:** AppleScript Injection ([CWE-74](https://cwe.mitre.org/data/definitions/74.html)) existed in `configs/.config/mole/lib/uninstall/batch.sh` where `osascript` was executing a string containing the user-controlled variable `$clean_name` (derived from `$app_name`). Even though the script attempted to manually escape double quotes (`${clean_name//\"/\\\"}`), this approach is brittle and can be bypassed.
 **Learning:** Using inline string interpolation in AppleScript code executed via `osascript` allows an attacker to inject arbitrary AppleScript commands if they control the variable, even if quotes are escaped.
 **Prevention:** Use `osascript - "$variable"` (or `osascript -e 'on run argv'`) and pass dynamic variables safely as command-line arguments to the `on run argv` handler (e.g. `item 1 of argv`).
+## 2026-06-01 - Bash Eval Injection in Trap Restoration
+**Vulnerability:** Bash Eval Injection via `eval "${old_int_trap:-trap - INT}"` in UI spinner traps.
+**Learning:** Shell-assigned variable expansions inside `eval` can still introduce command injection if an attacker previously influenced the environment's `trap` commands. It creates unnecessary attack surface.
+**Prevention:** Avoid saving and restoring traps using `eval` when executing local synchronous blocks like UI spinners. Isolate the execution and custom temporary traps inside a subshell `( ... )`, which protects the parent shell's configuration and eliminates the need for `eval`.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -42,14 +42,10 @@ spinner_wait() {
 		# Hide cursor gracefully in TTY
 		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
-		# Save original traps and set temporary ones
-		local old_int_trap
-		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
-
-		local old_term_trap
-		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		(
+			# Run in a subshell to avoid eval and trap restoration issues
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT; kill -INT $BASHPID' INT
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - TERM; kill -TERM $BASHPID' TERM
 
 		while [[ $c -lt $iterations ]]; do
 			printf "\r\033[0;34m[%c]\033[0m %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -57,11 +53,8 @@ spinner_wait() {
 			c=$((c + 1))
 		done
 		printf "\r\033[K" # Clear line
-
-		# Restore cursor and original traps
-		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
-		eval "${old_int_trap:-trap - INT}"
-		eval "${old_term_trap:-trap - TERM}"
+			[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
+		)
 	else
 		# Fallback for non-TTY environments (CI, screen readers)
 		log_info "$msg (waiting ${duration}s)..."

--- a/maintenance/bin/smart_scheduler.sh
+++ b/maintenance/bin/smart_scheduler.sh
@@ -41,14 +41,10 @@ spinner_wait() {
 		# Hide cursor
 		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
-		# Save original traps and set temporary ones
-		local old_int_trap
-		old_int_trap=$(trap -p INT)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_int_trap:-trap - INT}"; kill -INT "$$"' INT
-
-		local old_term_trap
-		old_term_trap=$(trap -p TERM)
-		trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; eval "${old_term_trap:-trap - TERM}"; kill -TERM "$$"' TERM
+		(
+			# Run in a subshell to avoid eval and trap restoration issues
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT; kill -INT $BASHPID' INT
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - TERM; kill -TERM $BASHPID' TERM
 
 		local interval=0.5
 		iterations=$(echo "$duration / $interval" | bc -l | cut -d. -f1)
@@ -58,11 +54,8 @@ spinner_wait() {
 			c=$((c + 1))
 		done
 		printf "\r\033[K" # Clear line
-
-		# Restore cursor and original traps
-		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
-		eval "${old_int_trap:-trap - INT}"
-		eval "${old_term_trap:-trap - TERM}"
+			[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
+		)
 	else
 		# Fallback for non-TTY environments (CI, screen readers)
 		log_info "$msg (waiting ${duration}s)..."

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -312,3 +312,4 @@
 **Rule:** Treat tag-based workflow edits as **merge blockers** in SHA-only repos. Required fixes must pin **every** action reference (including SARIF upload), never downgrade SHA → tag. Close or rewrite the PR before re-triage.
 **Related:** Lesson 0y (nested unpinned actions inside composites).
 **Detection cost:** Low — bandit workflow fails before pytest on workflow-only diffs.
+- **Bash Eval Injection in Subshells**: When running traps inside a subshell instead of `eval`, the trap must explicitly use `$BASHPID` instead of `$$` if it wants to signal itself properly, because `$$` refers to the parent process. Also, ensure the subshell's trap explicitly handles signal propagation (e.g. `trap - INT; kill -INT $BASHPID`) so that the subshell terminates correctly, and then the parent script's wait mechanism triggers properly (WCE).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -175,3 +175,8 @@ _(Blocked by Section 1: Proceed only after fetching actionable log data)_
 - **Least-Privilege Authorization:** The `release-drafter.yml` workflow will be explicitly constrained to `permissions: { contents: write }` (no pull-request write vectors).
 - **Assumptions:** The `run-pr-review-session.sh` enforces hard boundaries. No autonomous merges of code failing _Security Gate 2_ (as defined in `docs/automated-pr-review-agent.md`) will be permitted. _Zero-diff / superseded_ heuristic rules (also defined in `docs/automated-pr-review-agent.md`) will govern closure rationale.
 
+- [x] Reproduce the eval injection vulnerability locally.
+- [x] Root-cause the issue in `performance_optimizer.sh` and `smart_scheduler.sh`.
+- [x] Implement subshell isolation to remove the insecure `eval` usages entirely.
+- [x] Write/confirm unit tests pass to prevent regressions.
+- [x] Review: Subshell effectively mitigates trap vulnerability.


### PR DESCRIPTION
🎯 **What:** Fixed a High severity Bash Eval Injection vulnerability in the `spinner_wait` function across `maintenance/bin/performance_optimizer.sh` and `maintenance/bin/smart_scheduler.sh`.

⚠️ **Risk:** The previous implementation used `eval` with variables like `old_int_trap` (derived from `trap -p INT`) to restore traps. If an attacker had influenced the system's previously set trap configuration, `eval "${old_int_trap...}"` could execute arbitrary malicious commands.

🛡️ **Solution:** Removed the `eval` statements and manual trap restoration completely. The spinner logic and its temporary traps have been isolated inside a subshell `( ... )`. This inherently protects the parent shell's trap state. The subshell handles signal interruptions safely via `$BASHPID` self-signaling, maintaining expected `Ctrl+C` behavior (WCE) without relying on unsafe evaluations.

========== ELIR ==========
PURPOSE: Isolate `spinner_wait` temporary traps inside a subshell to avoid evaluating unsanitized prior trap strings.
SECURITY: Prevents Bash Eval Injection (CWE-78) via environment-controlled trap assignments.
FAILS IF: The subshell does not cleanly exit or propagate signals using `$BASHPID` instead of `$$`, leading to uninterruptible scripts.
VERIFY: Ensure pressing `Ctrl+C` during the spinner correctly terminates both the spinner and the parent script.
MAINTAIN: When running localized TTY processes, always favor subshell isolation over manually saving and evaluating system states.

---
*PR created automatically by Jules for task [14573958316864447869](https://jules.google.com/task/14573958316864447869) started by @abhimehro*