### PR TITLE
fix(ci): dedupe mashed duplicate uses lines in workflow YAML (unblocks #1304)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0        uses: actions/dependency-review-action@v5.0.0 # v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0 # v5.0.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/mac-audit.yml
+++ b/.github/workflows/mac-audit.yml
@@ -66,7 +66,7 @@ jobs:
             > mac-audit/reports/audit-${{ runner.os }}-${{ github.sha }}.txt || true
 
       - name: Upload report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: audit-report-${{ matrix.os }}

--- a/.github/workflows/repository-automation-daily.yml
+++ b/.github/workflows/repository-automation-daily.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload workflow updater artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workflow-updater
           path: .automation-output/workflow-updater
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload performance artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: performance-optimizer
           path: .automation-output/performance-optimizer
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload QA artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quality-assurance
           path: .automation-output/quality-assurance
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload backlog artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backlog-manager
           path: .automation-output/backlog-manager
@@ -220,7 +220,7 @@ jobs:
         run: python -m pip install --upgrade pip pyyaml
 
       - name: Download task artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: .automation-output
 
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload status artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daily-status-report
           path: .automation-output/daily-status-report

--- a/.github/workflows/repository-automation-weekly.yml
+++ b/.github/workflows/repository-automation-weekly.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload retrospective artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: weekly-retrospective
           path: .automation-output/weekly-retrospective

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0      - uses: actions/stale@v10.3.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "Stale issue message"

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run AI inference
         id: inference
-        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2.1.1        uses: actions/ai-inference@v2.1.1
+        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2.1.1
         with:
           prompt: |
             Summarize the following GitHub issue in one paragraph:


### PR DESCRIPTION
## Summary

Removes concatenated duplicate `uses:` action references introduced on `main` by an `automation-workflow-updates-*` branch. Six workflow files had mashed lines like:

```
uses: actions/foo@<sha> # vX.Y.Z        uses: actions/foo@vX.Y.Z
```

This restores single SHA-pinned references and unblocks `dependency-review` and artifact upload/download steps.

## Impact chain

- **Blocked:** [#1304](https://github.com/abhimehro/personal-config/pull/1304) (corrupted workflow automation PR — SHA→tag regression on top of mashed YAML)
- **Unblocks:** dependency-review, stale, summary, mac-audit, repository-automation-* workflows

## Verification

```bash
rg 'uses:.*uses:' .github/workflows/   # expect no matches
make lint-errors
```

═══ ELIR ═══
PURPOSE: Restore valid GitHub Actions workflow YAML by deduplicating mashed `uses:` lines on `main`.
SECURITY: Keeps SHA-pinned action refs; does not broaden to floating tags.
FAILS IF: A workflow still contains inline duplicate `uses:` tokens — YAML parse or action resolution fails at runtime.
VERIFY: `rg 'uses:.*uses:' .github/workflows/` returns empty; spot-check `dependency-review.yml`.
MAINTAIN: Never merge `automation-workflow-updates-*` PRs without scanning for mashed `uses:` lines (Lesson 0ct).

Refs: #1304 (salvage source)