### PR TITLE
🎨 Palette: Ensure CLI gracefully clears artifacts on interruption

### DIFF
--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -99,6 +99,9 @@ async function main() {
   // Handle graceful exit
   process.on("SIGINT", () => {
     stopSpinner();
+    if (process.stdout.isTTY) {
+      process.stdout.write("\r\x1B[K\x1B[?25h");
+    }
     console.log("\n👋 Cancelled by user. Goodbye!");
     process.exit(130);
   });


### PR DESCRIPTION
💡 What: Added `\r\x1B[K\x1B[?25h` inside an `isTTY` check in the `SIGINT` handler.
🎯 Why: Prevents orphaned text artifacts (like "Assistant:") from cluttering the prompt if the user cancels during streaming, and ensures the cursor is restored.
📸 Before/After: N/A (CLI change)
♿ Accessibility: Ensures non-TTY logs aren't spammed while providing a clean, accessible UI for interactive sessions.

---
*PR created automatically by Jules for task [2136743603594569371](https://jules.google.com/task/2136743603594569371) started by @abhimehro*