### PR TITLE
🎨 Palette: Enhance HTML Template Accessibility and UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - HTML Template Accessibility
+**Learning:** Simple HTML strings in Python scripts often miss crucial accessibility foundations like `lang`, `viewport` meta tags, focus outlines, and sufficient color contrast, hurting mobile users and keyboard navigators.
+**Action:** When working with Python's `http.server` or generating ad-hoc HTML, always add responsive viewport tags, `:focus-visible` styles, and ensure text contrast passes WCAG AA.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -216,15 +216,17 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
 
         html_parts = [f"""
         <!DOCTYPE html>
-        <html>
+        <html lang="en">
         <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Media Library - {safe_path}</title>
             <style>
-                body {{ font-family: Arial, sans-serif; margin: 40px; }}
+                body {{ font-family: Arial, sans-serif; margin: 5%; }}
                 .file {{ display: block; padding: 10px; text-decoration: none; color: #333; }}
-                .file:hover {{ background: #f0f0f0; }}
+                .file:hover, .file:focus-visible {{ background: #f0f0f0; outline: 2px solid #0066cc; outline-offset: -2px; }}
                 .directory {{ font-weight: bold; color: #0066cc; }}
-                .video {{ color: #ff6600; }}
+                .video {{ color: #c04c00; }}
             </style>
         </head>
         <body>


### PR DESCRIPTION
**🎨 Palette: HTML Template Accessibility and UX Polish**

**💡 What:**
- Added `<html lang="en">` attribute for screen readers.
- Added viewport meta tag for mobile responsiveness.
- Changed base CSS margin to `5%` for responsive layout instead of hardcoded `40px`.
- Added `:focus-visible` state (`outline`) for keyboard navigation.
- Improved color contrast for `.video` text (changed from `#ff6600` to `#c04c00` to pass WCAG AA).

**🎯 Why:**
The `infuse-media-server.py` auto-generates a simple HTML directory listing. However, it lacked basic accessibility elements (language definition, mobile responsiveness, keyboard focus states) and had a color contrast violation on the video links. These changes ensure the generated directory is readable on mobile, navigable via keyboard, and accessible to screen readers.

**♿ Accessibility:**
- Language explicitly set.
- Pass WCAG AA for text contrast.
- Focus rings restored for tabbing.
- Content scales correctly on mobile.

---
*PR created automatically by Jules for task [5213704971932654032](https://jules.google.com/task/5213704971932654032) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->