### PR TITLE
fix(security): prevent AppleScript injection in GUI sudo prompt (salvages #1279)

### DIFF
--- a/configs/.config/mole/lib/core/sudo.sh
+++ b/configs/.config/mole/lib/core/sudo.sh
@@ -105,7 +105,7 @@ request_sudo_access() {
 
         cat << 'ASKPASS_EOF' > "$askpass_script"
 #!/bin/bash
-osascript -e 'on run argv' -e 'display dialog (item 1 of argv) default answer "" with title "Mole" with icon caution with hidden answer' -e 'text returned of result' -e 'end run' "${MOLE_SUDO_PROMPT:-Admin access required}" 2> /dev/null
+osascript -e 'on run argv' -e 'display dialog (item 1 of argv) default answer "" with title "Mole" with icon caution with hidden answer' -e 'text returned of result' -e 'end run' -- "${MOLE_SUDO_PROMPT:-Admin access required}" 2> /dev/null
 ASKPASS_EOF
 
         local sudo_success=false


### PR DESCRIPTION
## Summary

Salvages the security fix from #1279 onto a fresh branch from `main`. The original PR went `DIRTY` after concurrent merges to session-tracking files.

**Change:** Add `--` argument separator before `MOLE_SUDO_PROMPT` in the osascript ASKPASS helper so prompt text cannot inject AppleScript commands (CWE-74).

**Tier:** T1 — security-sensitive salvage

**Original PR:** #1279 (closing as superseded)

## Verification

```bash
bash -n configs/.config/mole/lib/core/sudo.sh
make test-quick
```

## ELIR

**PURPOSE:** Harden GUI sudo password prompt against AppleScript injection by passing the prompt via osascript's `argv` with a proper argument separator.

**SECURITY:** Prevents CWE-74 — malicious prompt text could previously alter osascript command structure; `--` terminates option parsing.

**FAILS IF:** Prompt still interpolated without separator, or ASKPASS script regresses to inline string concatenation.

**VERIFY:** Confirm `osascript` line uses `--` before `"${MOLE_SUDO_PROMPT...}"` in `configs/.config/mole/lib/core/sudo.sh`.

**MAINTAIN:** Any future GUI auth prompts using osascript must use `--` + argv pattern, never inline interpolation.