### PR TITLE
🧪 [testing improvement] Cover generate_report.py main routine

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -72,8 +72,8 @@ def generate_report_content(results, closed_data, escalated_data):
     )
 
 
-if __name__ == "__main__":
-    with open("tasks/pr-merge-results.json") as f:
+def main(input_path="tasks/pr-merge-results.json", output_path="tasks/pr-review-2026-03-10.md"):
+    with open(input_path) as f:
         results = json.load(f)
 
     # Adjust for draft PRs fixed manually
@@ -110,5 +110,9 @@ if __name__ == "__main__":
     results = process_draft_fixes(results, draft_fixes)
     report = generate_report_content(results, closed, escalated)
 
-    with open("tasks/pr-review-2026-03-10.md", "w") as f:
+    with open(output_path, "w") as f:
         f.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from unittest.mock import patch, mock_open
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import generate_report
@@ -66,6 +67,18 @@ class TestGenerateReport(unittest.TestCase):
         merged_data = [("repo1", "123")]
         with self.assertRaises(ValueError):
             generate_report.format_lists(merged_data, [], [])
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{"merged": [], "escalated": []}')
+    def test_main(self, mock_file):
+        generate_report.main("dummy_input.json", "dummy_output.md")
+
+        # Verify open was called correctly
+        mock_file.assert_any_call("dummy_input.json")
+        mock_file.assert_any_call("dummy_output.md", "w")
+
+        # Verify writing occurred
+        handle = mock_file()
+        self.assertTrue(handle.write.called)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The main routine in `generate_report.py` was untested because it lacked parameterization for input and output paths, relying entirely on side effects. Extracted the logic into a `main` function with default parameters.
📊 **Coverage:** The new `test_main` unit test covers the previously untestable report generation flow using mocked file I/O operations (`unittest.mock`).
✨ **Result:** Improved test coverage for `generate_report.py`, ensuring future modifications to the main execution block do not accidentally break file handling or reporting logic.

---
*PR created automatically by Jules for task [3641612539272691231](https://jules.google.com/task/3641612539272691231) started by @abhimehro*