### PR TITLE
🧹 Remove unused annotations import

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -538,3 +538,7 @@ invocation.
 
 **Learning:** Evaluating loop-invariant string operations like `replace("/", "-")` inside a loop iterations causes unnecessary allocations. Similarly, calling `startswith()` sequentially inside a tight loop causes unecessary python overhead.
 **Action:** Hoist the string operations out of the loop and use a single tuple in `.startswith(("string1", "string2"))` to ensure operations evaluate at the C-level.
+
+## 2023-10-25 - Code Health Check
+**Action:** Removed unused `from __future__ import annotations` from `tests/test_morning_brief.py`.
+**Insight:** Code clarity and readability can be improved by pruning unused imports.

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -7,7 +7,6 @@ Run with:
     # or: python3 -m pytest test_morning_brief.py -v  (optional dev dependency)
 """
 
-from __future__ import annotations
 
 import datetime as dt
 import importlib.util


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `tests/test_morning_brief.py`.
💡 **Why:** This file does not need postponed evaluation of annotations. Removing this unused import cleans up the header and improves readability.
✅ **Verification:** Verified by running the test suite (`python3 -m unittest tests.test_morning_brief -v`) which passed successfully.
✨ **Result:** A cleaner file header with no unused imports.

---
*PR created automatically by Jules for task [340908542977768854](https://jules.google.com/task/340908542977768854) started by @abhimehro*