### PR TITLE
🎨 Palette: Add ARIA labels and hide emojis for screen readers in Media Server

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-12 - Accessible HTML structure
+**Learning:** This repo has shell and python scripts that generate HTML string. It follows standard HTML structure and uses standard accessibility practices like aria-label and aria-hidden on inner emojis. Also, note that color contrasts standard must follow WCAG AA guidelines.
+**Action:** When adding HTML in scripts, stick to accessibility best practices.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2026-06-12 - Accessible HTML structure
-**Learning:** This repo has shell and python scripts that generate HTML string. It follows standard HTML structure and uses standard accessibility practices like aria-label and aria-hidden on inner emojis. Also, note that color contrasts standard must follow WCAG AA guidelines.
-**Action:** When adding HTML in scripts, stick to accessibility best practices.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -139,3 +139,7 @@
 
 **Learning:** Shell scripts generating HTML dashboard need better ARIA support. Visual health indicators are only conveyed through CSS classes or unicode characters, and metric cards lack screen reader context.
 **Action:** Add explicit `aria-label` to dashboard metric cards and ensure ARIA grouping of values/labels. Add `aria-hidden="true"` to inner decorative text.
+
+## 2026-06-12 - Accessible HTML structure
+**Learning:** This repo has shell and python scripts that generate HTML string. It follows standard HTML structure and uses standard accessibility practices like aria-label and aria-hidden on inner emojis. Also, note that color contrasts standard must follow WCAG AA guidelines.
+**Action:** When adding HTML in scripts, stick to accessibility best practices.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -213,7 +213,6 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
     def generate_directory_listing(self, files, current_path):
         """Generate HTML directory listing"""
         safe_path = html.escape(current_path)
-        aria_path = "/" if current_path == "/" else f"/{safe_path}"
 
         html_parts = [f"""
         <!DOCTYPE html>
@@ -231,7 +230,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1 aria-label="Media Library: {aria_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            <h1 aria-label="Media Library: {safe_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
         """]
 
         # Add parent directory link if not root

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -213,6 +213,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
     def generate_directory_listing(self, files, current_path):
         """Generate HTML directory listing"""
         safe_path = html.escape(current_path)
+        aria_path = "/" if current_path == "/" else f"/{safe_path}"
 
         html_parts = [f"""
         <!DOCTYPE html>
@@ -230,7 +231,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1 aria-label="Media Library: {safe_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            <h1 aria-label="Media Library: {aria_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
         """]
 
         # Add parent directory link if not root

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -230,7 +230,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1>📁 Media Library: /{safe_path}</h1>
+            <h1 aria-label="Media Library: {safe_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
         """]
 
         # Add parent directory link if not root

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -138,7 +138,7 @@ class TestMediaServerHandler(unittest.TestCase):
         html_root = self.handler.generate_directory_listing(files, "/")
 
         self.assertIn("<title>Media Library - /</title>", html_root)
-        self.assertIn("\U0001f4c1 Media Library: //</h1>", html_root)
+        self.assertIn("<h1 aria-label=\"Media Library: /\"><span aria-hidden=\"true\">\U0001f4c1</span> Media Library: //</h1>", html_root)
         self.assertNotIn(".. (Parent Directory)", html_root)
 
         # File checks with escaped characters


### PR DESCRIPTION
💡 What: Added aria-label and aria-hidden to the h1 header to improve accessibility for screen readers.
🎯 Why: To prevent screen readers from redundantly reading the clean label along with the visual text or unicode emojis, following the guidelines in `.Jules/palette.md`.
📸 Before/After: Not applicable for visual changes, but screen reader output is improved.
♿ Accessibility: Added `aria-label` to the `h1` container and `aria-hidden="true"` to the inner `span` containing the emoji.

---
*PR created automatically by Jules for task [17732253775575593367](https://jules.google.com/task/17732253775575593367) started by @abhimehro*