### PR TITLE
🎨 Palette: [UX improvement] Add aria-hidden to inner text of Infuse directory listings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Notebook
+
+## 2024-06-10 - Dashboard HTML Accessibility
+**Learning:** Shell scripts generating HTML dashboard need better ARIA support. Visual health indicators are only conveyed through CSS classes or unicode characters, and metric cards lack screen reader context.
+**Action:** Add explicit `aria-label` to dashboard metric cards and ensure ARIA grouping of values/labels. Add `aria-hidden="true"` to inner decorative text.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -239,7 +239,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             # Parent path is constructed safely from split, but escaping is good hygiene
             safe_parent = html.escape(parent)
             html_parts.append(
-                f'<a href="/{safe_parent}" class="file directory" aria-label="Parent Directory">📁 .. (Parent Directory)</a>\n'
+            f'<a href="/{safe_parent}" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">📁 .. (Parent Directory)</span></a>\n'
             )
 
         # ⚡ Performance: tuple for fast C-level endswith checking
@@ -257,12 +257,12 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             (
                 (
                     f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory" aria-label="Directory: {html.escape(item)[:-1]}">'
-                    f"📁 {html.escape(item)[:-1]}</a>\n"
+                    f'<span aria-hidden="true">📁 {html.escape(item)[:-1]}</span></a>\n'
                 )
                 if item.endswith("/")
                 else (
                     f'<a href="/{safe_base_path}{html.escape(item)}" class="file video" aria-label="File: {html.escape(item)}">'
-                    f'{"🎬" if item.lower().endswith(video_exts) else "📄"} {html.escape(item)}</a>\n'
+                    f'<span aria-hidden="true">{"🎬" if item.lower().endswith(video_exts) else "📄"} {html.escape(item)}</span></a>\n'
                 )
             )
             for item in files

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -143,19 +143,19 @@ class TestMediaServerHandler(unittest.TestCase):
 
         # File checks with escaped characters
         self.assertIn(
-            '<a href="/video.mp4" class="file video" aria-label="File: video.mp4">\U0001f3ac video.mp4</a>',
+            '<a href="/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;">\U0001f4c1 folder with &lt;tag&gt;</a>',
+            '<a href="/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/document &amp; file.txt" class="file video" aria-label="File: document &amp; file.txt">\U0001f4c4 document &amp; file.txt</a>',
+            '<a href="/document &amp; file.txt" class="file video" aria-label="File: document &amp; file.txt"><span aria-hidden="true">\U0001f4c4 document &amp; file.txt</span></a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video" aria-label="File: &lt;script&gt;alert(1)&lt;/script&gt;.avi">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
+            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video" aria-label="File: &lt;script&gt;alert(1)&lt;/script&gt;.avi"><span aria-hidden="true">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</span></a>',
             html_root,
         )
 
@@ -173,15 +173,15 @@ class TestMediaServerHandler(unittest.TestCase):
         # Note: actually current_path does NOT get escaped before computing parent?
         # Let's check code: parent = "/".join(current_path.rstrip("/").split("/")[:-1]) -> "/Movies & TV"
         # safe_parent = html.escape(parent) -> "/Movies &amp; TV"
-        self.assertIn('<a href="//Movies &amp; TV" class="file directory" aria-label="Parent Directory">', html_sub)
+        self.assertIn('<a href="//Movies &amp; TV" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">', html_sub)
 
         # Check files in subdirectory (href should append to the escaped base_path)
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video" aria-label="File: video.mp4">\U0001f3ac video.mp4</a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
             html_sub,
         )
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;">\U0001f4c1 folder with &lt;tag&gt;</a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
             html_sub,
         )
 


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add aria-hidden to inner text of Infuse directory listings

💡 What: Added `<span aria-hidden="true">` to wrap the unicode emojis and file/directory names inside the Infuse media server's anchor tags. Also updated the test assertions to match.
🎯 Why: The anchor tags already have descriptive `aria-label` attributes (e.g. `aria-label="Directory: Movies"`). Without `aria-hidden` on the inner content, screen readers announce both the clean label and the messy inner text containing emojis, creating a redundant and confusing experience for users relying on assistive technologies.
♿ Accessibility: Improves screen reader experience by preventing double-announcement of links and eliminating the announcement of purely decorative unicode folder/film emojis.

---
*PR created automatically by Jules for task [11397581573389380805](https://jules.google.com/task/11397581573389380805) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->