### PR TITLE
Daily QA Review - Fix Redefinitions

### DIFF
--- a/tests/test_detect_duplicates.py
+++ b/tests/test_detect_duplicates.py
@@ -14,7 +14,7 @@ from detect_duplicates import (
     _generate_ready_section,
 )
 
-from detect_duplicates import _extract_duplicates_from_groups, _group_prs_by_files
+from detect_duplicates import _group_prs_by_files
 
 class TestDetectDuplicates(unittest.TestCase):
     def test_extract_duplicates_from_groups_multiple_prs(self):

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -128,10 +128,6 @@ class TestParseInventory(unittest.TestCase):
     def test_is_pr_stale_none(self):
         self.assertFalse(_is_pr_stale(None))
 
-    def test_load_inventory_lines_file_not_found(self):
-        lines = _load_inventory_lines("nonexistent_file_xyz_123.txt")
-        self.assertEqual(lines, [])
-
     # --- _is_checks_failing ---
 
     def test_is_checks_failing_fail(self):

--- a/tests/test_repo_credential_hygiene.sh
+++ b/tests/test_repo_credential_hygiene.sh
@@ -46,7 +46,7 @@ fi
 
 # Legacy hardcoded WebDAV curl examples (literal password in quotes)
 if git grep -nE 'curl -u "infuse:[^$"\{]+"' media-streaming "${exclude_dirs[@]}" 2>/dev/null |
-	grep -v "\${MEDIA_WEBDAV_PASS}" |
+	grep -v '${MEDIA_WEBDAV_PASS}' |
 	grep -v "generated-secret" |
 	grep -v '<set in'; then
 	echo "✗ Found hardcoded curl -u infuse:password examples"

--- a/tests/test_vulnerability_fix.py
+++ b/tests/test_vulnerability_fix.py
@@ -81,9 +81,36 @@ class TestRunGhListArgs(unittest.TestCase):
     @patch("subprocess.run")
     def test_list_arg_scripts(self, mock_run):
         test_cases = {
-            "categorize_ready.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "title"],
-            "detect_duplicates.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "files"],
-            "run_merges.py": ["gh", "pr", "view", INJECTION_PR, "-R", INJECTION_REPO, "--json", "mergeStateStatus"],
+            "categorize_ready.py": [
+                "gh",
+                "pr",
+                "view",
+                INJECTION_PR,
+                "-R",
+                INJECTION_REPO,
+                "--json",
+                "title",
+            ],
+            "detect_duplicates.py": [
+                "gh",
+                "pr",
+                "view",
+                INJECTION_PR,
+                "-R",
+                INJECTION_REPO,
+                "--json",
+                "files",
+            ],
+            "run_merges.py": [
+                "gh",
+                "pr",
+                "view",
+                INJECTION_PR,
+                "-R",
+                INJECTION_REPO,
+                "--json",
+                "mergeStateStatus",
+            ],
         }
 
         for script, cmd_list in test_cases.items():


### PR DESCRIPTION
- Verified that the codebase builds and runs without errors.
- Ran tests via `PYTHONPATH=. make test-all`, all 36 shell tests and 270 Python unit tests passed.
- Fixed two `ruff/F811` redefinition lint errors in `tests/test_parse_inventory.py` and `tests/test_detect_duplicates.py`.
- Formatted `tests/test_parse_inventory.py`, `tests/test_repo_credential_hygiene.sh` and `tests/test_vulnerability_fix.py` via `trunk fmt`.
- Highlighted bash commands used during verification: `PYTHONPATH=. make test-all`, `export PATH="$HOME/.local/bin:/usr/local/bin:$PATH" && trunk check --all`, `export PATH="$HOME/.local/bin:/usr/local/bin:$PATH" && trunk fmt tests/test_parse_inventory.py tests/test_repo_credential_hygiene.sh tests/test_vulnerability_fix.py`.
- Checked and installed `trufflehog` via `curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b "$HOME/.local/bin"` and ran `make verify-credentials` which passed successfully.

---
*PR created automatically by Jules for task [3129240123090376470](https://jules.google.com/task/3129240123090376470) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->