### PR TITLE
🧹 Remove unused annotations import

### DIFF
--- a/tests/test_copilot_setup_steps_workflow.py
+++ b/tests/test_copilot_setup_steps_workflow.py
@@ -7,7 +7,6 @@ blocks as JavaScript string literals. Binding via step ``env:`` and reading
 Merged fix: PR #980 (commit 4972970). Related: email-security-pipeline#881.
 """
 
-from __future__ import annotations
 
 import re
 import unittest


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `tests/test_copilot_setup_steps_workflow.py`.
💡 **Why:** The file contains straightforward tests without forward references requiring postponed type hinting, so the import is unused and unnecessary.
✅ **Verification:** The python test suite passed successfully after removal.
✨ **Result:** Improved code cleanliness by removing an unnecessary import.

---
*PR created automatically by Jules for task [4953091279039172039](https://jules.google.com/task/4953091279039172039) started by @abhimehro*