### PR TITLE
🧪 Add unit tests for _fetch_repo_prs

### DIFF
--- a/tests/test_scratch_inventory.py
+++ b/tests/test_scratch_inventory.py
@@ -5,7 +5,9 @@ import os
 # Ensure the project root is in the path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scratch_inventory import generate_markdown, get_category
+from scratch_inventory import generate_markdown, get_category, _fetch_repo_prs
+from unittest.mock import patch, MagicMock
+import json
 
 class TestScratchInventory(unittest.TestCase):
     def test_get_category_security(self):
@@ -68,5 +70,45 @@ class TestScratchInventory(unittest.TestCase):
         self.assertIn("'=HYPERLINK", md)
 
 
+
+    @patch('scratch_inventory.subprocess.run')
+    def test_fetch_repo_prs_success(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps([
+            {"number": 1, "title": "Test PR", "author": {"login": "testuser"}, "headRefName": "main", "mergeStateStatus": "CLEAN", "state": "OPEN", "createdAt": "2023-01-01T00:00:00Z"}
+        ])
+        mock_run.return_value = mock_result
+
+        repo = "abhimehro/test-repo"
+        prs = _fetch_repo_prs(repo)
+
+        self.assertEqual(len(prs), 1)
+        self.assertEqual(prs[0]["repo"], "test-repo")
+        self.assertEqual(prs[0]["number"], 1)
+
+        # Verify subprocess.run was called correctly
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertIn("gh", args[0])
+        self.assertIn(repo, args[0])
+        self.assertEqual(kwargs.get("capture_output"), True)
+        self.assertEqual(kwargs.get("text"), True)
+
+    @patch('scratch_inventory.subprocess.run')
+    def test_fetch_repo_prs_failure(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "Error"
+        mock_result.stderr = "Command failed"
+        mock_run.return_value = mock_result
+
+        repo = "abhimehro/test-repo"
+        prs = _fetch_repo_prs(repo)
+
+        self.assertEqual(prs, [])
+        mock_run.assert_called_once()
+
 if __name__ == '__main__':
+
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The untested _fetch_repo_prs function in scratch_inventory.py lacked test coverage, creating a blind spot in the PR inventory fetching logic.

📊 **Coverage:** Added tests for both the successful API response parsing (validating the correct repository string partition handling) and the CLI failure mode (non-zero return codes resulting in an empty list). 

✨ **Result:** Increased code coverage by testing the external subprocess invocation via unittest.mock.patch, ensuring future modifications to the fetching logic are protected against regressions.

---
*PR created automatically by Jules for task [11773552384241325330](https://jules.google.com/task/11773552384241325330) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->