### PR TITLE
🛡️ Sentinel: [HIGH] Fix AppleScript option injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -607,3 +607,9 @@ learning documented on 2026-04-22, found in another file. **Prevention:** Always
 use the `--` separator with `pgrep` and `pkill` before passing dynamic or
 external variables (e.g., `pkill -f -- "$pattern"`) to ensure arguments are
 treated strictly as patterns and not parsed as command-line options.
+
+## 2026-06-25 - AppleScript Option Injection Risk via osascript without -- delimiter
+
+**Vulnerability:** AppleScript Option Injection (CWE-74/CWE-88 variant). Even when passing dynamic variables safely to `osascript` using `-e 'on run argv'`, the variables were passed directly after the script string without the `--` delimiter (e.g. `osascript -e 'on run argv' ... -e 'end run' "$msg" "$title"`). If an attacker controls the variable and starts it with a hyphen, `osascript` may interpret the variable as a command-line flag rather than a positional argument, leading to option injection or unintended execution.
+**Learning:** When invoking `osascript` with dynamic variables from bash, you must explicitly separate options from arguments using the `--` delimiter before positional arguments to prevent them from being parsed as flags.
+**Prevention:** Always use the `--` argument delimiter before positional arguments when using `osascript` with external variables (e.g., `osascript -e 'on run argv' ... -- "$VAR"`).

--- a/media-streaming/scripts/approve-download
+++ b/media-streaming/scripts/approve-download
@@ -37,7 +37,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/check-stale-mounts.sh
+++ b/media-streaming/scripts/check-stale-mounts.sh
@@ -25,7 +25,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/cleanup-remote
+++ b/media-streaming/scripts/cleanup-remote
@@ -37,7 +37,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/mount-media.sh
+++ b/media-streaming/scripts/mount-media.sh
@@ -30,7 +30,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/media-streaming/scripts/rename-media.sh
+++ b/media-streaming/scripts/rename-media.sh
@@ -31,7 +31,7 @@ notify() {
 	if command -v terminal-notifier >/dev/null 2>&1; then
 		terminal-notifier -title "$t" -message "$m" -sound default
 	elif command -v osascript >/dev/null 2>&1; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$m" "$t" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$m" "$t" 2>/dev/null || true
 	fi
 }
 ensure_dirs() { mkdir -p "$STAGING_DIR" "$PROCESSED_DIR" "$FAILED_DIR" "$REVIEW_DIR" "$(dirname "$LOG_FILE")"; }

--- a/media-streaming/scripts/sync-alldebrid.sh
+++ b/media-streaming/scripts/sync-alldebrid.sh
@@ -65,7 +65,7 @@ notify() {
 	if command -v terminal-notifier &>/dev/null; then
 		terminal-notifier -title "$title" -message "$message" -sound default
 	elif command -v osascript &>/dev/null; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/secops/phase3-qa-health.sh
+++ b/secops/phase3-qa-health.sh
@@ -31,7 +31,7 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >>"$LOG_FILE"; }
 
 notify() {
 	local msg="$1"
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$msg" "SecOps Autopilot" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$msg" "SecOps Autopilot" 2>/dev/null || true
 }
 
 # Decide and run the repo's OWN declared test command.


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: AppleScript Option Injection (CWE-74) in `osascript` invocations where dynamic variables starting with a hyphen could be interpreted as command-line flags.
* 🎯 Impact: An attacker could potentially execute arbitrary commands or manipulate the notification if they control the variable contents.
* 🔧 Fix: Added the `--` delimiter before positional arguments in `osascript -e 'on run argv'` calls.
* ✅ Verification: Verified using `git diff` and running the test suite (`make test-all`).

---
*PR created automatically by Jules for task [1402674162531365843](https://jules.google.com/task/1402674162531365843) started by @abhimehro*