### PR TITLE
🎨 Palette: Add aria-hidden to decorative emojis in HTML sections

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -52,6 +52,7 @@ import datetime as dt
 import hashlib
 import html
 import json
+import re
 import logging
 import os
 import sys
@@ -578,7 +579,13 @@ def html_ul(items: Iterable[str]) -> str:
 
 
 def html_section(title: str, body: str) -> str:
-    return f"<h3>{sanitize_text(title)}</h3>{body}"
+    sanitized_title = sanitize_text(title)
+    accessible_title = re.sub(
+        r'([\U0001f300-\U0001f5ff\U0001f900-\U0001f9ff\U0001f600-\U0001f64f\U0001f680-\U0001f6ff\u2600-\u26ff\u2700-\u27bf\U0001f1e6-\U0001f1ff\U0001f191-\U0001f251]+)',
+        r'<span aria-hidden="true">\1</span>',
+        sanitized_title
+    )
+    return f"<h3>{accessible_title}</h3>{body}"
 
 
 def html_subsection(title: str, body: str) -> str:

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -174,6 +174,11 @@ class TestHtmlHelpers(unittest.TestCase):
         assert "<script>" not in result
         assert "&lt;script&gt;" in result
 
+    def test_html_section_accessibility_emojis(self):
+        result = mb.html_section("🚀 Focus", "<p>body</p>")
+        assert "<h3><span aria-hidden=\"true\">🚀</span> Focus</h3>" in result
+        assert "<p>body</p>" in result
+
 
 # ============================================================
 # Date Helpers


### PR DESCRIPTION
💡 What: Added accessible span wrappers with aria-hidden="true" around decorative emojis in HTML sections.
🎯 Why: Prevents screen readers from redundantly reading the clean label along with the inner visual emojis, improving the accessibility experience.
📸 Before/After: Visuals remain unchanged. Assistive technologies no longer read emojis.
♿ Accessibility: Added explicit aria-hidden attributes to inner decorative text emojis.

---
*PR created automatically by Jules for task [17192710269328923615](https://jules.google.com/task/17192710269328923615) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->