### PR TITLE
fix: daily QA lint and formatting fixes

### DIFF
--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -1,21 +1,22 @@
-import unittest
-import sys
 import os
-from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, MagicMock
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 # Ensure the project root is in the path so we can import parse_inventory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from parse_inventory import (
-    _parse_env_line,
-    parse_inventory_lines,
-    _is_pr_stale,
     _get_pr_category,
     _is_checks_failing,
-    run_gh,
+    _is_pr_stale,
     _load_inventory_lines,
+    _parse_env_line,
+    parse_inventory_lines,
+    run_gh,
 )
+
 
 class TestParseInventory(unittest.TestCase):
     @staticmethod
@@ -46,7 +47,7 @@ class TestParseInventory(unittest.TestCase):
 
     def test_parse_env_line_with_quotes(self):
         env = {}
-        _parse_env_line("export FOO=\"bar\"", env)
+        _parse_env_line('export FOO="bar"', env)
         self.assertEqual(env, {"FOO": "bar"})
 
         env = {}
@@ -178,7 +179,9 @@ class TestParseInventory(unittest.TestCase):
     def test_run_gh_success(self, mock_run, _mock_env):
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = '{"files": [{"filename": "foo.py"}], "updatedAt": "2026-05-03T00:00:00Z"}'
+        mock_result.stdout = (
+            '{"files": [{"filename": "foo.py"}], "updatedAt": "2026-05-03T00:00:00Z"}'
+        )
         mock_run.return_value = mock_result
         result = run_gh("repoA", 123)
         self.assertIsNotNone(result)
@@ -202,8 +205,6 @@ class TestParseInventory(unittest.TestCase):
         mock_run.return_value = mock_result
         self.assertIsNone(run_gh("repoA", 123))
 
-
-
     @patch("parse_inventory._load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
     def test_run_gh_returncode_not_zero(self, mock_run, _mock_env):
@@ -214,5 +215,5 @@ class TestParseInventory(unittest.TestCase):
         self.assertIsNone(run_gh("repoA", 123))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repo_credential_hygiene.sh
+++ b/tests/test_repo_credential_hygiene.sh
@@ -46,7 +46,7 @@ fi
 
 # Legacy hardcoded WebDAV curl examples (literal password in quotes)
 if git grep -nE 'curl -u "infuse:[^$"\{]+"' media-streaming "${exclude_dirs[@]}" 2>/dev/null |
-	grep -v '${MEDIA_WEBDAV_PASS}' |
+	grep -v "\${MEDIA_WEBDAV_PASS}" |
 	grep -v "generated-secret" |
 	grep -v '<set in'; then
 	echo "✗ Found hardcoded curl -u infuse:password examples"

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 import types
 import unittest
 

--- a/tests/test_rotate_media_webdav.sh
+++ b/tests/test_rotate_media_webdav.sh
@@ -70,7 +70,7 @@ document)
 esac
 exit 1
 MOCK
-sed -i "s|OP_LOG_PLACEHOLDER|$OP_LOG|g" "$MOCK_BIN/op" 2>/dev/null || \
+sed -i "s|OP_LOG_PLACEHOLDER|$OP_LOG|g" "$MOCK_BIN/op" 2>/dev/null ||
 	sed -i '' "s|OP_LOG_PLACEHOLDER|$OP_LOG|g" "$MOCK_BIN/op"
 chmod +x "$MOCK_BIN/op"
 
@@ -86,7 +86,7 @@ fi
 exit 1
 MOCK
 LAUNCH_LOG="$TEST_DIR/launchctl.log"
-sed -i "s|LAUNCH_LOG_PLACEHOLDER|$LAUNCH_LOG|g" "$MOCK_BIN/launchctl" 2>/dev/null || \
+sed -i "s|LAUNCH_LOG_PLACEHOLDER|$LAUNCH_LOG|g" "$MOCK_BIN/launchctl" 2>/dev/null ||
 	sed -i '' "s|LAUNCH_LOG_PLACEHOLDER|$LAUNCH_LOG|g" "$MOCK_BIN/launchctl"
 chmod +x "$MOCK_BIN/launchctl"
 

