### PR TITLE
🧪 Add tests for main function in fix-allowlist-format.py

### DIFF
--- a/adguard/scripts/import_fix_allowlist_format.py
+++ b/adguard/scripts/import_fix_allowlist_format.py
@@ -16,3 +16,4 @@ spec.loader.exec_module(fix_allowlist_format)
 extract_allowlist_domains_from_file = (
     fix_allowlist_format.extract_allowlist_domains_from_file
 )
+main = fix_allowlist_format.main

--- a/tests/test_fix_allowlist_format.py
+++ b/tests/test_fix_allowlist_format.py
@@ -14,6 +14,7 @@ sys.path.append(str(project_root))
 
 from adguard.scripts.import_fix_allowlist_format import (
     extract_allowlist_domains_from_file,
+    main,
 )
 
 
@@ -141,6 +142,47 @@ class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
             self.assertEqual(result, ["temp.com"])
         finally:
             os.remove(temp_path)
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+        self.env_patcher = patch.dict(os.environ, {"ADGUARD_LISTS_DIR": str(self.temp_path)})
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        self.temp_dir.cleanup()
+
+    def test_main_both_files_exist(self):
+        bypass_data = {"rules": [{"PK": "bypass.com", "action": {"do": 1}}]}
+        tld_data = {"rules": [{"PK": "tld.com", "action": {"do": 1}}]}
+
+        with open(self.temp_path / "CD-Control-D-Bypass.json", "w") as f:
+            json.dump(bypass_data, f)
+
+        with open(self.temp_path / "CD-Most-Abused-TLDs.json", "w") as f:
+            json.dump(tld_data, f)
+
+        with patch('builtins.print'):
+            main()
+
+        out_file = self.temp_path / "Consolidated-Allowlist-Fixed.txt"
+        self.assertTrue(out_file.exists())
+        content = out_file.read_text()
+        self.assertIn("bypass.com", content)
+        self.assertIn("tld.com", content)
+
+    def test_main_no_files_exist(self):
+        with patch('builtins.print'):
+            main()
+
+        out_file = self.temp_path / "Consolidated-Allowlist-Fixed.txt"
+        self.assertTrue(out_file.exists())
+        content = out_file.read_text()
+        self.assertNotIn("bypass.com", content)
+        self.assertIn("# Total domains: 0", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Added tests for the `main` function in `fix-allowlist-format.py` to address the untested main testing gap.
📊 **Coverage:** The test suite now covers scenarios where the input JSON files exist and are parsed correctly, as well as when no input files are present, verifying that the output file is generated appropriately in both cases.
✨ **Result:** Increased test coverage by ensuring the main execution logic is tested, preventing regressions when modifying file paths or the main flow.

---
*PR created automatically by Jules for task [3150227970833670554](https://jules.google.com/task/3150227970833670554) started by @abhimehro*