### PR TITLE
🎨 Palette: Improve spinner UX in non-TTY environments

### DIFF
--- a/scripts/windscribe-connect.sh
+++ b/scripts/windscribe-connect.sh
@@ -40,11 +40,11 @@ spinner_wait() {
 			local c=0
 
 			# Hide cursor gracefully in TTY
-			tput civis 2>/dev/null || true
+			[ -t 1 ] && [ -z "${CI-}" ] && tput civis 2>/dev/null || true
 
 			# Set temporary traps within subshell to avoid polluting parent
-			trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT; kill -INT $BASHPID' INT
-			trap 'tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - TERM; kill -TERM $BASHPID' TERM
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - INT; kill -INT $BASHPID' INT
+			trap '[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true; printf "\r\033[K"; trap - TERM; kill -TERM $BASHPID' TERM
 
 			while [[ $c -lt $iterations ]]; do
 				printf "\r${BLUE}[%c]${NC} %s..." "${sp:i++%${#sp}:1}" "$msg"
@@ -54,7 +54,7 @@ spinner_wait() {
 			printf "\r\033[K" # Clear line
 
 			# Restore cursor
-			tput cnorm 2>/dev/null || true
+			[ -t 1 ] && [ -z "${CI-}" ] && tput cnorm 2>/dev/null || true
 		)
 	else
 		# Fallback for non-TTY environments (CI, screen readers)


### PR DESCRIPTION
💡 What: Added `[ -t 1 ] && [ -z "${CI-}" ]` guards before all `tput civis` and `tput cnorm` commands in `scripts/windscribe-connect.sh`.
🎯 Why: Prevents terminal spam and cursor state bugs in CI/non-interactive environments by avoiding unconditionally outputting ANSI escape sequences to stdout.
♿ Accessibility: Ensures screen readers won't read cursor escape codes.

---
*PR created automatically by Jules for task [3721824303754512380](https://jules.google.com/task/3721824303754512380) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->