--- a/tests/test_scratch_inventory.py
+++ b/tests/test_scratch_inventory.py
@@ -1,13 +1,15 @@
-import unittest
-import sys
 import os
+import sys
+import unittest
 
 # Ensure the project root is in the path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scratch_inventory import generate_markdown, get_category, _fetch_repo_prs
-from unittest.mock import patch, MagicMock
 import json
+from unittest.mock import MagicMock, patch
+
+from scratch_inventory import _fetch_repo_prs, generate_markdown, get_category
+
 
 class TestScratchInventory(unittest.TestCase):
     def test_get_category_security(self):
@@ -49,7 +51,9 @@ class TestScratchInventory(unittest.TestCase):
 
     def test_get_category_feature(self):
         self.assertEqual(get_category("Add new widget", "main"), "FEATURE")
-        self.assertEqual(get_category("Implement dark mode", "feature/dark-mode"), "FEATURE")
+        self.assertEqual(
+            get_category("Implement dark mode", "feature/dark-mode"), "FEATURE"
+        )
         self.assertEqual(get_category("", ""), "FEATURE")
 
     def test_generate_markdown_escapes_formula_injection(self):
@@ -59,7 +63,7 @@ class TestScratchInventory(unittest.TestCase):
                 "number": 1,
                 "author": {"login": "+evil"},
                 "headRefName": "=branch",
-                "title": "=HYPERLINK(\"http://evil\")",
+                "title": '=HYPERLINK("http://evil")',
                 "mergeStateStatus": "CLEAN",
                 "createdAt": "2026-05-24T00:00:00Z",
             }
@@ -69,15 +73,23 @@ class TestScratchInventory(unittest.TestCase):
         self.assertIn("'=branch", md)
         self.assertIn("'=HYPERLINK", md)
 
-
-
-    @patch('scratch_inventory.subprocess.run')
+    @patch("scratch_inventory.subprocess.run")
     def test_fetch_repo_prs_success(self, mock_run):
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = json.dumps([
-            {"number": 1, "title": "Test PR", "author": {"login": "testuser"}, "headRefName": "main", "mergeStateStatus": "CLEAN", "state": "OPEN", "createdAt": "2023-01-01T00:00:00Z"}
-        ])
+        mock_result.stdout = json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "Test PR",
+                    "author": {"login": "testuser"},
+                    "headRefName": "main",
+                    "mergeStateStatus": "CLEAN",
+                    "state": "OPEN",
+                    "createdAt": "2023-01-01T00:00:00Z",
+                }
+            ]
+        )
         mock_run.return_value = mock_result
 
         repo = "abhimehro/test-repo"
@@ -95,7 +107,7 @@ class TestScratchInventory(unittest.TestCase):
         self.assertEqual(kwargs.get("capture_output"), True)
         self.assertEqual(kwargs.get("text"), True)
 
-    @patch('scratch_inventory.subprocess.run')
+    @patch("scratch_inventory.subprocess.run")
     def test_fetch_repo_prs_failure(self, mock_run):
         mock_result = MagicMock()
         mock_result.returncode = 1
@@ -109,6 +121,7 @@ class TestScratchInventory(unittest.TestCase):
         self.assertEqual(prs, [])
         mock_run.assert_called_once()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
 
     unittest.main()

--- a/tests/test_vulnerability_fix.py
+++ b/tests/test_vulnerability_fix.py
@@ -25,7 +25,6 @@ than importing the full script.
 
 import ast
 import os
-import subprocess
 import types
 import unittest
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
**Jules Daily QA & Agentic Review - Fixes**

This PR contains the minor fixes and code health improvements generated during the daily agentic review.

**Changes:**
- Formatted various tests scripts using `trunk fmt`.
- Fixed `shellcheck/SC2016` warnings in `tests/test_repo_credential_hygiene.sh` by switching from single-quote escaping to double-quotes with literal variable escaping.
- Fixed `ruff/F401` by removing an unused `import subprocess` from `tests/test_vulnerability_fix.py`.

**Verification:**
- All tests pass via `make test-all`.
- No new credentials found via `make verify-credentials`.
- Linter issues resolved for affected files.

---
*PR created automatically by Jules for task [925663898488966453](https://jules.google.com/task/925663898488966453) started by @abhimehro*