### PR TITLE
feat: Harden Control D DNS setup with network resilience improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ configs/.config/fish/functions/*
 !configs/.config/fish/RESTORE_CUSTOMIZATIONS.md
 !configs/.config/fish/functions/nm-*.fish
 !configs/.config/fish/functions/__ensure_dracula_theme.fish
+!configs/.config/fish/functions/fix-dns.fish
 !configs/.config/fish/functions/__run_editor.fish
 !configs/.config/fish/functions/fish_greeting.fish
 !configs/.config/fish/functions/git-mirror-clean.fish

--- a/configs/.config/controld/ctrld.toml.example
+++ b/configs/.config/controld/ctrld.toml.example
@@ -1,0 +1,30 @@
+# Control D Configuration - User Level
+# Hardened for network resilience
+
+[listener]
+  [listener.0]
+    ip = '127.0.0.1'
+    port = 53
+
+    [listener.0.policy]
+      name = 'Default Policy'
+      rules = [
+        { 'captive.apple.com' = [] },
+        { 'detectportal.firefox.com' = [] },
+        { 'neverssl.com' = [] },
+        { 'p.controld.com' = [] },
+        { 'local.adguard.org' = [] }
+      ]
+
+[network]
+  [network.0]
+    name = 'Default Network'
+    cidrs = ['0.0.0.0/0']
+
+[upstream]
+  [upstream.0]
+    name = 'Control D Default'
+    type = 'doh3'
+    endpoint = 'https://dns.controld.com/free'
+    bootstrap_ip = '76.76.2.0'
+    timeout = 3000

--- a/configs/.config/controld/ctrld.toml.example
+++ b/configs/.config/controld/ctrld.toml.example
@@ -1,5 +1,11 @@
 # Control D Configuration - User Level
 # Hardened for network resilience
+# This file should be deployed to ~/.config/controld/ctrld.toml
+#
+# IMPORTANT: Only use ONE ctrld.toml (system OR user level), not both.
+# Both bind to port 53 on 127.0.0.1, which will cause conflicts.
+# - Use this user-level config if ctrld runs as a user service
+# - Use the system-level config if ctrld runs as a system service
 
 [listener]
   [listener.0]

--- a/configs/.config/fish/functions/fix-dns.fish
+++ b/configs/.config/fish/functions/fix-dns.fish
@@ -7,7 +7,8 @@ function fix-dns
     sudo launchctl unload /Library/LaunchDaemons/ctrld.plist 2>/dev/null
     
     # Dynamically get all network services and clear DNS on each
-    for iface in (networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}')
+    # Uses same pattern as scripts/lib/network-utils.sh
+    for iface in (networksetup -listallnetworkservices | grep -v "^An asterisk")
         sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
     end
     

--- a/configs/.config/fish/functions/fix-dns.fish
+++ b/configs/.config/fish/functions/fix-dns.fish
@@ -1,0 +1,17 @@
+function fix-dns
+    # Emergency DNS recovery for Control D
+    # Force-kills ctrld, clears static DNS entries on ALL interfaces, and flushes DNS cache
+    # Uses dynamic interface detection to work with any network configuration
+    
+    sudo pkill -9 -f "ctrld run" 2>/dev/null
+    sudo launchctl unload /Library/LaunchDaemons/ctrld.plist 2>/dev/null
+    
+    # Dynamically get all network services and clear DNS on each
+    for iface in (networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}')
+        sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
+    end
+    
+    sudo dscacheutil -flushcache
+    sudo killall -HUP mDNSResponder
+    echo "DNS restored to DHCP on all interfaces"
+end

--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -8,11 +8,15 @@ fix-dns() {
   sudo pkill -9 -f "ctrld run" 2>/dev/null
   sudo launchctl unload /Library/LaunchDaemons/ctrld.plist 2>/dev/null
   # Dynamically get all network services and clear DNS on each
-  networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}' | while read -r iface; do
-    [[ -n "$iface" ]] && sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
-  done
+  # Uses same pattern as scripts/lib/network-utils.sh
+  local services
+  services=$(networksetup -listallnetworkservices | grep -v "^An asterisk")
+  if [[ -n "$services" ]]; then
+    while IFS= read -r iface; do
+      [[ -n "$iface" ]] && sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
+    done <<< "$services"
+  fi
   sudo dscacheutil -flushcache
   sudo killall -HUP mDNSResponder
   echo "DNS restored to DHCP on all interfaces"
 }
-alias fix-dns='fix-dns'

--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -1,2 +1,18 @@
 # Minimal Zsh compatibility shim
 export PATH="$HOME/.local/bin:$PATH"
+
+# Emergency DNS recovery function for Control D
+# Force-kills ctrld, clears static DNS entries on ALL interfaces, and flushes DNS cache
+# Uses dynamic interface detection to work with any network configuration
+fix-dns() {
+  sudo pkill -9 -f "ctrld run" 2>/dev/null
+  sudo launchctl unload /Library/LaunchDaemons/ctrld.plist 2>/dev/null
+  # Dynamically get all network services and clear DNS on each
+  networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}' | while read -r iface; do
+    [[ -n "$iface" ]] && sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
+  done
+  sudo dscacheutil -flushcache
+  sudo killall -HUP mDNSResponder
+  echo "DNS restored to DHCP on all interfaces"
+}
+alias fix-dns='fix-dns'

--- a/configs/bin/ctrld-network-watch.sh
+++ b/configs/bin/ctrld-network-watch.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Watches for network interface state changes and validates ctrld health
+# on every transition. Falls back to DHCP DNS if ctrld is unresponsive.
+# Dynamically detects available network interfaces.
+
+LOG="$HOME/Public/Scripts/controld_monitor.log"
+
+# Function to get all active network services dynamically
+get_network_services() {
+  networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}' | tr -d '\n*'
+}
+
+scutil --watch | while read -r line; do
+  if echo "$line" | grep -qE "State:/Network/Interface/.*/IPv4|State:/Network/Global/IPv4"; then
+    sleep 3  # allow interface to stabilize
+    
+    # Get current active interfaces dynamically
+    INTERFACES=()
+    while IFS= read -r iface; do
+      [[ -z "$iface" ]] && continue
+      INTERFACES+=("$iface")
+    done < <(get_network_services)
+    
+    if [[ ${#INTERFACES[@]} -eq 0 ]]; then
+      echo "$(date): No network interfaces found, skipping DNS check" >> "$LOG"
+      continue
+    fi
+    
+    if ! dig +time=3 +tries=1 @127.0.0.1 verify.controld.com &>/dev/null; then
+      echo "$(date): ctrld unresponsive after network event — falling back to DHCP" >> "$LOG"
+      for iface in "${INTERFACES[@]}"; do
+        sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
+      done
+      sudo dscacheutil -flushcache
+      sudo killall -HUP mDNSResponder
+      # Attempt service recovery
+      sudo ctrld service restart &
+      sleep 5
+      # Re-enforce DNS if ctrld recovered
+      if dig +time=3 +tries=1 @127.0.0.1 verify.controld.com &>/dev/null; then
+        echo "$(date): ctrld recovered — re-enforcing 127.0.0.1 DNS" >> "$LOG"
+        for iface in "${INTERFACES[@]}"; do
+          sudo networksetup -setdnsservers "$iface" 127.0.0.1 2>/dev/null
+        done
+      else
+        echo "$(date): ctrld failed to recover — DHCP DNS remains active" >> "$LOG"
+      fi
+    fi
+  fi
+done

--- a/configs/bin/ctrld-network-watch.sh
+++ b/configs/bin/ctrld-network-watch.sh
@@ -2,35 +2,49 @@
 # Watches for network interface state changes and validates ctrld health
 # on every transition. Falls back to DHCP DNS if ctrld is unresponsive.
 # Dynamically detects available network interfaces.
+#
+# REQUIREMENT: Passwordless sudo must be configured for the following commands:
+#   - networksetup -setdnsservers *
+#   - dscacheutil -flushcache
+#   - killall -HUP mDNSResponder
+#   - ctrld service restart
+#
+# To configure, add to /etc/sudoers (use visudo):
+#   username ALL=(ALL) NOPASSWD: /usr/sbin/networksetup,/usr/bin/dscacheutil,/usr/bin/killall,/usr/local/bin/ctrld
 
 LOG="$HOME/Public/Scripts/controld_monitor.log"
 
 # Function to get all active network services dynamically
+# Uses the same pattern as scripts/lib/network-utils.sh
 get_network_services() {
-  networksetup -listallnetworkservices | tail -n +2 | awk '{print $NF}' | tr -d '\n*'
+  networksetup -listallnetworkservices | grep -v "^An asterisk"
+}
+
+# Function to set DNS servers for all active interfaces
+set_dns_all_interfaces() {
+  local dns_value="$1"
+  local services
+  services=$(get_network_services)
+  
+  if [[ -z "$services" ]]; then
+    echo "$(date): No network services found" >> "$LOG"
+    return 1
+  fi
+  
+  while IFS= read -r iface; do
+    [[ -z "$iface" ]] && continue
+    sudo networksetup -setdnsservers "$iface" "$dns_value" 2>/dev/null
+  done <<< "$services"
+  return 0
 }
 
 scutil --watch | while read -r line; do
   if echo "$line" | grep -qE "State:/Network/Interface/.*/IPv4|State:/Network/Global/IPv4"; then
     sleep 3  # allow interface to stabilize
     
-    # Get current active interfaces dynamically
-    INTERFACES=()
-    while IFS= read -r iface; do
-      [[ -z "$iface" ]] && continue
-      INTERFACES+=("$iface")
-    done < <(get_network_services)
-    
-    if [[ ${#INTERFACES[@]} -eq 0 ]]; then
-      echo "$(date): No network interfaces found, skipping DNS check" >> "$LOG"
-      continue
-    fi
-    
     if ! dig +time=3 +tries=1 @127.0.0.1 verify.controld.com &>/dev/null; then
       echo "$(date): ctrld unresponsive after network event — falling back to DHCP" >> "$LOG"
-      for iface in "${INTERFACES[@]}"; do
-        sudo networksetup -setdnsservers "$iface" Empty 2>/dev/null
-      done
+      set_dns_all_interfaces "Empty"
       sudo dscacheutil -flushcache
       sudo killall -HUP mDNSResponder
       # Attempt service recovery
@@ -39,9 +53,7 @@ scutil --watch | while read -r line; do
       # Re-enforce DNS if ctrld recovered
       if dig +time=3 +tries=1 @127.0.0.1 verify.controld.com &>/dev/null; then
         echo "$(date): ctrld recovered — re-enforcing 127.0.0.1 DNS" >> "$LOG"
-        for iface in "${INTERFACES[@]}"; do
-          sudo networksetup -setdnsservers "$iface" 127.0.0.1 2>/dev/null
-        done
+        set_dns_all_interfaces "127.0.0.1"
       else
         echo "$(date): ctrld failed to recover — DHCP DNS remains active" >> "$LOG"
       fi

--- a/controld-system/configs/ctrld.toml.example
+++ b/controld-system/configs/ctrld.toml.example
@@ -1,0 +1,31 @@
+# Control D Configuration - System Level
+# Hardened for network resilience
+# This file should be deployed to /etc/controld/ctrld.toml
+
+[listener]
+  [listener.0]
+    ip = '127.0.0.1'
+    port = 53
+
+    [listener.0.policy]
+      name = 'System Policy'
+      rules = [
+        { 'captive.apple.com' = [] },
+        { 'detectportal.firefox.com' = [] },
+        { 'neverssl.com' = [] },
+        { 'p.controld.com' = [] },
+        { 'local.adguard.org' = [] }
+      ]
+
+[network]
+  [network.0]
+    name = 'System Network'
+    cidrs = ['0.0.0.0/0']
+
+[upstream]
+  [upstream.0]
+    name = 'Control D System'
+    type = 'doh3'
+    endpoint = 'https://dns.controld.com/free'
+    bootstrap_ip = '76.76.2.0'
+    timeout = 3000

--- a/controld-system/configs/ctrld.toml.example
+++ b/controld-system/configs/ctrld.toml.example
@@ -1,6 +1,11 @@
 # Control D Configuration - System Level
 # Hardened for network resilience
 # This file should be deployed to /etc/controld/ctrld.toml
+#
+# IMPORTANT: Only use ONE ctrld.toml (system OR user level), not both.
+# Both bind to port 53 on 127.0.0.1, which will cause conflicts.
+# - Use this system-level config if ctrld runs as a system service
+# - Use the user-level config if ctrld runs as a user service
 
 [listener]
   [listener.0]

--- a/controld-system/launchd/ctrld.plist
+++ b/controld-system/launchd/ctrld.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ctrld</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/ctrld</string>
+    <string>run</string>
+    <string>--config=/etc/controld/ctrld.toml</string>
+    <string>--skip_self_checks</string>
+    <string>--iface=auto</string>
+    <string>--homedir=/etc/controld</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/etc/controld</string>
+
+  <key>SessionCreate</key>
+  <false/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>Disabled</key>
+  <false/>
+
+  <key>ExitTimeOut</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/ctrld.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/ctrld.err.log</string>
+</dict>
+</plist>

--- a/launch-agents/com.personal.ctrld-network-watch.plist
+++ b/launch-agents/com.personal.ctrld-network-watch.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.personal.ctrld-network-watch</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/speedybee/bin/ctrld-network-watch.sh</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/speedybee/Public/Scripts/ctrld-watch.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/speedybee/Public/Scripts/ctrld-watch-error.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Implements comprehensive hardening for Control D standalone DNS setup to eliminate network failure mode after power outages or abrupt internet drops.

### Changes

**TASK 1 — Contain the DNS blast radius**
- Added `controld-system/configs/ctrld.toml.example` (system-level template)
- Added `configs/.config/controld/ctrld.toml.example` (user-level template)
- Both configs set `[listener.0] ip = '127.0.0.1'` to bind to localhost only
- Prevents ctrld from acting as network-wide DNS server for other LAN devices

**TASK 2 — Add ExitTimeOut to LaunchDaemon**
- Added `controld-system/launchd/ctrld.plist` with `<key>ExitTimeOut</key><integer>10</integer>`
- launchd will forcibly kill ctrld after 10 seconds if it doesn't exit cleanly during stop/unload
- Prevents terminal hangs when process is stuck in broken network state

**TASK 3 — Emergency DNS recovery**
- Modified `configs/.zshrc` to add `fix-dns` function (replaces alias for dynamic interface support)
- Added `configs/.config/fish/functions/fix-dns.fish` for fish shell
- Both use **dynamic interface detection** via `networksetup -listallnetworkservices`
- Force-kills ctrld, clears static DNS entries on ALL active interfaces, flushes DNS cache
- Works with any network configuration (Wi-Fi, Ethernet, VPN, etc.)

**TASK 4 — Reactive network event watcher**
- Added `configs/bin/ctrld-network-watch.sh` (executable)
- Added `launch-agents/com.personal.ctrld-network-watch.plist` (user-level LaunchAgent)
- Monitors network state changes via `scutil --watch`
- **Dynamic interface detection** - automatically detects all active network services
- Falls back to DHCP DNS if ctrld becomes unresponsive
- Attempts service recovery and re-enforces 127.0.0.1 DNS if ctrld recovers
- Logs all actions to `~/Public/Scripts/controld_monitor.log`

### Key Improvements

1. **Dynamic Interface Detection**: All scripts now automatically detect available network interfaces using `networksetup -listallnetworkservices`, making them work with any network configuration without hardcoding interface names.

2. **Network Resilience**: The combination of ExitTimeOut, emergency recovery alias, and reactive watcher ensures that DNS failures are automatically detected and recovered from.

3. **Security**: ctrld is now bound to localhost only, preventing it from being accessed by other devices on the LAN.

### Testing

See commit message for detailed testing instructions. Each component can be verified independently:
- Listener binding: `sudo lsof -nPi :53`
- ExitTimeOut: `grep ExitTimeOut /Library/LaunchDaemons/ctrld.plist`
- fix-dns: `type fix-dns` (in zsh) or `fix-dns` (in fish)
- Network watcher: `launchctl list | grep ctrld-network-watch`

### Deployment

Files are templates that need to be deployed to system paths:
- `ctrld.toml.example` → `/etc/controld/ctrld.toml` and `~/.config/controld/ctrld.toml`
- `ctrld.plist` → `/Library/LaunchDaemons/ctrld.plist`
- `ctrld-network-watch.sh` → `~/bin/ctrld-network-watch.sh`
- LaunchAgent plist → `~/Library/LaunchAgents/`

Use `./scripts/sync_all_configs.sh` for user-level configs.
