### PR TITLE
🧹 [Code Health] Remove unused __future__ import in get_prs_summarize.py

### DIFF
--- a/scripts/get_prs_summarize.py
+++ b/scripts/get_prs_summarize.py
@@ -5,7 +5,6 @@ Invoked as: python3 get_prs_summarize.py <true|false> <path-to-json>
 The second argument is include_details ("true" / "false").
 """
 
-from __future__ import annotations
 
 import concurrent.futures
 import json


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` in `scripts/get_prs_summarize.py`.
💡 **Why:** Clears up namespace and improves hygiene.
✅ **Verification:** Verified via `make test` successfully completing without errors in `get_prs_summarize.py`.
✨ **Result:** Improved codebase cleanliness and maintainability without changing behavior.

---
*PR created automatically by Jules for task [1738676511333423610](https://jules.google.com/task/1738676511333423610) started by @abhimehro*