### PR TITLE
🎨 Palette: Fix accessibility for heading emojis

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2026-03-07 - Hide decorative emojis properly
-**Learning:** When hiding decorative emojis within text-containing elements (e.g., `<h3>`), wrap only the emoji in `<span aria-hidden="true">`. Applying a duplicate `aria-label` to the parent text element unnecessarily overrides the native inner text for screen readers.
-**Action:** Only wrap the emoji in `<span aria-hidden="true">` and remove redundant `aria-label` from parent if it duplicates the visible text.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-07 - Hide decorative emojis properly
+**Learning:** When hiding decorative emojis within text-containing elements (e.g., `<h3>`), wrap only the emoji in `<span aria-hidden="true">`. Applying a duplicate `aria-label` to the parent text element unnecessarily overrides the native inner text for screen readers.
+**Action:** Only wrap the emoji in `<span aria-hidden="true">` and remove redundant `aria-label` from parent if it duplicates the visible text.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -143,3 +143,8 @@
 ## 2026-06-12 - Accessible HTML structure
 **Learning:** This repo has shell and python scripts that generate HTML string. It follows standard HTML structure and uses standard accessibility practices like aria-label and aria-hidden on inner emojis. Also, note that color contrasts standard must follow WCAG AA guidelines.
 **Action:** When adding HTML in scripts, stick to accessibility best practices.
+
+## 2026-03-07 - Hide decorative emojis properly
+
+**Learning:** When hiding decorative emojis within text-containing elements (e.g., `<h3>`), wrap only the emoji in `<span aria-hidden="true">`. Applying a duplicate `aria-label` to the parent text element unnecessarily overrides the native inner text for screen readers.
+**Action:** Only wrap the emoji in `<span aria-hidden="true">` and remove redundant `aria-label` from parent if it duplicates the visible text.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -403,7 +403,7 @@ generate_dashboard() {
 <body>
     <div class="container">
         <div class="header">
-            <h1>🔧 System Maintenance Dashboard</h1>
+            <h1><span aria-hidden="true">🔧</span> System Maintenance Dashboard</h1>
             <div class="date">$(date "+%B %d, %Y at %H:%M") - ${cap_period} Report</div>
         </div>
         
@@ -443,14 +443,14 @@ EOF
         </div>
         
         <div class="section">
-            <h2>📊 System Insights</h2>
+            <h2><span aria-hidden="true">📊</span> System Insights</h2>
             <div class="insights-box">
                 <pre>$(cat "$insights_file" 2>/dev/null || echo "Insights not available")</pre>
             </div>
         </div>
         
         <div class="section">
-            <h2>🔄 Recent Activity</h2>
+            <h2><span aria-hidden="true">🔄</span> Recent Activity</h2>
             <div class="insights-box">
                 <p>Latest maintenance tasks and system activities:</p>
                 <ul>

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -230,7 +230,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1 aria-label="Media Library: {safe_path}"><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
         """]
 
         # Add parent directory link if not root

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -138,7 +138,7 @@ class TestMediaServerHandler(unittest.TestCase):
         html_root = self.handler.generate_directory_listing(files, "/")
 
         self.assertIn("<title>Media Library - /</title>", html_root)
-        self.assertIn("<h1 aria-label=\"Media Library: /\"><span aria-hidden=\"true\">\U0001f4c1</span> Media Library: //</h1>", html_root)
+        self.assertIn("<h1><span aria-hidden=\"true\">\U0001f4c1</span> Media Library: //</h1>", html_root)
         self.assertNotIn(".. (Parent Directory)", html_root)
 
         # File checks with escaped characters


### PR DESCRIPTION
💡 What: Removed redundant `aria-label` on parent `<h1>` tags that only duplicated inner text, and added `<span aria-hidden="true">` to raw emojis in headings.
🎯 Why: Fixes accessibility issue where screen readers redundantly read labels, and prevents screen readers from reading decorative emojis aloud.
📸 Before/After: N/A
♿ Accessibility: Prevents screen readers from announcing redundant text and decorative emojis.

---
*PR created automatically by Jules for task [9797021811476121084](https://jules.google.com/task/9797021811476121084) started by @abhimehro*