### PR TITLE
🧪 Add tests for create_denylist

### DIFF
--- a/tests/test_create_consolidated_lists.py
+++ b/tests/test_create_consolidated_lists.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 # Ensure the module can be found
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from adguard.scripts.create_consolidated_lists import process_allowlist_files
+from adguard.scripts.create_consolidated_lists import (
+    process_allowlist_files,
+    create_denylist,
+)
 
 
 class TestProcessAllowlistFiles(unittest.TestCase):
@@ -148,6 +151,91 @@ class TestProcessAllowlistFiles(unittest.TestCase):
 
         expected_domains = {"duplicate.com", "bypass1.com", "tld1.org"}
         self.assertEqual(result, expected_domains)
+
+
+class TestCreateDenylist(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.base_dir = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def create_json_file(self, filename, data):
+        filepath = self.base_dir / filename
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return filepath
+
+    @patch("builtins.print")
+    def test_happy_path(self, mock_print):
+        # Tracker file 1 (Microsoft)
+        ms_data = {
+            "rules": [
+                {"PK": "block.microsoft.com", "action": {"do": 0}},
+                {"PK": "ignore.microsoft.com", "action": {"do": 1}},
+            ]
+        }
+        # Tracker file 2 (Amazon)
+        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
+        self.create_json_file("CD-Microsoft-Tracker.json", ms_data)
+        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
+
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, {"block.microsoft.com", "block.amazon.com"})
+
+    @patch("builtins.print")
+    def test_missing_files(self, mock_print):
+        # Provide only one file out of the many expected
+        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
+        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
+
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, {"block.amazon.com"})
+
+    @patch("builtins.print")
+    def test_all_files_missing(self, mock_print):
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, set())
+
+    @patch("builtins.print")
+    def test_invalid_json(self, mock_print):
+        # Invalid file
+        filepath = self.base_dir / "CD-Microsoft-Tracker.json"
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write("{ invalid }")
+
+        # Valid file
+        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
+        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
+
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, {"block.amazon.com"})
+
+    @patch("builtins.print")
+    def test_empty_tracker_file(self, mock_print):
+        empty_data = {"rules": []}
+        self.create_json_file("CD-Microsoft-Tracker.json", empty_data)
+
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, set())
+
+    @patch("builtins.print")
+    def test_deduplication(self, mock_print):
+        # Both files contain the same block rule
+        ms_data = {"rules": [{"PK": "shared-tracker.com", "action": {"do": 0}}]}
+        amz_data = {
+            "rules": [
+                {"PK": "shared-tracker.com", "action": {"do": 0}},
+                {"PK": "other-tracker.com", "action": {"do": 0}},
+            ]
+        }
+        self.create_json_file("CD-Microsoft-Tracker.json", ms_data)
+        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
+
+        result = create_denylist(self.base_dir)
+        self.assertEqual(result, {"shared-tracker.com", "other-tracker.com"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `create_denylist` in `adguard/scripts/create_consolidated_lists.py`.
📊 **Coverage:** Covered happy path (extracting block domains), missing subset of files, all missing files, invalid JSON parsing, empty rules arrays, and cross-file domain deduplication.
✨ **Result:** Enhanced code reliability and closed the testing gap for the consolidated denylist generation logic.

---
*PR created automatically by Jules for task [13114185723341448784](https://jules.google.com/task/13114185723341448784) started by @abhimehro*