### PR TITLE
🧹 [Refactor] Split long test_generate_directory_listing into smaller tests

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -1,1 +1,0 @@
-# Attempt to find what submit tool expects if it's available locally, or I can just see the error.

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -120,10 +120,10 @@ class TestMediaServerHandler(unittest.TestCase):
             "WWW-Authenticate", 'Basic realm="Infuse Media Server"'
         )
 
-    def test_generate_directory_listing(self):
+    def test_generate_directory_listing_root(self):
         """
         Test that generate_directory_listing produces correct HTML output,
-        handles proper paths, and escapes file and directory names.
+        handles proper paths, and escapes file and directory names for the root path.
         """
         # Include files and directories with characters needing escaping like < > &
         files = [
@@ -134,7 +134,6 @@ class TestMediaServerHandler(unittest.TestCase):
             "<script>alert(1)</script>.avi",
         ]
 
-        # Test 1: Root path
         html_root = self.handler.generate_directory_listing(files, "/")
 
         self.assertIn("<title>Media Library - /</title>", html_root)
@@ -162,8 +161,19 @@ class TestMediaServerHandler(unittest.TestCase):
             html_root,
         )
 
-        # Test 2: Subdirectory with escaping - matching a realistic path shape
-        # The server script typically hosts from a specific media directory, so we'll use a realistic relative path
+    def test_generate_directory_listing_subdirectory(self):
+        """
+        Test that generate_directory_listing produces correct HTML output,
+        handles proper paths, and escapes file and directory names for subdirectories.
+        """
+        files = [
+            "video.mp4",
+            "movie.MKV",
+            "folder with <tag>/",
+            "document & file.txt",
+            "<script>alert(1)</script>.avi",
+        ]
+
         current_path = "/Movies & TV/Action <Sci-Fi>"
         html_sub = self.handler.generate_directory_listing(files, current_path)
 


### PR DESCRIPTION
🎯 **What:** Split `test_generate_directory_listing` into `test_generate_directory_listing_root` and `test_generate_directory_listing_subdirectory`.
💡 **Why:** Smaller scenario tests improve code readability and maintainability.
✅ **Verification:** Verified by running `python -m unittest tests/test_infuse_media_server.py` to ensure all tests pass.
✨ **Result:** Improved test code health.

---
*PR created automatically by Jules for task [11727001764486740366](https://jules.google.com/task/11727001764486740366) started by @abhimehro*