### PR TITLE
perf(maintenance): consolidate ps aux polling (salvages #1446)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -545,3 +545,8 @@ invocation.
 ## 2025-07-01 - Optimizing directory traversal with find -prune
 **Learning:** When using `find` to search for specific directory names like `node_modules` (which contain heavily nested structures), omitting `-prune` causes `find` to unnecessarily traverse the entire deep directory tree inside matches, leading to significant I/O and CPU overhead.
 **Action:** Always use `-prune` when searching for directories whose contents you don't need to traverse, such as `node_modules` or build directories.
+
+## 2026-07-01 - [Avoid N+1 process spawning with ps aux pipelines]
+**Learning:** In shell scripts, executing multiple sequential `ps aux | grep ...` commands to check the status of different background processes is highly inefficient because it spawns new subprocesses for every check.
+**Action:** Consolidate multiple process checks into a single `ps aux` pipeline parsed by a unified `awk` script (e.g., `awk '/proc1/ {p1++} /proc2/ {p2++} END {print p1+0, p2+0}'`) and capture the output simultaneously using `read -r`. This drastically reduces system call overhead.
+

--- a/maintenance/bin/service_monitor.sh
+++ b/maintenance/bin/service_monitor.sh
@@ -237,14 +237,14 @@ append ""
 # Check for key background services that shouldn't be running persistently
 append "Background Services Check:"
 append "--------------------------"
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-CHRONOD_RUNNING=$(ps aux | grep -E "chronod" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-DUET_RUNNING=$(ps aux | grep -E "duetexpertd" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-SUGGESTD_RUNNING=$(ps aux | grep -E "suggestd" | grep -v grep | wc -l | tr -d ' ')
-# shellcheck disable=SC2126  # explicit grep | wc -l preferred for clarity
-PROACTIVED_RUNNING=$(ps aux | grep -E "proactived" | grep -v grep | wc -l | tr -d ' ')
+# ⚡ Bolt Optimization: Avoid repeated execution of ps aux by parsing multiple metrics in a single pass
+read -r CHRONOD_RUNNING DUET_RUNNING SUGGESTD_RUNNING PROACTIVED_RUNNING <<< "$(ps aux | awk '
+  /[c]hronod/ {c++}
+  /[d]uetexpertd/ {d++}
+  /[s]uggestd/ {s++}
+  /[p]roactived/ {p++}
+  END {print c+0, d+0, s+0, p+0}
+')"
 
 append "chronod instances: $CHRONOD_RUNNING"
 append "duetexpertd instances: $DUET_RUNNING"


### PR DESCRIPTION
## Salvage of #1446

Re-applied Bolt optimization onto current `main` after merge-burst cascade left the original DIRTY.

### Changes
- `maintenance/bin/service_monitor.sh`: single `ps aux | awk` pass for background service counts
- `.jules/bolt.md`: appended learning entry (append-only)

═══ ELIR ═══
PURPOSE: Reduce N+1 `ps aux` subprocess spawning in service_monitor background checks.
SECURITY: No trust-boundary change; read-only process listing.
FAILS IF: awk parsing misses a process name on macOS ps output format.
VERIFY: `bash -n maintenance/bin/service_monitor.sh`
MAINTAIN: Keep bracket-regex awk patterns to avoid self-match on grep.

**Tier:** T3 — routine salvage. Human review required before merge.