### PR TITLE
🎨 Palette: Fix redundant ARIA labels in infuse-media-server directory listing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -273,3 +273,8 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## $(date "+%Y-%m-%d") - WCAG AA Contrast for Dashboard Metric Cards
 **Learning:** Light background gradients (like light blue to cyan or pink to red) paired with white text often fail to meet the WCAG AA minimum contrast ratio (4.5:1), making them difficult to read for many users. The visual appeal of gradients does not outweigh the necessity of readability.
 **Action:** Replace low-contrast background gradients on metric cards or similar UI elements with solid, dark colors (e.g., dark purple, dark green, dark orange, dark red) to ensure sufficient contrast with white text.
+
+## 2024-06-20 - HTML Accessibility: Avoid redundant aria-labels
+
+**Learning:** When hiding decorative emojis within text-containing elements (like `<a>`), applying a duplicate `aria-label` to the parent tag unnecessarily overrides the native inner text for screen readers.
+**Action:** Wrap only the decorative emoji in `<span aria-hidden="true">` and remove the redundant `aria-label` from the parent element to rely on its natural text content.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -239,7 +239,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             # Parent path is constructed safely from split, but escaping is good hygiene
             safe_parent = html.escape(parent)
             html_parts.append(
-                f'<a href="/{safe_parent}" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">📁 .. (Parent Directory)</span></a>\n'
+                f'<a href="/{safe_parent}" class="file directory"><span aria-hidden="true">\U0001f4c1</span> .. (Parent Directory)</a>\n'
             )
 
         # ⚡ Performance: tuple for fast C-level endswith checking
@@ -256,13 +256,13 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         items_html = [
             (
                 (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory" aria-label="Directory: {html.escape(item)[:-1]}">'
-                    f'<span aria-hidden="true">📁 {html.escape(item)[:-1]}</span></a>\n'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory">'
+                    f'<span aria-hidden="true">\U0001f4c1</span> {html.escape(item)[:-1]}</a>\n'
                 )
                 if item.endswith("/")
                 else (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video" aria-label="File: {html.escape(item)}">'
-                    f'<span aria-hidden="true">{"🎬" if item.lower().endswith(video_exts) else "📄"} {html.escape(item)}</span></a>\n'
+                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video">'
+                    f'<span aria-hidden="true">{"\U0001f3ac" if item.lower().endswith(video_exts) else "\U0001f4c4"}</span> {html.escape(item)}</a>\n'
                 )
             )
             for item in files

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -146,19 +146,19 @@ class TestMediaServerHandler(unittest.TestCase):
 
         # File checks with escaped characters
         self.assertIn(
-            '<a href="/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
+            '<a href="/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
+            '<a href="/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/document &amp; file.txt" class="file video" aria-label="File: document &amp; file.txt"><span aria-hidden="true">\U0001f4c4 document &amp; file.txt</span></a>',
+            '<a href="/document &amp; file.txt" class="file video"><span aria-hidden="true">\U0001f4c4</span> document &amp; file.txt</a>',
             html_root,
         )
         self.assertIn(
-            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video" aria-label="File: &lt;script&gt;alert(1)&lt;/script&gt;.avi"><span aria-hidden="true">\U0001f3ac &lt;script&gt;alert(1)&lt;/script&gt;.avi</span></a>',
+            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video"><span aria-hidden="true">\U0001f3ac</span> &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
             html_root,
         )
 
@@ -177,17 +177,17 @@ class TestMediaServerHandler(unittest.TestCase):
         # Let's check code: parent = "/".join(current_path.rstrip("/").split("/")[:-1]) -> "/Movies & TV"
         # safe_parent = html.escape(parent) -> "/Movies &amp; TV"
         self.assertIn(
-            '<a href="//Movies &amp; TV" class="file directory" aria-label="Parent Directory"><span aria-hidden="true">',
+            '<a href="//Movies &amp; TV" class="file directory"><span aria-hidden="true">',
             html_sub,
         )
 
         # Check files in subdirectory (href should append to the escaped base_path)
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video" aria-label="File: video.mp4"><span aria-hidden="true">\U0001f3ac video.mp4</span></a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
             html_sub,
         )
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory" aria-label="Directory: folder with &lt;tag&gt;"><span aria-hidden="true">\U0001f4c1 folder with &lt;tag&gt;</span></a>',
+            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
             html_sub,
         )
 


### PR DESCRIPTION
💡 What: Removed redundant `aria-label`s from directory links and correctly scoped `aria-hidden` to only the emojis.
🎯 Why: Applying `aria-label` to the parent `<a>` tag unnecessarily overrides the native text for screen readers.
📸 Before/After: N/A
♿ Accessibility: Screen readers will now read the natural text of the links without redundant descriptions, while still ignoring the decorative emojis.

---
*PR created automatically by Jules for task [4184131271477318773](https://jules.google.com/task/4184131271477318773) started by @abhimehro*