### PR TITLE
🛡️ Sentinel: [HIGH] Fix AppleScript Option Injection in osascript calls

### DIFF
--- a/maintenance/bin/brew_maintenance.sh
+++ b/maintenance/bin/brew_maintenance.sh
@@ -244,7 +244,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "Homebrew Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "${STATUS_MSG}" "Homebrew Maintenance" 2>/dev/null || true
 fi
 
 log_info "Homebrew maintenance complete: ${STATUS_MSG}"

--- a/maintenance/bin/deep_cleaner.sh
+++ b/maintenance/bin/deep_cleaner.sh
@@ -326,7 +326,7 @@ log_info "Deep cleaning analysis complete"
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Analysis complete. Check report for cleanup recommendations." "Deep Cleaner" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Analysis complete. Check report for cleanup recommendations." "Deep Cleaner" 2>/dev/null || true
 fi
 
 echo ""

--- a/maintenance/bin/editor_cleanup.sh
+++ b/maintenance/bin/editor_cleanup.sh
@@ -160,10 +160,10 @@ total_freed_mb=$((total_freed / 1024))
 # Notification
 if command -v osascript >/dev/null 2>&1; then
 	if [[ $total_freed_mb -gt 0 ]]; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Completed - Freed ${total_freed_mb}MB" "Editor Cleanup" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Completed - Freed ${total_freed_mb}MB" "Editor Cleanup" 2>/dev/null || true
 		log_info "Editor cache cleanup freed ${total_freed_mb}MB total"
 	else
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Completed - Caches already clean" "Editor Cleanup" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Completed - Caches already clean" "Editor Cleanup" 2>/dev/null || true
 		log_info "Editor caches were already clean"
 	fi
 fi

--- a/maintenance/bin/google_drive_monitor.sh
+++ b/maintenance/bin/google_drive_monitor.sh
@@ -211,7 +211,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
 	if [[ $GDRIVE_STATUS != "Running" ]] || [[ $SYNC_STATUS == *"No recent activity"* ]] || [[ $SYNC_STATUS == *"errors"* ]]; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS_MSG
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS_MSG
 $BACKUP_MSG" "Google Drive Monitor - Issues Detected" 2>/dev/null || true
 		log_warn "Google Drive monitoring detected potential issues"
 	else

--- a/maintenance/bin/health_check.sh
+++ b/maintenance/bin/health_check.sh
@@ -406,7 +406,7 @@ elif command -v osascript >/dev/null 2>&1; then
 	if ((PANIC_COUNT > 0)) && [[ -n $PANIC_DETAILS ]]; then
 		NOTIFICATION_TEXT+=$'\n'"${PANIC_DETAILS}"
 	fi
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${NOTIFICATION_TEXT}" "Health Check" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "${NOTIFICATION_TEXT}" "Health Check" 2>/dev/null || true
 fi
 
 log_info "Health check complete: ${HEALTH_STATUS}"

--- a/maintenance/bin/monthly_maintenance.sh
+++ b/maintenance/bin/monthly_maintenance.sh
@@ -135,7 +135,7 @@ fi
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Monthly Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS" "Monthly Maintenance" 2>/dev/null || true
 fi
 
 log_info "Monthly maintenance finished: $STATUS"
@@ -164,7 +164,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Monthly Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS" "Monthly Maintenance" 2>/dev/null || true
 fi
 
 echo "Monthly maintenance completed!"

--- a/maintenance/bin/node_maintenance.sh
+++ b/maintenance/bin/node_maintenance.sh
@@ -221,7 +221,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS_MSG" "Node.js Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS_MSG" "Node.js Maintenance" 2>/dev/null || true
 fi
 
 log_info "Node.js maintenance complete: $STATUS_MSG"

--- a/maintenance/bin/quick_cleanup.sh
+++ b/maintenance/bin/quick_cleanup.sh
@@ -174,7 +174,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-execute "$HOME/Library/Maintenance/bin/view_logs.sh quick_cleanup" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Cleaned ${CLEANED} items | Disk: ${DISK_USE}%" "Quick Cleanup" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Cleaned ${CLEANED} items | Disk: ${DISK_USE}%" "Quick Cleanup" 2>/dev/null || true
 fi
 
 log_info "Quick cleanup completed: ${CLEANED} items cleaned"

--- a/maintenance/bin/service_monitor.sh
+++ b/maintenance/bin/service_monitor.sh
@@ -314,9 +314,9 @@ echo "$REPORT"
 # Send notification if not in automated mode
 if [[ ${AUTOMATED_RUN:-0} != "1" ]] && command -v osascript >/dev/null 2>&1; then
 	if ((ISSUES > 0)); then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT" "⚠️ Service Monitor" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Issues: $ISSUES | Actions: $ACTIONS_TAKEN | Widgets: $WIDGET_COUNT" "⚠️ Service Monitor" 2>/dev/null || true
 	elif ((WARNINGS > 0)); then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT" "ℹ️ Service Monitor" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Warnings: $WARNINGS | Widgets: $WIDGET_COUNT | Reports: $REPORT_COUNT" "ℹ️ Service Monitor" 2>/dev/null || true
 	fi
 fi
 

--- a/maintenance/bin/system_cleanup.sh
+++ b/maintenance/bin/system_cleanup.sh
@@ -259,7 +259,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 		-message "${STATUS_MSG}" \
 		-group "maintenance" 2>/dev/null || true
 elif command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "${STATUS_MSG}" "System Cleanup" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "${STATUS_MSG}" "System Cleanup" 2>/dev/null || true
 fi
 
 log_info "System cleanup complete: ${STATUS_MSG}"

