### PR TITLE
🎨 Palette: Improve color contrast for metric cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -152,3 +152,7 @@
 ## 2026-03-10 - Screen reader accessible emoji headings
 **Learning:** When using emojis in headings as visual icons, they can cause screen readers to read the unicode description of the emoji, breaking the flow of the section title. We must never use `not isascii()` to detect emoji as that would incorrectly hide valid non-ASCII text like 'Café'.
 **Action:** Added a reusable helper that splits emojis from the text using a strict emoji-range regex `^([\U0001F000-\U0001FAFF\U00002600-\U000027BF\u2600-\u27BF]+)\s+(.*)$`, applies an `aria-label` to the heading tag containing just the text, and wraps the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
+
+## 2026-06-18 - WCAG Accessible Metric Card Backgrounds
+**Learning:** When designing UI elements (like metric cards) with white text, using light background gradients (e.g., light blue, pink, cyan) often fails WCAG AA contrast guidelines, making the metrics unreadable for many users. The contrast ratios can be as low as 1.3:1 or 2.4:1 when they need to be at least 4.5:1.
+**Action:** Replace low-contrast gradients with WCAG AA compliant solid, dark colors (e.g., dark purple `#44337A`, dark green `#276749`, dark orange `#9C4221`, dark red `#9B2C2C`) to ensure proper readability while retaining the semantic color meaning.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -385,10 +385,10 @@ generate_dashboard() {
         .header h1 { color: #333; margin-bottom: 10px; }
         .header .date { color: #666; font-size: 14px; }
         .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 40px; }
-        .metric-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 8px; text-align: center; }
-        .metric-card.success { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
-        .metric-card.warning { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
-        .metric-card.critical { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); }
+        .metric-card { background: #44337A; color: white; padding: 20px; border-radius: 8px; text-align: center; }
+        .metric-card.success { background: #276749; }
+        .metric-card.warning { background: #9C4221; }
+        .metric-card.critical { background: #9B2C2C; }
         .metric-value { font-size: 2em; font-weight: bold; margin-bottom: 10px; }
         .metric-label { font-size: 0.9em; opacity: 0.9; }
         .section { margin-bottom: 40px; }


### PR DESCRIPTION
💡 What: Replaced low-contrast gradient backgrounds on metric cards with accessible solid colors.
🎯 Why: The original gradients failed WCAG AA contrast guidelines for white text, making the metrics difficult to read.
📸 Before/After: Before: #4facfe gradients (Contrast ~2.4:1). After: #276749 solid colors (Contrast >6.7:1).
♿ Accessibility: Enhanced text readability for all metric cards, satisfying WCAG AA requirements.

---
*PR created automatically by Jules for task [16735196903914852731](https://jules.google.com/task/16735196903914852731) started by @abhimehro*