### PR TITLE
🧪 Improve test coverage for _read_env_file

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,3 +3,6 @@
       unpacking scenario.
 - [x] Inject the new test correctly into `tests/test_generate_report.py`.
 - [x] Run `make test-all` and ensure no regressions.
+- [x] Analyze `gh_token_env.py` for missing OSError test in `_read_env_file`.
+- [x] Write `test_read_env_file_oserror` to cover `FileNotFoundError` and `PermissionError` paths.
+- [x] Run full tests to ensure no regressions.

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from gh_token_env import (
+    _read_env_file,
     clear_gh_token_cache,
     gh_token_configured,
     load_gh_token_env,
@@ -29,6 +30,13 @@ class TestGhTokenEnv(unittest.TestCase):
         self.assertEqual(env, {"FOO": "bar"})
         parse_env_line("export BAZ='qux'", env)
         self.assertEqual(env["BAZ"], "qux")
+
+    def test_read_env_file_oserror(self):
+        self.assertEqual(_read_env_file(Path("/does/not/exist/ever.env")), {})
+
+        with patch.object(Path, "open", side_effect=PermissionError("Permission denied")):
+            self.assertEqual(_read_env_file(Path("some_file.env")), {})
+
 
     def test_env_var_takes_precedence_over_file(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed (missing coverage for `_read_env_file` OSError exceptions).
📊 **Coverage:** FileNotFoundError and PermissionError paths in `_read_env_file`.
✨ **Result:** Improved test reliability and coverage for `gh_token_env.py`.

========== ELIR ==========
PURPOSE: Add test coverage for OSError (like FileNotFoundError and PermissionError) in `_read_env_file` within `gh_token_env.py` to ensure it safely returns an empty dict when a .env file is missing or unreadable.
SECURITY: Ensures local credential automation fails open safely without throwing unhandled exceptions if the environment files cannot be read.
FAILS IF: The mocked `Path.open` doesn't mimic real filesystem access control errors.
VERIFY: Confirm the `test_read_env_file_oserror` passes successfully locally.
MAINTAIN: Update these tests if the error handling approach in `_read_env_file` is changed.

---
*PR created automatically by Jules for task [5126802900786313046](https://jules.google.com/task/5126802900786313046) started by @abhimehro*