### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate title.lower() during PR fetch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -222,3 +222,8 @@
 
 **Learning:** When calculating the current date string `datetime.date.today().isoformat()` inside a loop or comprehension, Python repeatedly calls the method, generating a new object each time. This creates unnecessary CPU overhead when the output is a constant for the duration of the loop.
 **Action:** Always hoist method calls that generate static strings (like `today().isoformat()`) outside of tight loops to evaluate them once and reuse the value.
+
+## 2026-06-14 - [Avoid eager evaluation in `.get()` fallbacks]
+
+**Learning:** When using Python's `dict.get(key, default)` method, the `default` argument is evaluated eagerly before the method is called. If the fallback value is computationally expensive or allocates new objects (like `p["title"].lower()`), this evaluation happens on every iteration, negating any performance benefits of hoisting or memoization.
+**Action:** When a fallback value in a `.get()` lookup is expensive to compute, retrieve the value without a default (`value = p.get("key")`) and conditionally compute the fallback using an `if value is None:` block.

--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -31,7 +31,10 @@ def _find_matching_prs(all_prs, repo, title_keywords):
     for p in all_prs:
         if p["repo"] != repo:
             continue
-        if _contains_all_keywords(p["title"].lower(), lower_kws):
+        title_lower = p.get("title_lower")
+        if title_lower is None:
+            title_lower = p["title"].lower()
+        if _contains_all_keywords(title_lower, lower_kws):
             matches.append(p)
     return matches
 
@@ -127,6 +130,8 @@ def _fetch_repo_prs(repo):
             # ⚡ Bolt Optimization: Use rpartition() over split() to avoid intermediate list allocation overhead
             pr["repo"] = repo.rpartition("/")[2]
             pr["full_repo"] = repo
+            # ⚡ Bolt Optimization: Hoist title lowering out of filtering loops to prevent redundant C-level string allocations
+            pr["title_lower"] = pr["title"].lower()
             repo_prs.append(pr)
     return repo_prs
 


### PR DESCRIPTION
💡 What: Extracted and hoisted the `.lower()` computation for PR titles into the read-only fetch step `_fetch_repo_prs` as a cached dictionary key, and updated the grouping iteration filter in `scratch_triage.py` to use a lazy fallback.
🎯 Why: In `scratch_triage.py`, `p["title"].lower()` was executed for every PR keyword inside `_contains_all_keywords` for EVERY categorization group check inside `find_and_group`. This caused redundant C-level string allocations that degraded performance.
📊 Impact: Eliminates repeated C-level string creation of PR titles. By storing the pre-computed lowercased title as `title_lower` early in the process and updating the check using a non-eager `.get()`, list traversal becomes drastically less CPU/memory intensive during classification.
🔬 Measurement: Run unit tests locally with `PYTHONPATH=. python3 -m unittest tests/test_scratch_triage.py` or observe script execution speeds directly on real PR volumes.

---
*PR created automatically by Jules for task [16658472879796322558](https://jules.google.com/task/16658472879796322558) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->