### PR TITLE
🎨 Palette: [UX improvement] Improve screen reader accessibility in media server HTML

### DIFF
--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -239,7 +239,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             # Parent path is constructed safely from split, but escaping is good hygiene
             safe_parent = html.escape(parent)
             html_parts.append(
-                f'<a href="/{safe_parent}" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">📁 .. (Parent Directory)</span></a>\n'
+                f'<a href="/{safe_parent}" class="file directory"><span aria-hidden="true">📁</span> .. (Parent Directory)</a>\n'
             )
 
         # ⚡ Performance: tuple for fast C-level endswith checking
@@ -256,13 +256,13 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         items_html = [
             (
                 (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory" aria-label="Directory: {html.escape(item)[:-1]}">'
-                    f'<span aria-hidden="true">📁 {html.escape(item)[:-1]}</span></a>\n'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory">'
+                    f'<span aria-hidden="true">📁</span> {html.escape(item)[:-1]}</a>\n'
                 )
                 if item.endswith("/")
                 else (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video" aria-label="File: {html.escape(item)}">'
-                    f'<span aria-hidden="true">{"🎬" if item.lower().endswith(video_exts) else "📄"} {html.escape(item)}</span></a>\n'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video">'
+                    f'<span aria-hidden="true">{"🎬" if item.lower().endswith(video_exts) else "📄"}</span> {html.escape(item)}</a>\n'
                 )
             )
             for item in files

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -146,19 +146,19 @@ class TestMediaServerHandler(unittest.TestCase):
 
         # File checks with escaped characters
         self.assertIn(
-            '<a href="/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
+            '<a href="/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
+            '<a href="/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/document &amp; file.txt" class="file video" aria-label="File: document &amp; file.txt"><span aria-hidden="true">\U0001f4c4 document &amp; file.txt</span></a>',
+            '<a href="/document &amp; file.txt" class="file video"><span aria-hidden="true">\U0001f4c4</span> document &amp; file.txt</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video" aria-label="File: &lt;script&gt;alert(1)&lt;/script&gt;.avi"><span aria-hidden="true">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</span></a>',
+            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video"><span aria-hidden="true">\U0001f3ac</span> &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
             html_root,
         )
 
@@ -177,17 +177,17 @@ class TestMediaServerHandler(unittest.TestCase):
         # Let's check code: parent = "/".join(current_path.rstrip("/").split("/")[:-1]) -> "/Movies & TV"
         # safe_parent = html.escape(parent) -> "/Movies &amp; TV"
         self.assertIn(
-            '<a href="//Movies &amp; TV" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">',
+            '<a href="//Movies &amp; TV" class="file directory"><span aria-hidden="true">\U0001f4c1</span> .. (Parent Directory)</a>',
             html_sub,
         )
 
         # Check files in subdirectory (href should append to the escaped base_path)
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
             html_sub,
         )
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
             html_sub,
         )
 


### PR DESCRIPTION
💡 What: Removed redundant `aria-label` attributes that completely override the native link text for screen readers, and tightened `aria-hidden=true` to only hide the decorative emojis.
🎯 Why: A duplicate `aria-label` completely replaces the text element and its native reading flow, creating redundancy. Hiding the whole text rather than just the emoji prevents it from being read correctly without the override.
📸 Before/After: N/A (screen reader logic change, no visible difference)
♿ Accessibility: Ensures that screen readers naturally read the text of the links and ignore the decorative icons, adhering to proper semantic HTML guidelines.

---
*PR created automatically by Jules for task [16681819552403916514](https://jules.google.com/task/16681819552403916514) started by @abhimehro*