### PR TITLE
🧹 Remove unused json import

### DIFF
--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -4,7 +4,6 @@ import argparse
 import base64
 import html
 import http.server
-import json
 import os
 import secrets
 import socketserver


### PR DESCRIPTION
* 🎯 **What:** Removed unused `json` import in `infuse-media-server.py`.
* 💡 **Why:** The `json` module is imported but never used in the script, which handles basic text/HTML generation without needing json processing. This improves maintainability and cleans up the code.
* ✅ **Verification:** Successfully ran the test suite (`pytest tests/test_infuse_media_server.py`) and all tests passed, verifying no regressions were introduced.
* ✨ **Result:** A cleaner script without unused dependencies.

---
*PR created automatically by Jules for task [4591021654452640195](https://jules.google.com/task/4591021654452640195) started by @abhimehro*