### PR TITLE
a11y(analytics): hide decorative emojis from screen readers (salvages #1230)

### DIFF
--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -403,7 +403,7 @@ generate_dashboard() {
 <body>
     <div class="container">
         <div class="header">
-            <h1>🔧 System Maintenance Dashboard</h1>
+            <h1><span aria-hidden="true">🔧</span> System Maintenance Dashboard</h1>
             <div class="date">$(date "+%B %d, %Y at %H:%M") - ${cap_period} Report</div>
         </div>
         
@@ -443,14 +443,14 @@ EOF
         </div>
         
         <div class="section">
-            <h2>📊 System Insights</h2>
+            <h2><span aria-hidden="true">📊</span> System Insights</h2>
             <div class="insights-box">
                 <pre>$(cat "$insights_file" 2>/dev/null || echo "Insights not available")</pre>
             </div>
         </div>
         
         <div class="section">
-            <h2>🔄 Recent Activity</h2>
+            <h2><span aria-hidden="true">🔄</span> Recent Activity</h2>
             <div class="insights-box">
                 <p>Latest maintenance tasks and system activities:</p>
                 <ul>


### PR DESCRIPTION
## Summary
Salvages the accessibility intent of #1230 onto current `main` — wraps decorative emojis in `<span aria-hidden="true">` in `analytics_dashboard.sh` headings. Omits unrelated session-doc / rules churn from the original branch.

## Verification
```bash
bash -n maintenance/bin/analytics_dashboard.sh
make test-quick
```

═══ ELIR ═══
**PURPOSE:** Prevent screen readers from announcing decorative emoji glyphs in the maintenance HTML dashboard.
**SECURITY:** HTML output only; no credential or auth surface touched.
**FAILS IF:** Emoji spans break template substitution — visually inspect generated dashboard HTML.
**VERIFY:** Run dashboard generator and confirm headings render with hidden emoji spans.
**MAINTAIN:** Apply same `aria-hidden` pattern to new emoji headings in this script.

Closes #1230 (superseded).