### PR TITLE
🎨 Palette: Group screen reader announcements for metric cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-06-05 - Added ARIA labels to directory listing links
 **Learning:** Screen readers reading generated HTML directory structures (like from `infuse-media-server.py`) can encounter redundant emoji announcements (📁, 🎬, 📄) without context of whether the link represents a directory or a specific file type.
 **Action:** Always add descriptive `aria-label` attributes to anchor tags in generated HTML listings to clarify the file type and avoid redundant emoji reading. When doing so, ensure `html.escape()` is used correctly to prevent XSS vectors. Ensure unit tests checking these generated strings are updated simultaneously.
+
+## 2025-06-05 - Grouped screen reader announcements for metric cards
+**Learning:** When displaying a value and a label together (like "85" and "Health Score"), screen readers will read them as disconnected elements.
+**Action:** Apply `aria-label` to the parent container with a cohesive sentence (e.g., "Health Score: 85") and `aria-hidden="true"` to the inner value and label elements. This creates a single, understandable announcement.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -408,9 +408,9 @@ generate_dashboard() {
         </div>
         
         <div class="metrics-grid">
-            <div class="metric-card success">
-                <div class="metric-value">${current_health}</div>
-                <div class="metric-label">Health Score</div>
+            <div class="metric-card success" aria-label="Health Score: ${current_health}">
+                <div class="metric-value" aria-hidden="true">${current_health}</div>
+                <div class="metric-label" aria-hidden="true">Health Score</div>
             </div>
 EOF
 
@@ -424,17 +424,17 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <div class="metric-card">
-                <div class="metric-value">${avg_performance}</div>
-                <div class="metric-label">Performance Score</div>
+            <div class="metric-card" aria-label="Performance Score: ${avg_performance}">
+                <div class="metric-value" aria-hidden="true">${avg_performance}</div>
+                <div class="metric-label" aria-hidden="true">Performance Score</div>
             </div>
-            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")">
-                <div class="metric-value">${avg_disk}%</div>
-                <div class="metric-label">Disk Usage</div>
+            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" aria-label="Disk Usage: ${avg_disk}%">
+                <div class="metric-value" aria-hidden="true">${avg_disk}%</div>
+                <div class="metric-label" aria-hidden="true">Disk Usage</div>
             </div>
-            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")">
-                <div class="metric-value">${total_warnings}</div>
-                <div class="metric-label">Total Warnings</div>
+            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-label="Total Warnings: ${total_warnings}">
+                <div class="metric-value" aria-hidden="true">${total_warnings}</div>
+                <div class="metric-label" aria-hidden="true">Total Warnings</div>
             </div>
 EOF
 	fi


### PR DESCRIPTION
🎨 Palette: Group screen reader announcements for metric cards

💡 What: Added aria-label to metric-card parent containers and aria-hidden="true" to inner label/value elements.
🎯 Why: Groups disparate text nodes (like "85" and "Health Score") into a cohesive single announcement for screen readers.
♿ Accessibility: Significant improvement for assistive technologies parsing generated analytics dashboards.

This change ensures that screen readers announce "Health Score: 85" instead of disconnected "85" then "Health Score". Includes a journal update in `.Jules/palette.md` noting the UX/a11y learnings.

---
*PR created automatically by Jules for task [10635186657811344650](https://jules.google.com/task/10635186657811344650) started by @abhimehro*