### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-refactoring-agent.yml
+++ b/.github/workflows/test-refactoring-agent.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   refactor:
     if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/cs-agent')


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/personal-config/security/code-scanning/17](https://github.com/abhimehro/personal-config/security/code-scanning/17)

Add an explicit `permissions` block in `.github/workflows/test-refactoring-agent.yml` to enforce least privilege for `GITHUB_TOKEN`.

Best fix here (without changing functionality): add a workflow-level permission of `contents: read`, since the current job only runs shell echo commands and does not require write scopes. Placing it at the root applies to all jobs unless overridden and addresses the CodeQL warning directly.

Change location:
- File: `.github/workflows/test-refactoring-agent.yml`
- Insert `permissions:` block between `on:` trigger section and `jobs:`.

No imports, methods, or dependencies are needed (YAML workflow config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
