### PR TITLE
fix(a11y): use html_section for podcast error fallback heading (salvages #1281)

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -1282,7 +1282,7 @@ def fetch_podcast_section(llm: PerplexityClient, *, limit: int = 3) -> SectionRe
     except Exception as exc:
         logger.error("Podcast error: %s", exc)
         return SectionResult(
-            "<h3>🎧 Latest from America Adapts</h3><p><em>Could not fetch episodes today.</em></p>",
+            html_section("🎧 Latest from America Adapts", "<p><em>Could not fetch episodes today.</em></p>"),
             [],
         )
 


### PR DESCRIPTION
## Summary

Salvages the accessibility fix from #1281 onto a fresh branch from `main`. The original PR went `DIRTY` after concurrent merges.

**Change:** Use `html_section()` for the podcast fetch error fallback so the heading gets screen-reader semantics consistent with the success path.

**Tier:** T3 — routine salvage (accessibility)

**Original PR:** #1281 (closing as superseded)

**Note:** CodeScene-driven refactors from the original PR were intentionally omitted; only the one-line a11y fix is salvaged.

## Verification

```bash
python3 -m py_compile scripts/morning-brief/morning-brief.py
make test-quick
```

## ELIR

**PURPOSE:** Ensure podcast error fallback uses the same accessible heading renderer as the success path.

**SECURITY:** N/A — presentation-layer only.

**FAILS IF:** Error path still emits raw `<h3>` without `aria-hidden` icon handling.

**VERIFY:** `fetch_podcast_section` exception handler returns `html_section("🎧 Latest from America Adapts", ...)`.

**MAINTAIN:** All new section headings should use `html_section()` / `_render_heading()`, not raw HTML tags.