### PR TITLE
🎨 Palette: Improve status color contrast in analytics dashboard

### DIFF
--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -394,9 +394,9 @@ generate_dashboard() {
         .section { margin-bottom: 40px; }
         .section h2 { color: #333; border-bottom: 2px solid #eee; padding-bottom: 10px; }
         .insights-box { background: #f8f9fa; padding: 20px; border-radius: 8px; border-left: 4px solid #007bff; }
-        .status-good { color: #28a745; }
-        .status-warning { color: #ffc107; }
-        .status-critical { color: #dc3545; }
+        .status-good { color: #1E7E34; } /* WCAG AA accessible */
+        .status-warning { color: #B45309; } /* WCAG AA accessible */
+        .status-critical { color: #DC2626; } /* WCAG AA accessible */
         .footer { text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; color: #666; font-size: 0.9em; }
     </style>
 </head>


### PR DESCRIPTION
💡 What: Updated status text colors (#1E7E34, #B45309, #DC2626). 
🎯 Why: Better readability and WCAG AA contrast against the light background. 
♿ Accessibility: Improved contrast ratio.

---
*PR created automatically by Jules for task [12716388449888612649](https://jules.google.com/task/12716388449888612649) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->