### PR TITLE
🧪 Test format_lists error paths in generate_report

### DIFF
--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -67,6 +67,27 @@ class TestGenerateReport(unittest.TestCase):
         with self.assertRaises(ValueError):
             generate_report.format_lists(merged_data, [], [])
 
+    def test_format_lists_extra_fields(self):
+        # Extra fields in merged_data tuple triggers unpacking ValueError
+        merged_data = [("repo1", "123", "title", "extra")]
+        with self.assertRaises(ValueError):
+            generate_report.format_lists(merged_data, [], [])
+
+    def test_format_lists_invalid_closed_data(self):
+        # Invalid elements in closed_data trigger AttributeError
+        with self.assertRaises(AttributeError):
+            generate_report.format_lists([], [123], [])
+
+    def test_format_lists_invalid_escalated_data(self):
+        # Invalid elements in escalated_data trigger AttributeError
+        with self.assertRaises(AttributeError):
+            generate_report.format_lists([], [], [123])
+
+    def test_format_lists_none_inputs(self):
+        # Passing None instead of iterable triggers TypeError
+        with self.assertRaises(TypeError):
+            generate_report.format_lists(None, [], [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap for the error paths in the `format_lists` function within `generate_report.py` has been fully addressed by adding new test methods.
📊 **Coverage:** The test suite now explicitly covers error scenarios including invalid unpack operations for extra elements in `merged_data`, missing string methods for invalid elements in `closed_data` and `escalated_data` (`AttributeError`), and passing `None` as input to the arrays (`TypeError`).
✨ **Result:** Test coverage for the target function has improved, significantly raising the safety net, which allows for more confident refactoring by effectively catching potential real bugs related to malformed inputs.

---
*PR created automatically by Jules for task [16203860833983460420](https://jules.google.com/task/16203860833983460420) started by @abhimehro*