### PR TITLE
🎨 Palette: Make dashboard header emojis accessible to screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2024-06-14 - Accessible Emojis in Text Headers
-**Learning:** When text-containing elements like headers include decorative emojis, screen readers will audibly announce the emoji name, which disrupts reading flow. Wrapping only the emoji in `<span aria-hidden="true">` prevents this.
-**Action:** Avoid duplicate `aria-label` on the parent text element; wrap just the emoji in `<span aria-hidden="true">` so the native inner text continues to be read naturally.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Accessible Emojis in Text Headers
+**Learning:** When text-containing elements like headers include decorative emojis, screen readers will audibly announce the emoji name, which disrupts reading flow. Wrapping only the emoji in `<span aria-hidden="true">` prevents this.
+**Action:** Avoid duplicate `aria-label` on the parent text element; wrap just the emoji in `<span aria-hidden="true">` so the native inner text continues to be read naturally.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -143,3 +143,7 @@
 ## 2026-06-12 - Accessible HTML structure
 **Learning:** This repo has shell and python scripts that generate HTML string. It follows standard HTML structure and uses standard accessibility practices like aria-label and aria-hidden on inner emojis. Also, note that color contrasts standard must follow WCAG AA guidelines.
 **Action:** When adding HTML in scripts, stick to accessibility best practices.
+
+## 2024-06-14 - Accessible Emojis in Text Headers
+**Learning:** When text-containing elements like headers include decorative emojis, screen readers will audibly announce the emoji name, which disrupts reading flow. Wrapping only the emoji in `<span aria-hidden="true">` prevents this.
+**Action:** Avoid duplicate `aria-label` on the parent text element; wrap just the emoji in `<span aria-hidden="true">` so the native inner text continues to be read naturally.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -403,7 +403,7 @@ generate_dashboard() {
 <body>
     <div class="container">
         <div class="header">
-            <h1>🔧 System Maintenance Dashboard</h1>
+            <h1><span aria-hidden="true">🔧</span> System Maintenance Dashboard</h1>
             <div class="date">$(date "+%B %d, %Y at %H:%M") - ${cap_period} Report</div>
         </div>
         
@@ -443,14 +443,14 @@ EOF
         </div>
         
         <div class="section">
-            <h2>📊 System Insights</h2>
+            <h2><span aria-hidden="true">📊</span> System Insights</h2>
             <div class="insights-box">
                 <pre>$(cat "$insights_file" 2>/dev/null || echo "Insights not available")</pre>
             </div>
         </div>
         
         <div class="section">
-            <h2>🔄 Recent Activity</h2>
+            <h2><span aria-hidden="true">🔄</span> Recent Activity</h2>
             <div class="insights-box">
                 <p>Latest maintenance tasks and system activities:</p>
                 <ul>


### PR DESCRIPTION
💡 What: Wrapped decorative emojis in h1 and h2 tags with span aria-hidden="true".\n🎯 Why: Prevents screen readers from audibly announcing the emoji name (e.g., "wrench system maintenance dashboard"), which disrupts reading flow.\n📸 Before/After: Not applicable (invisible accessibility change).\n♿ Accessibility: Improves screen reader experience by allowing the native inner text to be read naturally without duplicate aria-label override.

---
*PR created automatically by Jules for task [1298048144796901534](https://jules.google.com/task/1298048144796901534) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->