### PR TITLE
⚡ Bolt: Optimize service_monitor ps aux polling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -542,3 +542,7 @@ invocation.
 ## 2023-10-25 - Code Health Check
 **Action:** Removed unused `from __future__ import annotations` from `tests/test_morning_brief.py`.
 **Insight:** Code clarity and readability can be improved by pruning unused imports.
+
+## 2026-07-01 - [Avoid N+1 process spawning with ps aux pipelines]
+**Learning:** In shell scripts, executing multiple sequential `ps aux | grep ...` commands to check the status of different background processes is highly inefficient because it spawns new subprocesses for every check.
+**Action:** Consolidate multiple process checks into a single `ps aux` pipeline parsed by a unified `awk` script (e.g., `awk '/proc1/ {p1++} /proc2/ {p2++} END {print p1+0, p2+0}'`) and capture the output simultaneously using `read -r`. This drastically reduces system call overhead.

--- a/maintenance/bin/service_monitor.sh
+++ b/maintenance/bin/service_monitor.sh
@@ -237,14 +237,14 @@ append ""
 # Check for key background services that shouldn't be running persistently
 append "Background Services Check:"
 append "--------------------------"
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-CHRONOD_RUNNING=$(ps aux | grep -E "chronod" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-DUET_RUNNING=$(ps aux | grep -E "duetexpertd" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-SUGGESTD_RUNNING=$(ps aux | grep -E "suggestd" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-PROACTIVED_RUNNING=$(ps aux | grep -E "proactived" | grep -v grep | wc -l | tr -d ' ')
+# ⚡ Bolt Optimization: Avoid repeated execution of ps aux by parsing multiple metrics in a single pass
+read -r CHRONOD_RUNNING DUET_RUNNING SUGGESTD_RUNNING PROACTIVED_RUNNING <<< "$(ps aux | awk '
+  /[c]hronod/ {c++}
+  /[d]uetexpertd/ {d++}
+  /[s]uggestd/ {s++}
+  /[p]roactived/ {p++}
+  END {print c+0, d+0, s+0, p+0}
+')"
 
 append "chronod instances: $CHRONOD_RUNNING"
 append "duetexpertd instances: $DUET_RUNNING"


### PR DESCRIPTION
💡 What: Consolidated four separate `ps aux` subprocess calls in `service_monitor.sh` into a single `ps aux` call parsed with `awk`.
🎯 Why: `ps aux` is relatively slow, and repeatedly spawning it creates significant performance overhead inside shell scripts, particularly those run periodically as daemons or cron jobs.
📊 Impact: Reduces system call overhead and speeds up execution time of `service_monitor.sh` by avoiding N+1 spawning of `ps aux`, `grep`, `wc`, and `tr` commands.
🔬 Measurement: Use `time ./maintenance/bin/service_monitor.sh` before and after to observe total execution time reduction.

---
*PR created automatically by Jules for task [664666424453919652](https://jules.google.com/task/664666424453919652) started by @abhimehro*