### PR TITLE
⚡ Bolt: Parallelize weekly retrospective API calls

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -571,7 +571,9 @@ def render_pr_rows(prs: list[dict[str, Any]]) -> list[str]:
     return rows
 
 
-def _fetch_backlog_items(max_issues: int, max_prs: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def _fetch_backlog_items(
+    max_issues: int, max_prs: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         f_issues = executor.submit(
             gh_json,
@@ -687,13 +689,43 @@ def status_icon(status: str) -> str:
     return STATUS_ICONS.get(status, status.upper())
 
 
-def _fetch_daily_metrics() -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+def _fetch_daily_metrics() -> (
+    tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]
+):
     # ⚡ Bolt Optimization: Parallelize independent read-only API calls using ThreadPoolExecutor to significantly reduce execution latency
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
         futures = [
-            executor.submit(gh_json, ["issue", "list", "--state", "open", "--limit", "200", "--json", "number"], default=[]),
-            executor.submit(gh_json, ["pr", "list", "--state", "open", "--limit", "200", "--json", "number"], default=[]),
-            executor.submit(gh_json, ["release", "list", "--limit", "5", "--json", "name,publishedAt,tagName"], default=[]),
+            executor.submit(
+                gh_json,
+                [
+                    "issue",
+                    "list",
+                    "--state",
+                    "open",
+                    "--limit",
+                    "200",
+                    "--json",
+                    "number",
+                ],
+                default=[],
+            ),
+            executor.submit(
+                gh_json,
+                ["pr", "list", "--state", "open", "--limit", "200", "--json", "number"],
+                default=[],
+            ),
+            executor.submit(
+                gh_json,
+                [
+                    "release",
+                    "list",
+                    "--limit",
+                    "5",
+                    "--json",
+                    "name,publishedAt,tagName",
+                ],
+                default=[],
+            ),
         ]
         open_issues, open_prs, releases = [f.result() for f in futures]
     return open_issues, open_prs, releases
@@ -928,12 +960,19 @@ def weekly_report_lines(
 
 def run_weekly_retrospective(config: dict[str, Any]) -> dict[str, Any]:
     section = config.get("weekly_retrospective", {})
-    runs = recent_daily_runs()
-    markers = weekly_markers(
-        config.get("reporting", {}).get(
-            "daily_issue_prefix", "[repo-automation] Daily Status Report"
+
+    # ⚡ Bolt Optimization: Parallelize independent read-only API calls using ThreadPoolExecutor to significantly reduce execution latency
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        f_runs = executor.submit(recent_daily_runs)
+        f_markers = executor.submit(
+            weekly_markers,
+            config.get("reporting", {}).get(
+                "daily_issue_prefix", "[repo-automation] Daily Status Report"
+            ),
         )
-    )
+        runs = f_runs.result()
+        markers = f_markers.result()
+
     safe_changes = []
     safe_pr_url = ""
     if ensure_gh_token():

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -531,3 +531,6 @@ invocation.
 ## 2026-06-22 - [Avoid unnecessary .split() list allocation in simple string formatting]
 
 **Learning:** When extracting substrings from a string separated by a known delimiter inside a loop or comprehension (e.g. `line.split("=", 1)`), repeatedly calling `.split()` allocates new lists each time, causing a performance overhead. **Action:** When you only need to split once on the first delimiter and want to avoid unnecessary list allocation, use `str.partition()` instead of `str.split()`. It returns a tuple directly in C and doesn't allocate an arbitrary-length list.
+## 2026-06-25 - Python str.startswith() Performance
+**Learning:** Python's C-implemented `.startswith()` is faster than short-circuiting with Python-level character indexing and set allocations.
+**Action:** Do not manually check the first character of strings in Python bytecode when `.startswith()` can handle it natively in C.


### PR DESCRIPTION
💡 What: Parallelized `recent_daily_runs` and `weekly_markers` API calls using `concurrent.futures.ThreadPoolExecutor`.
🎯 Why: Both functions perform independent, blocking GitHub API requests (`gh run list` and `gh issue list`). Running them sequentially increases the total execution time, which can be optimized.
📊 Impact: Reduces network latency and execution time by executing the two independent I/O-bound `gh` subprocess calls concurrently.
🔬 Measurement: The `run_weekly_retrospective` function should execute faster, and the unit tests should continue to pass.

---
*PR created automatically by Jules for task [10980714713669008846](https://jules.google.com/task/10980714713669008846) started by @abhimehro*