### PR TITLE
🛡️ Sentinel: [HIGH] Bash Eval Injection

### DIFF
--- a/media-streaming/scripts/final-media-server.sh
+++ b/media-streaming/scripts/final-media-server.sh
@@ -28,7 +28,7 @@ spinner_wait() {
 		local iterations=$((duration * 10))
 		local c=0
 
-		[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
+		if [ -t 1 ] && [ -z "${CI-}" ]; then tput civis 2>/dev/null || true; fi
 
 		local old_int_trap old_term_trap
 		old_int_trap=$(trap -p INT)
@@ -43,7 +43,8 @@ spinner_wait() {
 		done
 		printf "\r\033[K"
 
-		[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
+		if [ -t 1 ] && [ -z "${CI-}" ]; then tput cnorm 2>/dev/null || true; fi
+		# SECURITY: false positive, trap -p output is safely escaped
 		eval "${old_int_trap:-trap - INT}"
 		eval "${old_term_trap:-trap - TERM}"
 	else


### PR DESCRIPTION
🎯 **What:** The `eval` statements used to restore signal traps via `${old_int_trap:-trap - INT}` were flagged by SAST as a Bash Eval Injection vulnerability.
⚠️ **Risk:** The vulnerability was a false positive. `old_int_trap` is populated by `trap -p INT`, which outputs POSIX-compliant, properly escaped, and safely quoted strings specifically designed for safe re-evaluation. 
🛡️ **Solution:** The `eval` statements were preserved, as they are the standard, robust method for restoring dynamic traps in bash. Explicit `# SECURITY` comments were added to document that this is a false positive and that `eval` is safe in this context. Additionally, a fragile `A && B && C || true` idiom nearby was refactored into a robust `if [ A ] && [ B ]; then C || true; fi` block, clearing a ShellCheck SC2015 warning and improving script reliability.

========== ELIR ==========
PURPOSE: Document false positive Bash Eval Injection on trap restoration and fix adjacent SC2015 warnings.
SECURITY: Preserves robust trap restoration while adding audit comments for `eval` safety on `trap -p` output.
FAILS IF: Future developers incorrectly assume the `eval` is vulnerable and attempt to refactor it using less robust methods (like temporary files).
VERIFY: Confirm the `# SECURITY` comments are present above the `eval` statements.
MAINTAIN: When handling dynamic traps in bash, `eval` with `trap -p` output is safe and standard; do not attempt to obfuscate it.

---
*PR created automatically by Jules for task [16252107253640224334](https://jules.google.com/task/16252107253640224334) started by @abhimehro*