### PR TITLE
🧪 Add tests for _process_pr_group in scratch_triage

### DIFF
--- a/tests/test_scratch_triage.py
+++ b/tests/test_scratch_triage.py
@@ -1,4 +1,4 @@
-"""Unit tests for scratch_triage.run_cmd (salvages #992)."""
+"""Unit tests for scratch_triage (salvages #992)."""
 
 import subprocess
 import sys
@@ -9,6 +9,43 @@ from unittest.mock import patch
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1]))
 
 import scratch_triage  # noqa: E402
+
+
+class TestProcessPrGroup(unittest.TestCase):
+    def test_process_pr_group_multiple_matches(self):
+        matches = [
+            {"number": 100, "title": "fix: A"},
+            {"number": 105, "title": "fix: B"},
+            {"number": 102, "title": "fix: C"},
+        ]
+        groups = []
+        scratch_triage._process_pr_group(matches, "my-repo", "my-rationale", groups)
+
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+        self.assertEqual(group["repo"], "my-repo")
+        self.assertEqual(group["rationale"], "my-rationale")
+        self.assertEqual(group["keep"]["number"], 105)
+        self.assertEqual(group["keep"].get("status_action"), "KEEP")
+
+        self.assertEqual(len(group["dups"]), 2)
+        dup_nums = [d["number"] for d in group["dups"]]
+        self.assertEqual(dup_nums, [102, 100])
+        for d in group["dups"]:
+            self.assertEqual(d.get("status_action"), "CLOSE")
+
+    def test_process_pr_group_single_match(self):
+        matches = [{"number": 100, "title": "fix: A"}]
+        groups = []
+        scratch_triage._process_pr_group(matches, "my-repo", "my-rationale", groups)
+        self.assertEqual(len(groups), 0)
+        self.assertNotIn("status_action", matches[0])
+
+    def test_process_pr_group_no_matches(self):
+        matches = []
+        groups = []
+        scratch_triage._process_pr_group(matches, "my-repo", "my-rationale", groups)
+        self.assertEqual(len(groups), 0)
 
 
 class TestRunCmd(unittest.TestCase):


### PR DESCRIPTION
🎯 What: Added missing unit tests for the `_process_pr_group` function in `scratch_triage.py` inside `tests/test_scratch_triage.py`.
📊 Coverage: Covered the happy path (multiple matching PRs), and edge cases (single matching PR, zero matching PRs).
✨ Result: Improved test coverage and reliability for PR group processing logic, verifying the mutation of PR dictionaries and correct sorting behavior.

---
*PR created automatically by Jules for task [13089264164849948183](https://jules.google.com/task/13089264164849948183) started by @abhimehro*