### PR TITLE
🧹 Remove unused annotations import in select-best-alldebrid-candidate.py

### DIFF
--- a/media-streaming/scripts/select-best-alldebrid-candidate.py
+++ b/media-streaming/scripts/select-best-alldebrid-candidate.py
@@ -11,7 +11,6 @@ State:
   ~/CloudMedia/approval_needed/.alldebrid_candidate_pending.tsv, latest pending selection
 """
 
-from __future__ import annotations
 
 import os
 import re


### PR DESCRIPTION
  * 🎯 What: Removed the unused `from __future__ import annotations` import from `media-streaming/scripts/select-best-alldebrid-candidate.py`.
  * 💡 Why: The script's type hints are natively supported in Python 3.12 without needing the `annotations` future import, making this an easy cleanup to improve maintainability.
  * ✅ Verification: Ran `python3 -m py_compile` to ensure no syntax errors were introduced and ran the full test suite (`make test`) which passed successfully.
  * ✨ Result: Cleaner code with one less unnecessary import.

---
*PR created automatically by Jules for task [7389206867761344270](https://jules.google.com/task/7389206867761344270) started by @abhimehro*