### PR TITLE
🧪 Add missing edge case tests for format_time_label

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -821,3 +821,5 @@ optimization.
 ## Lesson 0cr: Salvage one-line fixes from DIRTY Jules PRs; omit CodeScene refactors (2026-06-19)
 
 **Pattern:** pc #1281 bundled a one-line podcast error-path `html_section()` a11y fix with CodeScene-driven `_parse_linear_focus_node` inlining that conflicted with `main`. **Rule:** When a DIRTY bot PR's stated intent is a small functional fix but the diff includes unrelated complexity refactors, salvage only the functional lines onto a fresh `main` branch. **Detection cost:** Low — `gh pr diff --stat` shows large churn in unrelated functions alongside a one-line stated fix in the PR title.
+## Add testing for missing edge cases
+When testing parsing/formatting logic, always consider unexpected data types, out of bound values and common malformed shapes.

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -216,6 +216,15 @@ class TestFormatTimeLabel(unittest.TestCase):
     def test_empty(self):
         assert mb.format_time_label("") == "Anytime"
 
+    def test_none(self):
+        assert mb.format_time_label(None) == "Anytime"
+
+    def test_whitespace(self):
+        assert mb.format_time_label("   ") == "All day"
+
+    def test_short_string_with_t(self):
+        assert mb.format_time_label("T") == ""
+
 
 # ============================================================
 # Horoscope Extraction


### PR DESCRIPTION
🎯 **What:** The `format_time_label` function was not tested for edge cases like `None`, very short strings, or strings containing only whitespace.
📊 **Coverage:** Added test cases for `None` inputs, short strings containing "T", and whitespace-only strings to `TestFormatTimeLabel`.
✨ **Result:** Improved test reliability by ensuring the function correctly handles unexpected or malformed inputs without crashing, bringing the function closer to full coverage.

---
*PR created automatically by Jules for task [2569365728168772167](https://jules.google.com/task/2569365728168772167) started by @abhimehro*