### PR TITLE
🧹 code health: fix unused import concurrent.futures warning

### DIFF
--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import subprocess
@@ -104,7 +104,7 @@ def fetch_pr_info(pr):
     return pr, info
 
 
-with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+with ThreadPoolExecutor(max_workers=10) as executor:
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls while preserving order using map()
     results = executor.map(fetch_pr_info, ready_prs)
 


### PR DESCRIPTION
🧹 [Fix unused concurrent.futures import]

🎯 **What:** The static analysis flagged `import concurrent.futures` as unused. However, it was being used through the fully qualified path (`concurrent.futures.ThreadPoolExecutor`). Instead of deleting it and breaking the code, I refactored the import to `from concurrent.futures import ThreadPoolExecutor` and updated the call site.

💡 **Why:** This improves the code health by resolving the static analysis warning, while also slightly shortening and cleaning up the call site.

✅ **Verification:** I ran the entire shell and Python test suite (`PYTHONPATH=. make test-all`) and confirmed that they still pass. `ThreadPoolExecutor` behaves exactly the same.

✨ **Result:** The code health warning is gone and the script continues to function correctly without regressions.

---
*PR created automatically by Jules for task [14945497426061926010](https://jules.google.com/task/14945497426061926010) started by @abhimehro*