### PR TITLE
⚡ Bolt: Hoist categories dictionary in categorize_ready.py

### DIFF
--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -79,16 +79,19 @@ ready_prs = [
 ]
 
 
+_CATEGORIES = (
+    ("SECURITY", ("sentinel", "security", "cve", "xxe")),
+    ("DEPENDENCY", ("dependabot", "renovate")),
+    ("CI/INFRA", ("chore", "ci", "automation", "action", "trunk")),
+)
+
+
 def get_category_from_title(title: str) -> str:
     title = title.lower()
 
-    categories = {
-        "SECURITY": ("sentinel", "security", "cve", "xxe"),
-        "DEPENDENCY": ("dependabot", "renovate"),
-        "CI/INFRA": ("chore", "ci", "automation", "action", "trunk"),
-    }
-
-    for cat_name, keywords in categories.items():
+    # ⚡ Bolt Optimization: Iterate over a predefined tuple of categories to avoid
+    # dictionary allocation overhead on every function call
+    for cat_name, keywords in _CATEGORIES:
         for kw in keywords:
             if kw in title:
                 return cat_name

--- a/tests/test_categorize_ready.py
+++ b/tests/test_categorize_ready.py
@@ -19,6 +19,11 @@ class TestCategorizeReady(unittest.TestCase):
                 "get_category_from_title",
             },
         )
+        self.mod._CATEGORIES = (
+            ("SECURITY", ("sentinel", "security", "cve", "xxe")),
+            ("DEPENDENCY", ("dependabot", "renovate")),
+            ("CI/INFRA", ("chore", "ci", "automation", "action", "trunk")),
+        )
 
     @patch("subprocess.run")
     def test_run_gh_invalid_json(self, mock_run):


### PR DESCRIPTION
💡 What: Hoisted the `categories` dictionary out of `get_category_from_title` into a module-level immutable tuple of tuples `_CATEGORIES`. Updated `test_categorize_ready.py` to inject `_CATEGORIES` into the dynamically loaded module context.
🎯 Why: `get_category_from_title` is called inside a loop for each PR. Defining the dictionary inside the function forces Python to allocate a new dictionary and tuple values on every single function call.
📊 Impact: Eliminates redundant dictionary allocations per PR, slightly improving overall execution speed and reducing memory allocation overhead.
🔬 Measurement: Run `PYTHONPATH=. make test-all` to verify that `test_categorize_ready.py` and other tests pass successfully with the mocked injection.

---
*PR created automatically by Jules for task [16992469574754685893](https://jules.google.com/task/16992469574754685893) started by @abhimehro*