### PR TITLE
🎨 Palette: Improve screen reader grouping for dashboard metrics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -278,3 +278,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 
 **Learning:** When hiding decorative emojis within text-containing elements (like `<a>`), applying a duplicate `aria-label` to the parent tag unnecessarily overrides the native inner text for screen readers.
 **Action:** Wrap only the decorative emoji in `<span aria-hidden="true">` and remove the redundant `aria-label` from the parent element to rely on its natural text content.
+## 2026-06-22 - [HTML Accessibility Pattern: Avoid duplicate announcements with aria-labelledby]
+**Learning:** When adding ARIA labels to a container (like `role="group"`) that already contains visible label text, do not use a hardcoded `aria-label` that duplicates the text, as it causes screen readers to announce it redundantly.
+**Action:** Assign an `id` to the visible text element and reference it using `aria-labelledby` on the container.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -408,9 +408,9 @@ generate_dashboard() {
         </div>
         
         <div class="metrics-grid">
-            <div class="metric-card success">
+            <div class="metric-card success" role="group" aria-labelledby="label-health">
                 <div class="metric-value">${current_health}</div>
-                <div class="metric-label">Health Score</div>
+                <div class="metric-label" id="label-health">Health Score</div>
             </div>
 EOF
 
@@ -424,17 +424,17 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <div class="metric-card">
+            <div class="metric-card" role="group" aria-labelledby="label-performance">
                 <div class="metric-value">${avg_performance}</div>
-                <div class="metric-label">Performance Score</div>
+                <div class="metric-label" id="label-performance">Performance Score</div>
             </div>
-            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")">
+            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" role="group" aria-labelledby="label-disk">
                 <div class="metric-value">${avg_disk}%</div>
-                <div class="metric-label">Disk Usage</div>
+                <div class="metric-label" id="label-disk">Disk Usage</div>
             </div>
-            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")">
+            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" role="group" aria-labelledby="label-warnings">
                 <div class="metric-value">${total_warnings}</div>
-                <div class="metric-label">Total Warnings</div>
+                <div class="metric-label" id="label-warnings">Total Warnings</div>
             </div>
 EOF
 	fi


### PR DESCRIPTION
💡 What: Added `role="group"` and `aria-labelledby` to metric cards, associating them directly with their child label elements using unique IDs.
🎯 Why: To improve screen reader accessibility by grouping the metric value and its label logically, without causing redundant "double-reading" of the label text (which was happening with the previous `aria-label` implementation).
📸 Before/After: N/A
♿ Accessibility: Screen readers will now group each metric value with its label efficiently.

---
*PR created automatically by Jules for task [16363120813736150769](https://jules.google.com/task/16363120813736150769) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->