--- a/maintenance/bin/system_metrics.sh
+++ b/maintenance/bin/system_metrics.sh
@@ -39,7 +39,7 @@ log_info "System metrics collection started"
 
 # CPU and Load Metrics
 # Read uptime once to avoid spawning multiple processes
-read -r LOAD_1MIN LOAD_5MIN LOAD_15MIN <<< "$(uptime | awk -F'load averages:' '{print $2}' | tr -d ',' | awk '{print $1, $2, $3}')"
+read -r LOAD_1MIN LOAD_5MIN LOAD_15MIN <<<"$(uptime | awk -F'load averages:' '{print $2}' | tr -d ',' | awk '{print $1, $2, $3}')"
 LOAD_1MIN=${LOAD_1MIN:-0}
 LOAD_5MIN=${LOAD_5MIN:-0}
 LOAD_15MIN=${LOAD_15MIN:-0}
@@ -137,7 +137,7 @@ fi
 
 # Process and System Load Analysis
 # Read ps aux once to avoid spawning multiple processes
-read -r PROCESS_COUNT HIGH_CPU_PROCESSES HIGH_MEM_PROCESSES <<< "$(ps aux | awk '
+read -r PROCESS_COUNT HIGH_CPU_PROCESSES HIGH_MEM_PROCESSES <<<"$(ps aux | awk '
   NR>1 {
     count++
     if ($3 > 10.0) cpu++
@@ -157,7 +157,7 @@ log_metric "high_memory_processes" "$HIGH_MEM_PROCESSES" "count"
 
 # Maintenance System Health
 # Read launchctl list once to avoid spawning multiple processes
-read -r MAINTENANCE_AGENTS FAILED_AGENTS <<< "$(launchctl list | awk '
+read -r MAINTENANCE_AGENTS FAILED_AGENTS <<<"$(launchctl list | awk '
   /com\.abhimehrotra\.maintenance/ {
     count++
     if ($3 != "0") failed++
@@ -291,7 +291,7 @@ if [[ $OVERALL_HEALTH == "critical" ]]; then
 			-sound "Basso" \
 			-group "maintenance" 2>/dev/null || true
 	elif command -v osascript >/dev/null 2>&1; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Basso"' -e 'end run' "System health is critical! Check metrics for details." "System Alert" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Basso"' -e 'end run' -- "System health is critical! Check metrics for details." "System Alert" 2>/dev/null || true
 	fi
 fi
 

--- a/maintenance/bin/weekly_maintenance.sh
+++ b/maintenance/bin/weekly_maintenance.sh
@@ -128,7 +128,7 @@ fi
 
 # Notification
 if command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Weekly Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS" "Weekly Maintenance" 2>/dev/null || true
 fi
 
 log_info "Weekly maintenance finished: $STATUS"
@@ -157,7 +157,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
 	fi
 elif command -v osascript >/dev/null 2>&1; then
 	# Fallback to osascript
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$STATUS" "Weekly Maintenance" 2>/dev/null || true
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$STATUS" "Weekly Maintenance" 2>/dev/null || true
 fi
 
 echo "Weekly maintenance completed!"

--- a/maintenance/lib/common.sh
+++ b/maintenance/lib/common.sh
@@ -96,7 +96,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_fixed.sh
+++ b/maintenance/lib/common_fixed.sh
@@ -211,7 +211,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/maintenance/lib/common_simple.sh
+++ b/maintenance/lib/common_simple.sh
@@ -91,7 +91,7 @@ notify() {
 
 	# macOS notification
 	if command -v osascript >/dev/null 2>&1; then
-		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "$message" "$title" 2>/dev/null || true
+		osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "$message" "$title" 2>/dev/null || true
 	fi
 }
 

--- a/scripts/youtube-download.sh
+++ b/scripts/youtube-download.sh
@@ -150,5 +150,5 @@ info "Video saved to ~/Downloads"
 if command -v terminal-notifier >/dev/null 2>&1; then
 	terminal-notifier -title "Download Complete" -message "Video saved to Downloads"
 elif [[ $(uname) == "Darwin" ]] && command -v osascript >/dev/null 2>&1; then
-	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' "Video saved to Downloads" "Download Complete"
+	osascript -e 'on run argv' -e 'display notification (item 1 of argv) with title (item 2 of argv)' -e 'end run' -- "Video saved to Downloads" "Download Complete"
 fi


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Option Injection risk (CWE-74/CWE-88) in bash scripts invoking `osascript`. The `--` argument delimiter was missing before positional arguments. If an attacker-controlled variable starts with a hyphen (like `-e`), `osascript` could interpret it as a command-line flag instead of a positional argument, leading to arbitrary code execution or unintended behavior.
🎯 Impact: Potential execution of arbitrary AppleScript commands if untrusted input begins with a hyphen.
🔧 Fix: Added the `--` delimiter to `osascript` calls across the codebase (e.g. replacing `-e 'end run' "$msg"` with `-e 'end run' -- "$msg"`).
✅ Verification: Run `make test` to ensure all tests pass and functionality is intact.

---
*PR created automatically by Jules for task [2556698986131795776](https://jules.google.com/task/2556698986131795776) started by @abhimehro*