### PR TITLE
🧹 Remove unused __future__ annotations import

### DIFF
--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -9,8 +9,6 @@ Precedence for ``GH_TOKEN``:
 2. Optional file from ``GH_TOKEN_ENV_FILE`` or well-known paths (legacy fallback)
 """
 
-from __future__ import annotations
-
 import os
 from functools import lru_cache
 from pathlib import Path


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `gh_token_env.py`.
💡 **Why:** This file does not have any forward references or cyclic type hints that require the `annotations` import. Removing it is a simple code health improvement that cleans up unused imports.
✅ **Verification:** Verified by checking the file, seeing no forward references that would require it, successfully running `make test-python`, and `make test-all`.
✨ **Result:** A slightly cleaner file with one fewer unused import, improving code health without changing behavior.

---
*PR created automatically by Jules for task [12775624909065785240](https://jules.google.com/task/12775624909065785240) started by @abhimehro*