### PR TITLE
🎨 Palette: Remove redundant aria-label from headings

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -607,7 +607,7 @@ def _render_heading(level: int, title: str) -> str:
     if match:
         icon = match.group(1)
         clean_title = match.group(2)
-        return f'<h{level} aria-label="{clean_title}"><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
+        return f'<h{level}><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
 
     return f"<h{level}>{safe_title}</h{level}>"
 

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -176,7 +176,7 @@ class TestHtmlHelpers(unittest.TestCase):
 
     def test_html_section_with_emoji(self):
         result = mb.html_section("🌅 Good Morning", "<p>body</p>")
-        assert '<h3 aria-label="Good Morning">' in result
+        assert 'aria-label' not in result
         assert '<span aria-hidden="true">🌅</span>' in result
         assert "Good Morning</h3>" in result
 


### PR DESCRIPTION
💡 What: Removed duplicate `aria-label` from parent heading elements when hiding decorative emojis.
🎯 Why: To prevent screen readers from redundantly overriding and repeating the native inner text.
📸 Before/After: Before: `<h3 aria-label="Good Morning"><span aria-hidden="true">🌅</span> Good Morning</h3>` / After: `<h3><span aria-hidden="true">🌅</span> Good Morning</h3>`
♿ Accessibility: Improved screen reader flow by relying on the native text content of the heading rather than overriding it with an identical `aria-label` while correctly hiding the visual icon.

---
*PR created automatically by Jules for task [8499629900744234696](https://jules.google.com/task/8499629900744234696) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->