### PR TITLE
test: process_allowlist_files mocks (salvages #1438)

### DIFF
--- a/tests/test_create_consolidated_lists.py
+++ b/tests/test_create_consolidated_lists.py
@@ -1,241 +1,144 @@
-import json
 import os
 import sys
-import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 # Ensure the module can be found
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from adguard.scripts.create_consolidated_lists import (
-    process_allowlist_files,
-    create_denylist,
-)
+from adguard.scripts.create_consolidated_lists import process_allowlist_files
 
 
-class TestProcessAllowlistFiles(unittest.TestCase):
+class TestProcessAllowlistMocked(unittest.TestCase):
 
-    def setUp(self):
-        # Create a temporary directory for sandbox
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.base_dir = Path(self.temp_dir.name)
-
-    def tearDown(self):
-        # Cleanup temporary directory
-        self.temp_dir.cleanup()
-
-    def create_json_file(self, filename, data):
-        filepath = self.base_dir / filename
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(data, f)
-        return filepath
-
+    @patch("adguard.scripts.create_consolidated_lists.extract_domains_from_file")
     @patch("builtins.print")
-    def test_happy_path_both_files_present(self, mock_print):
-        """Test with both bypass and TLD files present and valid."""
-        bypass_data = {
-            "rules": [
-                {"PK": "bypass1.com", "action": {"do": 1}},
-                {"PK": "bypass2.com", "action": {"do": 1}},
-                {"PK": "ignored.com", "action": {"do": 0}},  # Should be ignored
-            ]
-        }
-        tlds_data = {
-            "rules": [
-                {"PK": "tld1.org", "action": {"do": 1}},
-                {"PK": "tld2.net", "action": {"do": 1}},
-            ]
-        }
-        self.create_json_file("CD-Control-D-Bypass.json", bypass_data)
-        self.create_json_file("CD-Most-Abused-TLDs.json", tlds_data)
+    def test_process_allowlist_files_mocked(self, mock_print, mock_extract):
+        # Create a mock base_dir (Path object)
+        mock_base_dir = unittest.mock.MagicMock()
 
-        result = process_allowlist_files(self.base_dir)
+        # Create mock file objects
+        mock_bypass_file = unittest.mock.MagicMock()
+        mock_tlds_file = unittest.mock.MagicMock()
 
+        # Configure base_dir / filename behavior
+        def base_dir_truediv(filename):
+            if filename == "CD-Control-D-Bypass.json":
+                return mock_bypass_file
+            elif filename == "CD-Most-Abused-TLDs.json":
+                return mock_tlds_file
+            return unittest.mock.MagicMock()
+
+        mock_base_dir.__truediv__.side_effect = base_dir_truediv
+
+        # Configure file existence
+        mock_bypass_file.exists.return_value = True
+        mock_tlds_file.exists.return_value = True
+
+        # Configure extract_domains_from_file behavior
+        def extract_side_effect(filepath, action_filter=None):
+            if filepath == mock_bypass_file:
+                return ["bypass1.com", "bypass2.com"]
+            elif filepath == mock_tlds_file:
+                return ["tld1.org", "tld2.net"]
+            return []
+
+        mock_extract.side_effect = extract_side_effect
+
+        # Execute
+        result = process_allowlist_files(mock_base_dir)
+
+        # Verify
         expected_domains = {"bypass1.com", "bypass2.com", "tld1.org", "tld2.net"}
         self.assertEqual(result, expected_domains)
 
+        # Verify extract_domains_from_file was called with correct arguments
+        mock_extract.assert_any_call(mock_bypass_file, action_filter=1)
+        mock_extract.assert_any_call(mock_tlds_file, action_filter=1)
+        self.assertEqual(mock_extract.call_count, 2)
+
+    @patch("adguard.scripts.create_consolidated_lists.extract_domains_from_file")
     @patch("builtins.print")
-    def test_missing_bypass_file(self, mock_print):
-        """Test with missing bypass file but valid TLD file."""
-        tlds_data = {"rules": [{"PK": "tld1.org", "action": {"do": 1}}]}
-        self.create_json_file("CD-Most-Abused-TLDs.json", tlds_data)
+    def test_missing_bypass_file(self, mock_print, mock_extract):
+        mock_base_dir = unittest.mock.MagicMock()
+        mock_bypass_file = unittest.mock.MagicMock()
+        mock_tlds_file = unittest.mock.MagicMock()
 
-        result = process_allowlist_files(self.base_dir)
+        def base_dir_truediv(filename):
+            if filename == "CD-Control-D-Bypass.json":
+                return mock_bypass_file
+            elif filename == "CD-Most-Abused-TLDs.json":
+                return mock_tlds_file
+            return unittest.mock.MagicMock()
 
+        mock_base_dir.__truediv__.side_effect = base_dir_truediv
+
+        mock_bypass_file.exists.return_value = False
+        mock_tlds_file.exists.return_value = True
+
+        def extract_side_effect(filepath, action_filter=None):
+            if filepath == mock_tlds_file:
+                return ["tld1.org"]
+            return []
+
+        mock_extract.side_effect = extract_side_effect
+
+        result = process_allowlist_files(mock_base_dir)
         self.assertEqual(result, {"tld1.org"})
+        mock_extract.assert_called_once_with(mock_tlds_file, action_filter=1)
 
+    @patch("adguard.scripts.create_consolidated_lists.extract_domains_from_file")
     @patch("builtins.print")
-    def test_missing_tlds_file(self, mock_print):
-        """Test with missing TLD file but valid bypass file."""
-        bypass_data = {"rules": [{"PK": "bypass1.com", "action": {"do": 1}}]}
-        self.create_json_file("CD-Control-D-Bypass.json", bypass_data)
+    def test_missing_tlds_file(self, mock_print, mock_extract):
+        mock_base_dir = unittest.mock.MagicMock()
+        mock_bypass_file = unittest.mock.MagicMock()
+        mock_tlds_file = unittest.mock.MagicMock()
 
-        result = process_allowlist_files(self.base_dir)
+        def base_dir_truediv(filename):
+            if filename == "CD-Control-D-Bypass.json":
+                return mock_bypass_file
+            elif filename == "CD-Most-Abused-TLDs.json":
+                return mock_tlds_file
+            return unittest.mock.MagicMock()
 
+        mock_base_dir.__truediv__.side_effect = base_dir_truediv
+
+        mock_bypass_file.exists.return_value = True
+        mock_tlds_file.exists.return_value = False
+
+        def extract_side_effect(filepath, action_filter=None):
+            if filepath == mock_bypass_file:
+                return ["bypass1.com"]
+            return []
+
+        mock_extract.side_effect = extract_side_effect
+
+        result = process_allowlist_files(mock_base_dir)
         self.assertEqual(result, {"bypass1.com"})
+        mock_extract.assert_called_once_with(mock_bypass_file, action_filter=1)
 
+    @patch("adguard.scripts.create_consolidated_lists.extract_domains_from_file")
     @patch("builtins.print")
-    def test_both_files_missing(self, mock_print):
-        """Test when neither file exists."""
-        result = process_allowlist_files(self.base_dir)
+    def test_both_files_missing(self, mock_print, mock_extract):
+        mock_base_dir = unittest.mock.MagicMock()
+        mock_bypass_file = unittest.mock.MagicMock()
+        mock_tlds_file = unittest.mock.MagicMock()
+
+        def base_dir_truediv(filename):
+            if filename == "CD-Control-D-Bypass.json":
+                return mock_bypass_file
+            elif filename == "CD-Most-Abused-TLDs.json":
+                return mock_tlds_file
+            return unittest.mock.MagicMock()
+
+        mock_base_dir.__truediv__.side_effect = base_dir_truediv
+
+        mock_bypass_file.exists.return_value = False
+        mock_tlds_file.exists.return_value = False
+
+        result = process_allowlist_files(mock_base_dir)
         self.assertEqual(result, set())
-
-    @patch("builtins.print")
-    def test_invalid_json_syntax(self, mock_print):
-        """Test handling of malformed JSON."""
-        # Create a malformed bypass file
-        filepath = self.base_dir / "CD-Control-D-Bypass.json"
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write("{ invalid json ")
-
-        # Valid TLDs file
-        tlds_data = {"rules": [{"PK": "tld1.org", "action": {"do": 1}}]}
-        self.create_json_file("CD-Most-Abused-TLDs.json", tlds_data)
-
-        result = process_allowlist_files(self.base_dir)
-
-        # The invalid JSON should be caught and logged (skipped),
-        # but the valid TLDs file should still be processed.
-        self.assertEqual(result, {"tld1.org"})
-
-    @patch("builtins.print")
-    def test_empty_allowlists(self, mock_print):
-        """Test with valid JSON but empty rules arrays."""
-        empty_data = {"rules": []}
-        self.create_json_file("CD-Control-D-Bypass.json", empty_data)
-        self.create_json_file("CD-Most-Abused-TLDs.json", empty_data)
-
-        result = process_allowlist_files(self.base_dir)
-        self.assertEqual(result, set())
-
-    @patch("builtins.print")
-    def test_unexpected_data_structures(self, mock_print):
-        """Test with unexpected data structures."""
-        # Missing 'rules' key
-        bypass_data = {"other_key": "value"}
-        # 'rules' is not a list
-        tlds_data = {"rules": {"not_a_list": "value"}}
-
-        self.create_json_file("CD-Control-D-Bypass.json", bypass_data)
-        self.create_json_file("CD-Most-Abused-TLDs.json", tlds_data)
-
-        # Assuming extract_domains_from_file handles these safely
-        # based on `if 'rules' in data` and iterating over `rules`.
-        # Note: if 'rules' is a dict, iterating over it might yield keys,
-        # but then `if 'PK' in rule` would look for 'PK' in the string key,
-        # which will be false. So it should safely return empty.
-        result = process_allowlist_files(self.base_dir)
-        self.assertEqual(result, set())
-
-    @patch("builtins.print")
-    def test_duplicate_entries(self, mock_print):
-        """Test that duplicate domains across files are deduplicated."""
-        bypass_data = {
-            "rules": [
-                {"PK": "duplicate.com", "action": {"do": 1}},
-                {"PK": "bypass1.com", "action": {"do": 1}},
-            ]
-        }
-        tlds_data = {
-            "rules": [
-                {"PK": "duplicate.com", "action": {"do": 1}},
-                {"PK": "tld1.org", "action": {"do": 1}},
-            ]
-        }
-        self.create_json_file("CD-Control-D-Bypass.json", bypass_data)
-        self.create_json_file("CD-Most-Abused-TLDs.json", tlds_data)
-
-        result = process_allowlist_files(self.base_dir)
-
-        expected_domains = {"duplicate.com", "bypass1.com", "tld1.org"}
-        self.assertEqual(result, expected_domains)
-
-
-class TestCreateDenylist(unittest.TestCase):
-
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.base_dir = Path(self.temp_dir.name)
-
-    def tearDown(self):
-        self.temp_dir.cleanup()
-
-    def create_json_file(self, filename, data):
-        filepath = self.base_dir / filename
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(data, f)
-        return filepath
-
-    @patch("builtins.print")
-    def test_happy_path(self, mock_print):
-        # Tracker file 1 (Microsoft)
-        ms_data = {
-            "rules": [
-                {"PK": "block.microsoft.com", "action": {"do": 0}},
-                {"PK": "ignore.microsoft.com", "action": {"do": 1}},
-            ]
-        }
-        # Tracker file 2 (Amazon)
-        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
-        self.create_json_file("CD-Microsoft-Tracker.json", ms_data)
-        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
-
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, {"block.microsoft.com", "block.amazon.com"})
-
-    @patch("builtins.print")
-    def test_missing_files(self, mock_print):
-        # Provide only one file out of the many expected
-        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
-        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
-
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, {"block.amazon.com"})
-
-    @patch("builtins.print")
-    def test_all_files_missing(self, mock_print):
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, set())
-
-    @patch("builtins.print")
-    def test_invalid_json(self, mock_print):
-        # Invalid file
-        filepath = self.base_dir / "CD-Microsoft-Tracker.json"
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write("{ invalid }")
-
-        # Valid file
-        amz_data = {"rules": [{"PK": "block.amazon.com", "action": {"do": 0}}]}
-        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
-
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, {"block.amazon.com"})
-
-    @patch("builtins.print")
-    def test_empty_tracker_file(self, mock_print):
-        empty_data = {"rules": []}
-        self.create_json_file("CD-Microsoft-Tracker.json", empty_data)
-
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, set())
-
-    @patch("builtins.print")
-    def test_deduplication(self, mock_print):
-        # Both files contain the same block rule
-        ms_data = {"rules": [{"PK": "shared-tracker.com", "action": {"do": 0}}]}
-        amz_data = {
-            "rules": [
-                {"PK": "shared-tracker.com", "action": {"do": 0}},
-                {"PK": "other-tracker.com", "action": {"do": 0}},
-            ]
-        }
-        self.create_json_file("CD-Microsoft-Tracker.json", ms_data)
-        self.create_json_file("CD-Amazon-Tracker.json", amz_data)
-
-        result = create_denylist(self.base_dir)
-        self.assertEqual(result, {"shared-tracker.com", "other-tracker.com"})
+        mock_extract.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Salvage of #1438/#1407 onto current main. Mock-based tests for `process_allowlist_files`.

VERIFY: `python3 -m unittest tests.test_create_consolidated_lists`

**Tier:** T3