### PR TITLE
🧹 Remove redundant annotations import

### DIFF
--- a/tests/test_copilot_setup_workflow.py
+++ b/tests/test_copilot_setup_workflow.py
@@ -7,8 +7,6 @@ process.env in github-script, not interpolated into the script body.
 Related: ABHI-929, ABHI-963, ABHI-955, ABHI-956 (malicious payload cases).
 """
 
-from __future__ import annotations
-
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `tests/test_copilot_setup_workflow.py`.
💡 **Why:** This import is not used within the file and removing it aligns the file with other test files in the codebase, improving cleanliness and readability.
✅ **Verification:** Ran `make lint-fix`, `make lint-errors`, and `make test-all` to ensure no functionality is broken.
✨ **Result:** A cleaner test file with no unused imports.

---
*PR created automatically by Jules for task [11017704414762950244](https://jules.google.com/task/11017704414762950244) started by @abhimehro*