### PR TITLE
⚡ Bolt: [performance improvement] Hoist datetime.date.today().isoformat() to avoid redundant parsing overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -222,3 +222,7 @@
 
 **Learning:** When calculating the current date string `datetime.date.today().isoformat()` inside a loop or comprehension, Python repeatedly calls the method, generating a new object each time. This creates unnecessary CPU overhead when the output is a constant for the duration of the loop.
 **Action:** Always hoist method calls that generate static strings (like `today().isoformat()`) outside of tight loops to evaluate them once and reuse the value.
+## 2026-11-20 - [Avoid redundant datetime.date.today().isoformat() parsing overhead]
+
+**Learning:** When calculating the current date string `datetime.date.today().isoformat()` inside multiple string formats or loops, Python repeatedly calls the method, generating a new object and formatting string each time. This creates unnecessary CPU overhead when the output is a constant for the duration of the script.
+**Action:** Always hoist method calls that generate static strings (like `today().isoformat()`) outside of multiple usage sites to evaluate them once and reuse the cached string value.

--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -184,8 +184,11 @@ if __name__ == "__main__":
     closed = []
     escalated = []
 
+    # ⚡ Bolt Optimization: Hoisted datetime.date.today().isoformat() out of formatting blocks to avoid redundant parsing overhead
+    today_iso = datetime.date.today().isoformat()
+
     triage_md = [
-        f"# PR triage — backlog cleanup test ({datetime.date.today().isoformat()})\n",
+        f"# PR triage — backlog cleanup test ({today_iso})\n",
         "**Policy:** squash merge, stale_days 30, auto-fix enabled, mode review-and-merge. **No force-push.**\n",
         "## Duplicate / supersede groups\n",
         "| Keep (canonical) | Close as duplicate / superseded | Rationale |",
@@ -231,7 +234,7 @@ if __name__ == "__main__":
 
     # Session Report
     report_md = [
-        f"\n## Run — {datetime.date.today().isoformat()} (backlog cleanup E2E, review-and-merge)\n",
+        f"\n## Run — {today_iso} (backlog cleanup E2E, review-and-merge)\n",
         "### Repos processed\n",
     ]
     for i, r in enumerate(repos, 1):


### PR DESCRIPTION
💡 What: Replaced multiple `datetime.date.today().isoformat()` calls with a single hoisted `today_iso` variable.
🎯 Why: To avoid redundant datetime object creation and ISO string formatting overhead.
📊 Impact: Negligible speedup but follows the codebase's performance pattern of hoisting date formatting outside of repeated usages, avoiding unnecessary redundant parsing and allocation.
🔬 Measurement: Observe that the generated markdown output is identical, but without invoking `datetime.date.today().isoformat()` twice.

---
*PR created automatically by Jules for task [5304275476117931236](https://jules.google.com/task/5304275476117931236) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->