### PR TITLE
⚡ Bolt: Refactor permission fixing logic and ensure script fails on chmod error

### DIFF
--- a/scripts/verify_all_configs.sh
+++ b/scripts/verify_all_configs.sh
@@ -97,8 +97,12 @@ verify_file_link() {
 			warn "$name target file permissions are $actual_perms (expected $expected_perms)"
 			# Try to fix permissions
 			log "Attempting to fix permissions on target file..."
-			# shellcheck disable=SC2015
-			chmod "$expected_perms" "$expected_target" 2>/dev/null && success "Fixed permissions" || warn "Could not fix permissions (may need manual intervention)"
+			if chmod "$expected_perms" "$expected_target" 2>/dev/null; then
+				success "Fixed permissions"
+			else
+				warn "Could not fix permissions (may need manual intervention)"
+				fail=1
+			fi
 		else
 			success "$name permissions are correct ($expected_perms)"
 		fi

--- a/submit.py
+++ b/submit.py
@@ -1,1 +1,0 @@
-# Attempt to find what submit tool expects if it's available locally, or I can just see the error.


### PR DESCRIPTION
💡 What: Refactored the `chmod` command in `scripts/verify_all_configs.sh` from a one-liner `A && B || C` to a proper `if-else` block, removing the need for a ShellCheck disable directive, and ensuring `fail=1` is set if fixing permissions fails.
🎯 Why: To fix technical debt (resolving SC2015 warnings correctly) and ensure the script correctly reports a failure if it is unable to automatically fix file permissions.
📊 Impact: Improves script reliability and correct failure reporting.
🔬 Measurement: Verified by running `./scripts/verify_all_configs.sh` locally.

========== ELIR ==========
PURPOSE: Refactor `chmod` logic to an if-else block and set `fail=1` on failure in `verify_all_configs.sh`.
SECURITY: Eliminates ambiguous error handling (`&& ... ||`).
FAILS IF: `chmod` fails, which will correctly trigger script failure.
VERIFY: Ensure script correctly sets `fail=1` when unable to fix permissions.
MAINTAIN: N/A

---
*PR created automatically by Jules for task [8988077506616065589](https://jules.google.com/task/8988077506616065589) started by @abhimehro*