### PR TITLE
🧹 [Remove unused __future__ import in PR review config]

### DIFF
--- a/scripts/_load_pr_review_agent_config.py
+++ b/scripts/_load_pr_review_agent_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Emit repos and bot_authors from tasks/pr-review-agent.config.yaml for get_prs.sh.
+r"""Emit repos and bot_authors from tasks/pr-review-agent.config.yaml for get_prs.sh.
 
 Uses PyYAML when installed (same as repository automation). Exits 2 if PyYAML is
 missing so the caller can fall back to bash line parsing.
@@ -8,8 +8,6 @@ Output format (machine lines for bash):
   repo\towner/name
   bot\tdependabot[bot]
 """
-
-from __future__ import annotations
 
 import sys
 from pathlib import Path


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `scripts/_load_pr_review_agent_config.py`.
💡 **Why:** This improves maintainability as the type hints used in the file are standard and don't need postponed evaluation, reducing unnecessary imports.
✅ **Verification:** Ran `trunk check` to ensure no linting issues and manually executed the script to verify correct output generation.
✨ **Result:** A cleaner script with no unused imports.

---
*PR created automatically by Jules for task [7708156960072592450](https://jules.google.com/task/7708156960072592450) started by @abhimehro*