### PR TITLE
🎨 Palette: [UX improvement] Fix redundant aria-labels in analytics dashboard metric cards

### DIFF
--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -408,9 +408,9 @@ generate_dashboard() {
         </div>
         
         <div class="metrics-grid">
-            <div class="metric-card success" aria-label="Health Score: ${current_health}">
-                <div class="metric-value" aria-hidden="true">${current_health}</div>
-                <div class="metric-label" aria-hidden="true">Health Score</div>
+            <div class="metric-card success">
+                <div class="metric-value">${current_health}</div>
+                <div class="metric-label">Health Score</div>
             </div>
 EOF
 
@@ -424,17 +424,17 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <div class="metric-card" aria-label="Performance Score: ${avg_performance}">
-                <div class="metric-value" aria-hidden="true">${avg_performance}</div>
-                <div class="metric-label" aria-hidden="true">Performance Score</div>
+            <div class="metric-card">
+                <div class="metric-value">${avg_performance}</div>
+                <div class="metric-label">Performance Score</div>
             </div>
-            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" aria-label="Disk Usage: ${avg_disk}%">
-                <div class="metric-value" aria-hidden="true">${avg_disk}%</div>
-                <div class="metric-label" aria-hidden="true">Disk Usage</div>
+            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")">
+                <div class="metric-value">${avg_disk}%</div>
+                <div class="metric-label">Disk Usage</div>
             </div>
-            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-label="Total Warnings: ${total_warnings}">
-                <div class="metric-value" aria-hidden="true">${total_warnings}</div>
-                <div class="metric-label" aria-hidden="true">Total Warnings</div>
+            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")">
+                <div class="metric-value">${total_warnings}</div>
+                <div class="metric-label">Total Warnings</div>
             </div>
 EOF
 	fi


### PR DESCRIPTION
- 💡 What: Removed duplicate `aria-label`s from parent `.metric-card` div elements and removed redundant `aria-hidden="true"` from their child elements in `maintenance/bin/analytics_dashboard.sh`.
- 🎯 Why: Applying an `aria-label` to a generic `<div>` (without a semantic role) is often ignored by screen readers. Simultaneously hiding the actual child text with `aria-hidden="true"` makes the metric cards completely invisible to assistive technologies. By removing these, the screen reader falls back to reading the native HTML text correctly.
- 📸 Before/After: N/A (Visuals are unchanged).
- ♿ Accessibility: Significant improvement. The screen reader will now naturally read the values and labels inside the metric cards, instead of ignoring the parent's `aria-label` and skipping the hidden children. This adheres to the First Rule of ARIA: "No ARIA is better than bad ARIA."

---
*PR created automatically by Jules for task [6314164123504848218](https://jules.google.com/task/6314164123504848218) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->