### PR TITLE
🧹 Code Health: Extract core logic from `main` in consolidate_adblock_lists.py

### DIFF
--- a/adguard/scripts/consolidate_adblock_lists.py
+++ b/adguard/scripts/consolidate_adblock_lists.py
@@ -181,6 +181,41 @@ def print_summary(denylist_domains, allowlist_domains, output_dir):
     print("  3. Test your configuration to ensure proper functionality")
 
 
+def run_consolidation(input_dir, output_dir):
+    """Execute the core logic of consolidating tracker and allowlist files."""
+    tracker_files = [
+        "CD-Microsoft-Tracker.json",
+        "CD-No-Safesearch-Support.json",
+        "CD-OPPO_Realme-Tracker.json",
+        "CD-Roku-Tracker.json",
+        "CD-Samsung-Tracker.json",
+        "CD-Tiktok-Tracker---aggressive.json",
+        "CD-Vivo-Tracker.json",
+        "CD-Xiaomi-Tracker.json",
+        "CD-Amazon-Tracker.json",
+        "CD-Apple-Tracker.json",
+        "CD-Badware-Hoster.json",
+        "CD-LG-webOS-Tracker.json",
+        "CD-Huawei-Tracker.json",
+    ]
+
+    print("🔍 Consolidating Ad-Blocking Lists...")
+    print(f"Input Directory: {input_dir}")
+    print(f"Output Directory: {output_dir}")
+    print("=" * 50)
+
+    # Process files
+    denylist_domains = process_tracker_files(input_dir, tracker_files)
+    allowlist_domains = process_allowlist_files(input_dir)
+
+    # Write output files
+    write_json_files(output_dir, denylist_domains, allowlist_domains)
+    write_text_files(output_dir, denylist_domains, allowlist_domains)
+
+    # Print summary
+    print_summary(denylist_domains, allowlist_domains, output_dir)
+
+
 def main():
     """Main consolidation workflow."""
     parser = argparse.ArgumentParser(description="Consolidate AdGuard blocklists.")
@@ -215,37 +250,7 @@ def main():
             print(f"Error: Could not create output directory '{output_dir}': {e}")
             sys.exit(1)
 
-    tracker_files = [
-        "CD-Microsoft-Tracker.json",
-        "CD-No-Safesearch-Support.json",
-        "CD-OPPO_Realme-Tracker.json",
-        "CD-Roku-Tracker.json",
-        "CD-Samsung-Tracker.json",
-        "CD-Tiktok-Tracker---aggressive.json",
-        "CD-Vivo-Tracker.json",
-        "CD-Xiaomi-Tracker.json",
-        "CD-Amazon-Tracker.json",
-        "CD-Apple-Tracker.json",
-        "CD-Badware-Hoster.json",
-        "CD-LG-webOS-Tracker.json",
-        "CD-Huawei-Tracker.json",
-    ]
-
-    print("🔍 Consolidating Ad-Blocking Lists...")
-    print(f"Input Directory: {input_dir}")
-    print(f"Output Directory: {output_dir}")
-    print("=" * 50)
-
-    # Process files
-    denylist_domains = process_tracker_files(input_dir, tracker_files)
-    allowlist_domains = process_allowlist_files(input_dir)
-
-    # Write output files
-    write_json_files(output_dir, denylist_domains, allowlist_domains)
-    write_text_files(output_dir, denylist_domains, allowlist_domains)
-
-    # Print summary
-    print_summary(denylist_domains, allowlist_domains, output_dir)
+    run_consolidation(input_dir, output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Extracted the core file processing and list consolidation logic from the `main` function into a new `run_consolidation` helper function.
💡 **Why:** `main` was a long function responsible for both parsing CLI arguments and executing the entire script's logic. Extracting the core logic improves readability, reduces complexity, and cleanly separates concerns (CLI setup vs. business logic).
✅ **Verification:** Ran `python3 adguard/scripts/consolidate_adblock_lists.py --help` to ensure the script runs, and ran `pytest tests/test_consolidate_adblock_lists.py` to verify that existing behavior remains intact.
✨ **Result:** A more modular script where `main` focuses on setup and argument parsing, delegating the complex work to `run_consolidation`.

---
*PR created automatically by Jules for task [5495161851551672905](https://jules.google.com/task/5495161851551672905) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->