### PR TITLE
🎨 Palette: Improve metric card color contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -269,3 +269,7 @@ reusable helper that splits emojis from the text using a strict emoji-range
 regex `^([\U0001F000-\U0001FAFF\U00002600-\U000027BF\u2600-\u27BF]+)\s+(.*)$`,
 applies an `aria-label` to the heading tag containing just the text, and wraps
 the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
+
+## $(date "+%Y-%m-%d") - WCAG AA Contrast for Dashboard Metric Cards
+**Learning:** Light background gradients (like light blue to cyan or pink to red) paired with white text often fail to meet the WCAG AA minimum contrast ratio (4.5:1), making them difficult to read for many users. The visual appeal of gradients does not outweigh the necessity of readability.
+**Action:** Replace low-contrast background gradients on metric cards or similar UI elements with solid, dark colors (e.g., dark purple, dark green, dark orange, dark red) to ensure sufficient contrast with white text.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -385,10 +385,10 @@ generate_dashboard() {
         .header h1 { color: #333; margin-bottom: 10px; }
         .header .date { color: #666; font-size: 14px; }
         .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 40px; }
-        .metric-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 8px; text-align: center; }
-        .metric-card.success { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
-        .metric-card.warning { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
-        .metric-card.critical { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); }
+        .metric-card { background: #44337A; color: white; padding: 20px; border-radius: 8px; text-align: center; }
+        .metric-card.success { background: #276749; }
+        .metric-card.warning { background: #9C4221; }
+        .metric-card.critical { background: #9B2C2C; }
         .metric-value { font-size: 2em; font-weight: bold; margin-bottom: 10px; }
         .metric-label { font-size: 0.9em; opacity: 0.9; }
         .section { margin-bottom: 40px; }


### PR DESCRIPTION
* 💡 What: Replaced light background gradients with solid, high-contrast colors for metric cards.
* 🎯 Why: The previous light blue/pink gradients with white text failed WCAG AA minimum contrast ratio (4.5:1), making them hard to read.
* 📸 Before/After: N/A
* ♿ Accessibility: Improved text readability by ensuring all metric card backgrounds meet WCAG AA contrast standards.

---
*PR created automatically by Jules for task [17923744302069630091](https://jules.google.com/task/17923744302069630091) started by @abhimehro*