### PR TITLE
🎨 Palette: Added ARIA labels to directory listing links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-05 - Added ARIA labels to directory listing links
+**Learning:** Screen readers reading generated HTML directory structures (like from `infuse-media-server.py`) can encounter redundant emoji announcements (📁, 🎬, 📄) without context of whether the link represents a directory or a specific file type.
+**Action:** Always add descriptive `aria-label` attributes to anchor tags in generated HTML listings to clarify the file type and avoid redundant emoji reading. When doing so, ensure `html.escape()` is used correctly to prevent XSS vectors. Ensure unit tests checking these generated strings are updated simultaneously.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -239,7 +239,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             # Parent path is constructed safely from split, but escaping is good hygiene
             safe_parent = html.escape(parent)
             html_parts.append(
-                f'<a href="/{safe_parent}" class="file directory">📁 .. (Parent Directory)</a>\n'
+                f'<a href="/{safe_parent}" class="file directory" aria-label="Parent Directory">📁 .. (Parent Directory)</a>\n'
             )
 
         # ⚡ Performance: tuple for fast C-level endswith checking
@@ -256,12 +256,12 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         items_html = [
             (
                 (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory">'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory" aria-label="Directory: {html.escape(item)[:-1]}">'
                     f"📁 {html.escape(item)[:-1]}</a>\n"
                 )
                 if item.endswith("/")
                 else (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video">'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video" aria-label="File: {html.escape(item)}">'
                     f'{"🎬" if item.lower().endswith(video_exts) else "📄"} {html.escape(item)}</a>\n'
                 )
             )

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -143,19 +143,19 @@ class TestMediaServerHandler(unittest.TestCase):
 
         # File checks with escaped characters
         self.assertIn(
-            '<a href="/video.mp4" class="file video">\U0001f3ac video.mp4</a>',
+            '<a href="/video.mp4" class="file video" aria-label="File: video.mp4">\U0001f3ac video.mp4</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/folder with &lt;tag&gt;/" class="file directory">\U0001f4c1 folder with &lt;tag&gt;</a>',
+            '<a href="/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;">\U0001f4c1 folder with &lt;tag&gt;</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/document &amp; file.txt" class="file video">\U0001f4c4 document &amp; file.txt</a>',
+            '<a href="/document &amp; file.txt" class="file video" aria-label="File: document &amp; file.txt">\U0001f4c4 document &amp; file.txt</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
+            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video" aria-label="File: &lt;script&gt;alert(1)&lt;/script&gt;.avi">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
             html_root,
         )
 
@@ -173,15 +173,15 @@ class TestMediaServerHandler(unittest.TestCase):
         # Note: actually current_path does NOT get escaped before computing parent?
         # Let's check code: parent = "/".join(current_path.rstrip("/").split("/")[:-1]) -> "/Movies & TV"
         # safe_parent = html.escape(parent) -> "/Movies &amp; TV"
-        self.assertIn('<a href="//Movies &amp; TV" class="file directory">', html_sub)
+        self.assertIn('<a href="//Movies &amp; TV" class="file directory" aria-label="Parent Directory">', html_sub)
 
         # Check files in subdirectory (href should append to the escaped base_path)
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video">\U0001f3ac video.mp4</a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video" aria-label="File: video.mp4">\U0001f3ac video.mp4</a>',
             html_sub,
         )
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory">\U0001f4c1 folder with &lt;tag&gt;</a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;">\U0001f4c1 folder with &lt;tag&gt;</a>',
             html_sub,
         )
 


### PR DESCRIPTION
💡 What: Added descriptive `aria-label` attributes to the anchor tags generating the directory and file listings in `infuse-media-server.py`.
🎯 Why: Screen readers would previously read the emojis (📁, 🎬, 📄) without explicit context of whether the link represents a directory or a specific file type. The `aria-label`s provide clear, explicit context.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader navigation and context understanding for directory and file links.

---
*PR created automatically by Jules for task [1381595415397466470](https://jules.google.com/task/1381595415397466470) started by @abhimehro*