### PR TITLE
⚡ Bolt: Optimize startswith checks and hoist loop invariant

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -198,7 +198,8 @@ def discover_hotspots(limit: int = 5) -> list[tuple[str, int]]:
 
 
 def _extract_repo_id(action_ref: str) -> str | None:
-    if action_ref.startswith("./") or action_ref.startswith("docker://"):
+    # ⚡ Bolt Optimization: Use tuple check to evaluate multiple startswith strings simultaneously at the C-level
+    if action_ref.startswith(("./", "docker://")):
         return None
     parts = action_ref.split("/")
     if len(parts) < 2:
@@ -367,8 +368,10 @@ def close_invalid_prs(branch_prefix: str) -> None:
         ["pr", "list", "--state", "open", "--json", "number,headRefName,body"],
         default=[],
     )
+    # ⚡ Bolt Optimization: Hoist loop-invariant string replacement out of the iteration to prevent redundant allocations
+    prefix = branch_prefix.replace("/", "-")
     for pr in open_prs:
-        if not pr.get("headRefName", "").startswith(branch_prefix.replace("/", "-")):
+        if not pr.get("headRefName", "").startswith(prefix):
             continue
         if _pr_has_invalid_tags(pr.get("body", "")):
             print(

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -534,3 +534,7 @@ invocation.
 ## 2026-06-25 - Python str.startswith() Performance
 **Learning:** Python's C-implemented `.startswith()` is faster than short-circuiting with Python-level character indexing and set allocations.
 **Action:** Do not manually check the first character of strings in Python bytecode when `.startswith()` can handle it natively in C.
+## 2026-03-10 - [Avoid redundant string replacements inside loops and multiple startswith strings calls]
+
+**Learning:** Evaluating loop-invariant string operations like `replace("/", "-")` inside a loop iterations causes unnecessary allocations. Similarly, calling `startswith()` sequentially inside a tight loop causes unecessary python overhead.
+**Action:** Hoist the string operations out of the loop and use a single tuple in `.startswith(("string1", "string2"))` to ensure operations evaluate at the C-level.


### PR DESCRIPTION
💡 What: Replaced sequential `.startswith()` checks with a tuple evaluation at the C-level in `_extract_repo_id`. Hoisted the `branch_prefix.replace()` string operation out of the loop in `close_invalid_prs`.
🎯 Why: Multiple Python-level `.startswith()` checks cause unnecessary function call overhead. Evaluating a string replacement inside a loop creates redundant allocations.
📊 Impact: Reduces string allocation overhead and speeds up PR processing iteration by preventing O(N) repetitive string operations.
🔬 Measurement: Verified that tests pass successfully via make test-all. The runtime overhead of these specific operations is reduced.

---
*PR created automatically by Jules for task [3035161952341616185](https://jules.google.com/task/3035161952341616185) started by @abhimehro*