### PR TITLE
🎨 Palette: Improve metric card color contrast for WCAG AA compliance

### DIFF
--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -386,9 +386,9 @@ generate_dashboard() {
         .header .date { color: #666; font-size: 14px; }
         .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 40px; }
         .metric-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 8px; text-align: center; }
-        .metric-card.success { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
-        .metric-card.warning { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
-        .metric-card.critical { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); }
+        .metric-card.success { background: linear-gradient(135deg, #1E7E34 0%, #14532D 100%); }
+        .metric-card.warning { background: linear-gradient(135deg, #B45309 0%, #78350F 100%); }
+        .metric-card.critical { background: linear-gradient(135deg, #DC2626 0%, #7F1D1D 100%); }
         .metric-value { font-size: 2em; font-weight: bold; margin-bottom: 10px; }
         .metric-label { font-size: 0.9em; opacity: 0.9; }
         .section { margin-bottom: 40px; }


### PR DESCRIPTION
💡 What: Updated the background gradients of `.metric-card` status classes (success, warning, critical) in `maintenance/bin/analytics_dashboard.sh` to darker shades.
🎯 Why: The previous light gradients (e.g., `#00f2fe`, `#fecfef`) failed WCAG AA contrast ratios when used with white text, making the metrics difficult to read for users with visual impairments. The new darker gradients ensure sufficient contrast.
📸 Before/After: Visual change in HTML dashboard generated by the script.
♿ Accessibility: Improved contrast ratio to >4.5:1 for all metric cards.

---
*PR created automatically by Jules for task [176030886256308258](https://jules.google.com/task/176030886256308258) started by @abhimehro*