### PR TITLE
⚡ Bolt: [performance improvement] Hoist category dictionary to avoid loop allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -222,3 +222,7 @@
 
 **Learning:** When calculating the current date string `datetime.date.today().isoformat()` inside a loop or comprehension, Python repeatedly calls the method, generating a new object each time. This creates unnecessary CPU overhead when the output is a constant for the duration of the loop.
 **Action:** Always hoist method calls that generate static strings (like `today().isoformat()`) outside of tight loops to evaluate them once and reuse the value.
+## 2026-06-12 - [Hoist static dictionaries to module scope]
+
+**Learning:** Declaring static dictionaries or collections inside frequently called functions (e.g., `categories = {...}`) causes Python to allocate memory and recreate the object structure on every single function call. When combined with a loop (e.g., `.items()`), this adds unnecessary iterator allocation overhead, degrading performance during high-volume operations.
+**Action:** When a function relies on a static mapping for lookups or iteration, hoist the structure to the module level as a constant (preferably a tuple of tuples to ensure immutability and avoid mutable default issues). When testing with the custom `_load_function_only()` utility, remember to dynamically inject the hoisted constant into the returned mock module to prevent `NameError` exceptions.

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -79,16 +79,19 @@ ready_prs = [
 ]
 
 
+_CATEGORIES = (
+    ("SECURITY", ("sentinel", "security", "cve", "xxe")),
+    ("DEPENDENCY", ("dependabot", "renovate")),
+    ("CI/INFRA", ("chore", "ci", "automation", "action", "trunk")),
+)
+
+
 def get_category_from_title(title: str) -> str:
     title = title.lower()
 
-    categories = {
-        "SECURITY": ("sentinel", "security", "cve", "xxe"),
-        "DEPENDENCY": ("dependabot", "renovate"),
-        "CI/INFRA": ("chore", "ci", "automation", "action", "trunk"),
-    }
-
-    for cat_name, keywords in categories.items():
+    # ⚡ Bolt Optimization: Iterate over a predefined tuple of categories to avoid
+    # dictionary and iterator allocation overhead on every function call.
+    for cat_name, keywords in _CATEGORIES:
         for kw in keywords:
             if kw in title:
                 return cat_name

--- a/tests/test_categorize_ready.py
+++ b/tests/test_categorize_ready.py
@@ -19,6 +19,11 @@ class TestCategorizeReady(unittest.TestCase):
                 "get_category_from_title",
             },
         )
+        self.mod._CATEGORIES = (
+            ("SECURITY", ("sentinel", "security", "cve", "xxe")),
+            ("DEPENDENCY", ("dependabot", "renovate")),
+            ("CI/INFRA", ("chore", "ci", "automation", "action", "trunk")),
+        )
 
     @patch("subprocess.run")
     def test_run_gh_invalid_json(self, mock_run):


### PR DESCRIPTION
* 💡 What: Hoisted the `categories` dictionary out of the `get_category_from_title` function into a module-level tuple `_CATEGORIES`.
* 🎯 Why: To avoid redundant dictionary and iterator allocation overhead on every call to `get_category_from_title`.
* 📊 Impact: Improves execution time and reduces unnecessary memory allocations when processing many PRs.
* 🔬 Measurement: Observe lower CPU and memory overhead during large volume PR processing.

---
*PR created automatically by Jules for task [12963040418504764693](https://jules.google.com/task/12963040418504764693) started by @abhimehro*