### PR TITLE
🧪 Add tests for _contains_all_keywords in scratch_triage

### DIFF
--- a/tests/test_scratch_triage.py
+++ b/tests/test_scratch_triage.py
@@ -36,5 +36,32 @@ class TestRunCmd(unittest.TestCase):
         self.assertEqual(err, "not found")
 
 
+class TestContainsAllKeywords(unittest.TestCase):
+    def test_contains_all_present(self):
+        title = "bolt optimization: fix dataframe iteration performance"
+        kws = ("bolt", "iteration", "performance")
+        self.assertTrue(scratch_triage._contains_all_keywords(title, kws))
+
+    def test_missing_one_keyword(self):
+        title = "bolt optimization: fix dataframe performance"
+        kws = ("bolt", "iteration", "performance")
+        self.assertFalse(scratch_triage._contains_all_keywords(title, kws))
+
+    def test_empty_keywords_list(self):
+        title = "bolt optimization: fix dataframe iteration performance"
+        kws = ()
+        self.assertTrue(scratch_triage._contains_all_keywords(title, kws))
+
+    def test_empty_title(self):
+        title = ""
+        kws = ("bolt", "iteration")
+        self.assertFalse(scratch_triage._contains_all_keywords(title, kws))
+
+    def test_partial_match(self):
+        title = "bolt optimization: iterate data"
+        kws = ("iteration",)
+        self.assertFalse(scratch_triage._contains_all_keywords(title, kws))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Add unit tests for `_contains_all_keywords` function in `scratch_triage.py` to prevent potential string matching regressions.
📊 **Coverage:** Added coverage for happy path (all keywords present), missing keywords, empty keywords tuple/list, empty title, and partial word matches.
✨ **Result:** Increased test reliability and prevents regressions in PR title filtering logic.

---
*PR created automatically by Jules for task [3953080861313348064](https://jules.google.com/task/3953080861313348064) started by @abhimehro*