### PR TITLE
docs: add references to new daily automation skills and update repo list

### DIFF
--- a/docs/automated-pr-review-agent.md
+++ b/docs/automated-pr-review-agent.md
@@ -222,6 +222,32 @@ scheduled workflow may be added after permission parity and a validated
 orchestrator exist. See
 [.github/workflows/README.md](../.github/workflows/README.md).
 
+### Daily Automation Chain
+
+This agent operates within a broader daily automation workflow. The following
+scheduled tasks run automatically each day on all seven priority repositories:
+
+1. **6:00 AM** - [GitHub PR Summarizer](https://github.com/abhimehro/personal-config/tree/main/skills/github-pr-summarizer)
+   - Creates daily PR summary reports in Notion's "GitHub PRs Daily Reports" database
+   - Provides foundational context for all downstream agents
+   - Runs before all other automations to ensure fresh documentation
+
+2. **8:00 AM** - Proactive issue creation task
+
+3. **8:15 AM** - [Repository Health Triage](https://github.com/abhimehro/personal-config/tree/main/skills/repo-health-triage)
+   - Scans for security issues, risky code patterns, dependency problems
+   - Creates issue candidates in Notion's "Repo Issue Candidates" database
+   - Analyzes all seven repositories: personal-config, ctrld-sync, email-security-pipeline, Seatek_Analysis, Hydrograph_Versus_Seatek_Sensors_Project, series_correction_project_updated, repoprompt-ce
+
+4. **9:00 AM** - PR automation test
+
+5. **1:00 PM** - Salvaging task
+
+**Note:** This PR Review Agent (Phase 1) and the Salvage Agent (Phase 2) are
+separate from the scheduled daily automations. The scheduled tasks provide
+input documents and issue candidates that these agents can reference during
+triage and salvage operations.
+
 ## Related docs
 
 - [Automated PR Salvage & Recovery Agent](automated-pr-salvage-agent.md) — Phase
@@ -231,3 +257,7 @@ orchestrator exist. See
   Permissions, preflight, probe PRs, runbook.
 - [PR Review Automation ELIR](pr-review-automation-elir.md) — Handoff summary
   for maintainers.
+- [Repository Health Triage Skill](../../skills/repo-health-triage/SKILL.md) —
+  Daily repo health scanning and issue triage.
+- [GitHub PR Summarizer Skill](../../skills/github-pr-summarizer/SKILL.md) —
+  Daily PR summary generation for non-technical audiences.

--- a/docs/automated-pr-salvage-agent.md
+++ b/docs/automated-pr-salvage-agent.md
@@ -4,15 +4,15 @@
 with
 [Automated PR Review & Consolidation Agent v1.0](automated-pr-review-agent.md).
 **Scope:** Investigate, recover, and rationalize the deferred / escalated tail
-of a PR Review Agent session — i.e. PRs that the Review Agent could **not**
+of a PR Review Agent session â i.e. PRs that the Review Agent could **not**
 safely merge or close because they were `DIRTY`, `UNSTABLE`, blocked by a trust
 boundary, or blocked by an infrastructure failure on `main`.
 
 ## Mission
 
-The Review Agent (Phase 1) is optimized for _throughput_ — merge what's clean,
+The Review Agent (Phase 1) is optimized for _throughput_ â merge what's clean,
 close what's redundant, and surface the rest. The Salvage Agent (Phase 2) is
-optimized for _recovery_ — drive every PR in that surfaced tail to a final state
+optimized for _recovery_ â drive every PR in that surfaced tail to a final state
 by either:
 
 - **Salvaging** the legitimate work onto a fresh branch from `main` and opening
@@ -31,13 +31,13 @@ resolution, test adaptation, file reverts) and must not bypass human judgment.
 
 ## Why a separate skill rather than an addendum
 
-| Concern                        | Phase 1 — Review Agent                                                             | Phase 2 — Salvage Agent                                                                                         |
+| Concern                        | Phase 1 â Review Agent                                                             | Phase 2 â Salvage Agent                                                                                         |
 | ------------------------------ | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | Trigger                        | A scheduled or on-demand run over **all open PRs in scope**                        | An investigation of **a known list of deferred / escalated PRs** (e.g. from this morning's Phase-1 report)      |
 | Throughput vs depth            | Shallow per PR (read description, diff, CI rollup, decide)                         | Deep per PR (clone repo, compare against current `main`, attempt rebase, inspect history, write or adapt tests) |
 | Merge authority                | May squash-merge clean PRs autonomously                                            | **Never** merges autonomously; every output is draft                                                            |
 | Output                         | Merges, closes, escalation comments                                                | New draft PRs (salvage), supersede-closes, infra-fix PRs                                                        |
-| Failure mode if rules conflate | Routine auto-merge becomes risky; deep-dive becomes too slow to run on every cycle | — (separation removes the ambiguity)                                                                            |
+| Failure mode if rules conflate | Routine auto-merge becomes risky; deep-dive becomes too slow to run on every cycle | â (separation removes the ambiguity)                                                                            |
 | Preflight                      | Read-only `gh auth` + repo list check                                              | Same as Phase 1 + ability to clone repos and push new branches                                                  |
 
 The two skills share the same config file (`tasks/pr-review-agent.config.yaml`)
@@ -57,11 +57,11 @@ cycle:
    resolve itself; a `DIRTY` that's been sitting for a day usually won't).
 3. A **whole-repo CI failure on `main`** is suspected (e.g. 4+ open PRs in the
    same repo show the same failing required check, and that check has been
-   failing on `main` since at least one merge ago — see Lesson 0t).
+   failing on `main` since at least one merge ago â see Lesson 0t).
 4. The maintainer flags a specific PR for "is this still salvageable?" review
    (e.g. via a label, a comment mentioning the agent, or a direct request).
 
-**Do not** trigger Phase 2 just because a Phase 1 cycle had merges or closures —
+**Do not** trigger Phase 2 just because a Phase 1 cycle had merges or closures â
 that's normal Phase 1 output and doesn't require deep investigation.
 
 **Do not** trigger Phase 2 on a stale snapshot. Always re-fetch the open PR list
@@ -78,8 +78,8 @@ report was written.
 | Configured repos                            | `tasks/pr-review-agent.config.yaml`                                                                                                       | yes       | Same field as Phase 1.                                                                                                                                                      |
 | Bot authors / automation patterns           | `tasks/pr-review-agent.config.yaml`                                                                                                       | yes       | Same as Phase 1.                                                                                                                                                            |
 | List of PRs to investigate                  | Phase 1 report (`tasks/pr-review-YYYY-MM-DD.md` "Post-session remainder" section) **or** explicit override list passed at invocation time | yes       | If invoked without an explicit list, use the most recent dated session report's deferred/escalated tail.                                                                    |
-| Live PR state                               | GitHub API at run time                                                                                                                    | yes       | Re-fetch — never trust the snapshot in the Phase 1 report alone.                                                                                                            |
-| Repo working clones                         | Cloned at run time into a scratch directory (e.g. `/tmp/salvage/<repo>`)                                                                  | yes       | Need read **and** write access — Salvage opens new branches and pushes them.                                                                                                |
+| Live PR state                               | GitHub API at run time                                                                                                                    | yes       | Re-fetch â never trust the snapshot in the Phase 1 report alone.                                                                                                            |
+| Repo working clones                         | Cloned at run time into a scratch directory (e.g. `/tmp/salvage/<repo>`)                                                                  | yes       | Need read **and** write access â Salvage opens new branches and pushes them.                                                                                                |
 | `GH_TOKEN` with push + PR-create permission | Env var                                                                                                                                   | yes       | If `git push` would otherwise pick a read-only bot credential, override the remote URL with `https://x-access-token:${GH_TOKEN}@github.com/<owner>/<repo>.git` (Lesson 0j). |
 
 ## Outputs
@@ -89,8 +89,8 @@ report was written.
 | Salvage PRs (one per recoverable original)                 | New branches `cursor-agent/salvage-<repo>-<old_pr>-<short_label>-<suffix>` on each affected repo, opened as **draft** | `gh pr create --draft`                                                                                                    |
 | Infra-fix PRs (one per repo whose `main` needs unblocking) | Same naming pattern: `cursor-agent/fix-<short_label>-<suffix>`                                                        | `gh pr create --draft`                                                                                                    |
 | Closure comments on superseded / blocked-by originals      | Inline PR comments with cross-link to either the salvage PR or the existing-on-main commit                            | `gh pr close --comment "..."` or `gh pr comment`                                                                          |
-| Salvage session report                                     | Append to `tasks/salvage-session-reports.md` under a `## Run — YYYY-MM-DD` heading                                    | Markdown table with `Repo`, `Old PR`, `Disposition`, `New PR`, `Notes` columns + a counts summary + new patterns observed |
-| New lessons                                                | Append to `tasks/lessons.md`                                                                                          | One numbered lesson per new pattern (Pattern → Rule → Detection cost)                                                     |
+| Salvage session report                                     | Append to `tasks/salvage-session-reports.md` under a `## Run â YYYY-MM-DD` heading                                    | Markdown table with `Repo`, `Old PR`, `Disposition`, `New PR`, `Notes` columns + a counts summary + new patterns observed |
+| New lessons                                                | Append to `tasks/lessons.md`                                                                                          | One numbered lesson per new pattern (Pattern â Rule â Detection cost)                                                     |
 
 ### Conflict-proofing write boundaries
 
@@ -112,7 +112,7 @@ After a Phase 2 run finishes, the human maintainer is expected to:
    blocked-by PR and let CI re-run; then re-trigger Phase 1 on that repo to
    merge what's now clean.
 4. If a salvage PR's verification step fails, leave a review comment on the
-   salvage PR (not the original — the original is already closed).
+   salvage PR (not the original â the original is already closed).
 
 The agent is expected to never:
 
@@ -125,30 +125,30 @@ The agent is expected to never:
 
 ## Phase 2 workflow
 
-### Step 0 — Preflight (mandatory)
+### Step 0 â Preflight (mandatory)
 
 Same preflight as Phase 1: `gh auth status` confirms the active token, the
 configured repo list resolves, and the canonical `make cursor-cloud-hooks` is
 run on the personal-config repo so commit-message secret scanning works (Lesson
-0r). If any preflight check fails, abort — do not silently fall back.
+0r). If any preflight check fails, abort â do not silently fall back.
 
 <!-- pragma: allowlist secret -->
 
-### Step 1 — Re-fetch the deferred / escalated tail
+### Step 1 â Re-fetch the deferred / escalated tail
 
 Read the most recent `tasks/pr-review-YYYY-MM-DD.md` (or the override list
 passed at invocation). For each PR in the deferred / escalated section, hit the
 GitHub API:
 
-- If the PR is now `MERGED` → drop it from the queue (a human or another agent
+- If the PR is now `MERGED` â drop it from the queue (a human or another agent
   already merged it).
-- If the PR is now `CLOSED` (and not by this agent) → drop it from the queue.
-- If the PR is `OPEN` and `MERGEABLE/CLEAN` → drop it from the queue and add a
+- If the PR is now `CLOSED` (and not by this agent) â drop it from the queue.
+- If the PR is `OPEN` and `MERGEABLE/CLEAN` â drop it from the queue and add a
   note to the addendum saying "auto-resolved since Phase 1; consider re-running
   Phase 1 to merge."
-- Otherwise → keep it for investigation.
+- Otherwise â keep it for investigation.
 
-### Step 2 — Per-repo grouping and infra detection
+### Step 2 â Per-repo grouping and infra detection
 
 Group the surviving queue by repo. For each repo, count how many open PRs share
 the same failing required check. If 4+ PRs share the same failure **and** the
@@ -159,7 +159,7 @@ latest run of that check on `main` is also failing, classify the repo as
 2. Run Step 3 (root-cause infra investigation) before Step 4 (per-PR salvage).
 3. Mark the addendum entry for that repo as "Top escalation."
 
-### Step 3 — Root-cause infrastructure investigation (only if Step 2 flagged a repo)
+### Step 3 â Root-cause infrastructure investigation (only if Step 2 flagged a repo)
 
 Goal: locate the single change on `main` that broke the required check, and
 propose the smallest possible revert.
@@ -177,12 +177,12 @@ propose the smallest possible revert.
    - If the offending commit's intended change can be re-authored in a small
      clean PR, prefer **revert + clean re-roll** over trying to fix the blob in
      place. The decoded-but-still-wrong file in Phase 2's ESP investigation lost
-     ~547 lines of validated logic — re-authoring is safer.
+     ~547 lines of validated logic â re-authoring is safer.
    - If the offending commit has been built on top of by other commits, use
      `git show <bad_commit> -- <file>` to identify which earlier commit's
      version of the file should be restored, and revert just that one file.
 5. Open a draft PR with title
-   `fix(<area>): <one-line description> (revert PR #<N>) — unblocks <check> on main`.
+   `fix(<area>): <one-line description> (revert PR #<N>) â unblocks <check> on main`.
    The body must include:
    - The full chain of impact (which PRs are blocked behind this).
    - The verification command (e.g. `python -m py_compile <file>` and
@@ -195,7 +195,7 @@ propose the smallest possible revert.
    `**Blocked by #<infra_pr>.** ... Once this lands, sync this branch with \`gh
    api -X PUT .../update-branch\` and re-run CI.`
 
-### Step 4 — Per-PR salvage decision tree
+### Step 4 â Per-PR salvage decision tree
 
 For each surviving PR in the queue (after infra-broken repos are paused), run
 this decision tree:
@@ -207,49 +207,49 @@ decision based on the updated check state and diff.
 
 ```
 read PR title, body, file list, and full diff
-│
-├── Does main ALREADY contain the change this PR proposes?
-│   │
-│   ├── YES → CLOSE-SUPERSEDED with a comment naming the canonical commit / PR.
-│   │        Skip; do not open a salvage PR.
-│   │
-│   └── NO → continue.
-│
-├── Does the PR's diff have any value worth keeping?
-│   (functional change OR test addition OR doc improvement OR security
-│    hardening that is NOT yet on main)
-│   │
-│   ├── NO → CLOSE as no-op with a comment explaining why.
-│   │        (Common case: a reformatter PR whose `content.replace(...)`
-│   │         targets are all gone.)
-│   │
-│   └── YES → continue to salvage.
-│
-├── Salvage path:
-│   1. git checkout -b cursor-agent/salvage-<repo>-<old_pr>-<short_label>-<suffix> main
-│   2. For each VALUABLE file in the original PR:
-│        - if the file is a JOURNAL / APPEND-ONLY (.jules/*.md, CHANGELOG.md):
-│            * extract only the new entry from the PR's diff
-│            * APPEND it to main's current version (NEVER `git checkout pr -- file`
-│              on a journal — Lesson 0y)
-│        - else if the file's signature changed on main (e.g. a refactored function):
-│            * adapt the change/test to main's actual API (Lesson 0z); use
-│              `ast`-based isolated import for tests if the target script has
-│              module-level side effects
-│            * verify with the relevant unit-test command before committing
-│        - else (clean cherry-pick):
-│            * git checkout pr_branch -- path/to/file
-│            * if the file is a journal, see the APPEND-ONLY branch above
-│   3. python -m py_compile (or pytest, or repo-specific) verification
-│   4. git commit with author preserved if cherry-picked, descriptive subject
-│      `<type>(<scope>): <change> (salvages #<N>)`
-│   5. git push -u origin <branch>      (use GH_TOKEN-injected remote URL)
-│   6. gh pr create --draft with the standard ELIR
-│   7. gh pr close <old_pr> --comment "Closing as **superseded by #<new_pr>** ..."
-└── done
+â
+âââ Does main ALREADY contain the change this PR proposes?
+â   â
+â   âââ YES â CLOSE-SUPERSEDED with a comment naming the canonical commit / PR.
+â   â        Skip; do not open a salvage PR.
+â   â
+â   âââ NO â continue.
+â
+âââ Does the PR's diff have any value worth keeping?
+â   (functional change OR test addition OR doc improvement OR security
+â    hardening that is NOT yet on main)
+â   â
+â   âââ NO â CLOSE as no-op with a comment explaining why.
+â   â        (Common case: a reformatter PR whose `content.replace(...)`
+â   â         targets are all gone.)
+â   â
+â   âââ YES â continue to salvage.
+â
+âââ Salvage path:
+â   1. git checkout -b cursor-agent/salvage-<repo>-<old_pr>-<short_label>-<suffix> main
+â   2. For each VALUABLE file in the original PR:
+â        - if the file is a JOURNAL / APPEND-ONLY (.jules/*.md, CHANGELOG.md):
+â            * extract only the new entry from the PR's diff
+â            * APPEND it to main's current version (NEVER `git checkout pr -- file`
+â              on a journal â Lesson 0y)
+â        - else if the file's signature changed on main (e.g. a refactored function):
+â            * adapt the change/test to main's actual API (Lesson 0z); use
+â              `ast`-based isolated import for tests if the target script has
+â              module-level side effects
+â            * verify with the relevant unit-test command before committing
+â        - else (clean cherry-pick):
+â            * git checkout pr_branch -- path/to/file
+â            * if the file is a journal, see the APPEND-ONLY branch above
+â   3. python -m py_compile (or pytest, or repo-specific) verification
+â   4. git commit with author preserved if cherry-picked, descriptive subject
+â      `<type>(<scope>): <change> (salvages #<N>)`
+â   5. git push -u origin <branch>      (use GH_TOKEN-injected remote URL)
+â   6. gh pr create --draft with the standard ELIR
+â   7. gh pr close <old_pr> --comment "Closing as **superseded by #<new_pr>** ..."
+âââ done
 ```
 
-### Step 5 — Document the salvage run
+### Step 5 â Document the salvage run
 
 Append a section to `tasks/salvage-session-reports.md`. Optionally link the
 corresponding Phase 1 snapshot (`tasks/pr-review-YYYY-MM-DD.md`) as input
@@ -258,8 +258,8 @@ context. Required content:
 - A salvage-results table: `Repo | Old PR | Disposition | New PR | Notes`.
 - Counts: deep-dived, salvaged, new infra-fix PR, closed as superseded / no-op,
   cross-linked blocked-by, net new draft PRs awaiting human review.
-- New patterns observed → file each as a numbered lesson in `tasks/lessons.md`
-  (one Pattern → Rule → Detection cost block per lesson).
+- New patterns observed â file each as a numbered lesson in `tasks/lessons.md`
+  (one Pattern â Rule â Detection cost block per lesson).
 
 Salvage automation must not write to `tasks/review-session-reports.md`.
 
@@ -270,13 +270,13 @@ Salvage automation must not write to `tasks/review-session-reports.md`.
 These exist to prevent the specific classes of mistakes Phase 2 is designed to
 catch:
 
-### S1 — No autonomous merges. Ever.
+### S1 â No autonomous merges. Ever.
 
 Every PR opened by the Salvage Agent is `--draft`. Every closure is paired with
 a salvage PR or an existing-on-main reference. The agent does not merge a
-salvage PR even when CI is green — that's the maintainer's call.
+salvage PR even when CI is green â that's the maintainer's call.
 
-### S2 — Append-only protection for journal files
+### S2 â Append-only protection for journal files
 
 When a salvage touches `.jules/*.md`, `CHANGELOG.md`, `.jules/sentinel.md`,
 `.jules/palette.md`, `.jules/bolt.md`, `tasks/lessons.md`, or any file matching
@@ -290,7 +290,7 @@ When a salvage touches `.jules/*.md`, `CHANGELOG.md`, `.jules/sentinel.md`,
 4. Verify the resulting file is **strictly longer** than `main`'s version
    (line-count regression is a tripwire).
 
-### S3 — JSON-blob detection on every "perf" PR that touches a single file > 5KB
+### S3 â JSON-blob detection on every "perf" PR that touches a single file > 5KB
 
 Before salvaging, run `head -c 200 <file> | grep -E '\\\\n.{20,}\\\\n'` (or
 equivalent). If the file appears to be a stringified blob, immediately switch to
@@ -299,7 +299,7 @@ normal salvage. The same check applies during normal Phase 1 review of any PR
 that adds or replaces a single source file, but Phase 2 is the last line of
 defense.
 
-### S4 — Test adaptation, not test wholesale-checkout
+### S4 â Test adaptation, not test wholesale-checkout
 
 When the PR being salvaged contains test files, **do not**
 `git checkout pr -- tests/<file>` blindly. Instead:
@@ -307,23 +307,23 @@ When the PR being salvaged contains test files, **do not**
 1. Read the test file from the PR.
 2. Compare each tested function/method against `main`'s current signature and
    call sites.
-3. If signatures match → checkout is fine.
-4. If signatures changed → rewrite the test to match `main`'s actual API.
+3. If signatures match â checkout is fine.
+4. If signatures changed â rewrite the test to match `main`'s actual API.
 5. Verify the rewritten test by running it locally.
 6. Add at least one defense-in-depth assertion if the original was a
    single-property test.
 
-### S5 — `update-branch` 422 disambiguation
+### S5 â `update-branch` 422 disambiguation
 
 When attempting to sync a deferred branch, distinguish the two `422` responses:
 
-- `"There are no new commits on the base branch."` → benign; the branch is
+- `"There are no new commits on the base branch."` â benign; the branch is
   current.
-- `"merge conflict between base and head"` → real conflict. Switch to the
+- `"merge conflict between base and head"` â real conflict. Switch to the
   salvage path (apply only unique files onto a fresh branch from `main`); do
   **not** try interactive rebase on the original branch.
 
-### S6 — Security-classified repo gates
+### S6 â Security-classified repo gates
 
 For repos classified as security-sensitive in
 `tasks/pr-review-agent.config.yaml` (currently: `email-security-pipeline`), the
@@ -337,14 +337,14 @@ agent must:
    before drafting salvage changes so the remediation attempt is captured in PR
    history.
 
-### S7 — Provenance preservation on cherry-picks
+### S7 â Provenance preservation on cherry-picks
 
 When salvaging via `git cherry-pick <commit>`, do not strip the original author.
 The salvage commit message should mention `Refs: #<old_pr> (salvage source)` so
 the audit trail back to the original automation agent's contribution is
 preserved.
 
-### S8 — Branch naming and isolation
+### S8 â Branch naming and isolation
 
 Salvage branches use the prefix
 **`cursor-agent/salvage-<repo>-<old_pr>-<short_label>-<suffix>`**. Infra-fix
@@ -353,13 +353,13 @@ branch the agent did not create. Never delete a remote branch the agent did not
 create. The `<suffix>` is the same per-agent suffix used by the Review Agent's
 branch policy so cloud-agent branches are easily distinguishable.
 
-### S9 — Force-push prohibition (with one bounded exception)
+### S9 â Force-push prohibition (with one bounded exception)
 
 Never `git push --force` and never `git push --force-with-lease` to any
 pre-existing branch. The bounded exception: a salvage branch that was just
 created and pushed by the agent, and that the agent then locally amended (e.g.
 to drop an unintended file from the commit), may be replaced via **delete +
-re-push** — not via `--force`. If that's not possible (branch already has
+re-push** â not via `--force`. If that's not possible (branch already has
 reviewer comments), abandon the branch and create a new one with a `-v2` suffix.
 
 ---
@@ -379,10 +379,10 @@ Suggested tiers:
 
 | Tier                                | Examples                                                           | Maintainer review SLA                      |
 | ----------------------------------- | ------------------------------------------------------------------ | ------------------------------------------ |
-| **T0 — infra-fix**                  | `esp#723`-style reverts that unblock an entire repo's CI           | Within the same review session             |
-| **T1 — security-sensitive salvage** | `sa#157`-style Sentinel fixes (info-leak, auth, secrets)           | Highest priority among salvage PRs         |
-| **T2 — trust-boundary salvage**     | `pc#826`-style changes touching the PR automation toolchain itself | Always merge by hand, never via auto-merge |
-| **T3 — routine salvage**            | `pc#825/827`, `cs#743`, `hg#148`-style perf / UX / test additions  | Normal review queue                        |
+| **T0 â infra-fix**                  | `esp#723`-style reverts that unblock an entire repo's CI           | Within the same review session             |
+| **T1 â security-sensitive salvage** | `sa#157`-style Sentinel fixes (info-leak, auth, secrets)           | Highest priority among salvage PRs         |
+| **T2 â trust-boundary salvage**     | `pc#826`-style changes touching the PR automation toolchain itself | Always merge by hand, never via auto-merge |
+| **T3 â routine salvage**            | `pc#825/827`, `cs#743`, `hg#148`-style perf / UX / test additions  | Normal review queue                        |
 
 The agent surfaces the tier in the salvage PR title prefix when meaningful (e.g.
 `fix(security): ...` for T1, `perf(adguard): ...` for T3). The addendum links to
@@ -408,7 +408,7 @@ next Phase 2 run should:
    comment cited a salvage PR that was itself closed-without-merge).
 2. Add a `tasks/lessons.md` entry capturing the rejection reason if the
    maintainer left a review comment.
-3. Do **not** automatically re-open the original — the maintainer rejected the
+3. Do **not** automatically re-open the original â the maintainer rejected the
    salvage for a reason; that reason almost always applies to the original too.
 
 ---
@@ -440,7 +440,7 @@ into Phase 1 too where applicable:
 5. **Cache the `gh api repos/<repo>/contents/<file>` response for the duration
    of a Phase 2 run.** The deep-dive made dozens of API calls re-fetching the
    same `main` versions of files; a per-repo file-content cache would cut
-   runtime ~3× on a heavy run.
+   runtime ~3Ã on a heavy run.
 6. **Make the Phase 1 deferred-tail format explicit and parsable.** Right now
    Phase 2 reads the `tasks/pr-review-YYYY-MM-DD.md` "Post-session remainder"
    section by `grep`-style heuristics. Convert it to a small YAML block at the
@@ -449,26 +449,32 @@ into Phase 1 too where applicable:
 7. **Run Phase 2 within a few hours of Phase 1, not on a separate day.** The
    deeper the gap, the more likely deferred PRs have been hand-rebased / merged
    / closed by the maintainer in between, requiring more Step 1 reconciliation.
-   Same-session Phase 1 → Phase 2 is the cheapest cycle.
+   Same-session Phase 1 â Phase 2 is the cheapest cycle.
 
 ---
 
 ## Hard boundaries (non-negotiable)
 
-- ❌ Never merge a salvage PR or an infra-fix PR autonomously, regardless of CI
+- â Never merge a salvage PR or an infra-fix PR autonomously, regardless of CI
   color.
-- ❌ Never force-push (the bounded delete-and-re-push for fresh agent-created
+- â Never force-push (the bounded delete-and-re-push for fresh agent-created
   branches is the only exception, per S9).
-- ❌ Never push to a branch the agent did not create.
-- ❌ Never re-open a PR that the maintainer closed.
-- ❌ Never apply `git checkout <pr_branch> -- <journal_file>` (Lesson 0y).
-- ❌ Never autonomously approve / `gh pr review --approve` a salvage PR (the
+- â Never push to a branch the agent did not create.
+- â Never re-open a PR that the maintainer closed.
+- â Never apply `git checkout <pr_branch> -- <journal_file>` (Lesson 0y).
+- â Never autonomously approve / `gh pr review --approve` a salvage PR (the
   agent might be a CODEOWNER on some repos; treat that as a privilege not to be
   exercised).
-- ❌ Never bypass a broken pytest gate on a security-classified repo (Lesson
+- â Never bypass a broken pytest gate on a security-classified repo (Lesson
   0bb).
-- ❌ Never modify `tasks/pr-review-agent.config.yaml` from inside the agent. The
+- â Never modify `tasks/pr-review-agent.config.yaml` from inside the agent. The
   config is human-curated.
+
+## Related docs
+
+- [Automated PR Review & Consolidation Agent](automated-pr-review-agent.md) â
+  Phase 1 (the upstream skill that produces Phase 2's input).
+- [GitHub App Permission Checklist](github-app-pr-automation-checklist.md) â
 
 ## Related docs
 
@@ -480,3 +486,23 @@ into Phase 1 too where applicable:
   for maintainers.
 - [`tasks/lessons.md`](../tasks/lessons.md) — Lessons 0t, 0u, 0v, 0w, 0x, 0y,
   0z, 0aa, 0bb were all derived from the runs that motivated this skill.
+- [Repository Health Triage Skill](../../skills/repo-health-triage/SKILL.md) —
+  Daily repo health scanning and issue triage for all priority repositories.
+- [GitHub PR Summarizer Skill](../../skills/github-pr-summarizer/SKILL.md) —
+  Daily PR summary generation that provides foundational context for salvage operations.
+
+### Daily Automation Context
+
+This Salvage Agent (Phase 2) operates within a broader daily automation workflow.
+The following scheduled tasks run automatically each day on all seven priority
+repositories and may produce documents and issue candidates that this agent
+should reference:
+
+- **6:00 AM** - GitHub PR Summarizer: Creates daily PR summary reports in Notion
+- **8:15 AM** - Repository Health Triage: Scans for security issues and creates issue candidates
+
+Both scheduled tasks analyze the same seven repositories: personal-config,
+ctrld-sync, email-security-pipeline, Seatek_Analysis,
+Hydrograph_Versus_Seatek_Sensors_Project, series_correction_project_updated,
+repoprompt-ce.
+

--- a/docs/github-app-pr-automation-checklist.md
+++ b/docs/github-app-pr-automation-checklist.md
@@ -9,7 +9,8 @@ repositories with least privilege.
 - [ ] Install the app on every target repository.
 - [ ] Use one app installation per trust domain:
   - Personal projects: `personal-config`, `email-security-pipeline`,
-    `ctrld-sync`
+    `ctrld-sync`, `Seatek_Analysis`, `Hydrograph_Versus_Seatek_Sensors_Project`,
+    `series_correction_project_updated`, `repoprompt-ce`
   - Academic/research repos: separate installation (recommended)
 - [ ] Keep personal and research installations isolated (separate tokens,
       separate operational logs, separate policy defaults).
@@ -73,7 +74,11 @@ Or with explicit repos:
 bash scripts/preflight-gh-pr-automation.sh \
   --repo abhimehro/personal-config \
   --repo abhimehro/email-security-pipeline \
-  --repo abhimehro/ctrld-sync
+  --repo abhimehro/ctrld-sync \
+  --repo abhimehro/Seatek_Analysis \
+  --repo abhimehro/Hydrograph_Versus_Seatek_Sensors_Project \
+  --repo abhimehro/series_correction_project_updated \
+  --repo abhimehro/repoprompt-ce
 ```
 
 For full write-path verification (recommended), use dedicated probe PRs and
@@ -84,10 +89,18 @@ bash scripts/preflight-gh-pr-automation.sh \
   --repo abhimehro/personal-config \
   --repo abhimehro/email-security-pipeline \
   --repo abhimehro/ctrld-sync \
+  --repo abhimehro/Seatek_Analysis \
+  --repo abhimehro/Hydrograph_Versus_Seatek_Sensors_Project \
+  --repo abhimehro/series_correction_project_updated \
+  --repo abhimehro/repoprompt-ce \
   --require-write-probes \
   --probe-pr abhimehro/personal-config#<open_probe_pr_number> \
   --probe-pr abhimehro/email-security-pipeline#<open_probe_pr_number> \
-  --probe-pr abhimehro/ctrld-sync#<open_probe_pr_number>
+  --probe-pr abhimehro/ctrld-sync#<open_probe_pr_number> \
+  --probe-pr abhimehro/Seatek_Analysis#<open_probe_pr_number> \
+  --probe-pr abhimehro/Hydrograph_Versus_Seatek_Sensors_Project#<open_probe_pr_number> \
+  --probe-pr abhimehro/series_correction_project_updated#<open_probe_pr_number> \
+  --probe-pr abhimehro/repoprompt-ce#<open_probe_pr_number>
 ```
 
 ## 6) Probe PR Guidance
@@ -113,12 +126,14 @@ bash scripts/preflight-gh-pr-automation.sh \
 When elevating permissions to run close/merge queues on all repos:
 
 1. **Grant permissions:** Give the integration write access (Pull requests: Read
-   & write, Contents: Read & write) on `ctrld-sync` and
-   `email-security-pipeline` per sections 1–2 above.
+   & write, Contents: Read & write) on all seven priority repositories:
+   `personal-config`, `ctrld-sync`, `email-security-pipeline`, `Seatek_Analysis`,
+   `Hydrograph_Versus_Seatek_Sensors_Project`, `series_correction_project_updated`,
+   `repoprompt-ce` per sections 1–2 above.
 2. **Verify:** Run preflight with `--require-write-probes` and probe PRs to
    confirm close/comment/review.
 3. **Close queue:** Execute the close commands in `tasks/pr-triage.md` under
-   "Ready-to-Execute Human Actions" (ctrld-sync then email-security-pipeline).
+   "Ready-to-Execute Human Actions" for all repositories.
 4. **Merge queue:** Execute the merge commands in the same section in the
    recommended order (security/dependency first, then CI/infra, then refactors).
 5. **Re-check:** After each merge, re-check remaining approved PRs for new
@@ -131,3 +146,19 @@ When elevating permissions to run close/merge queues on all repos:
 After each session, update `tasks/lessons.md` and reflect material lessons in
 the [Automated PR Review Agent](automated-pr-review-agent.md) heuristics
 subsection.
+
+## 9) Daily Automation Workflow Integration
+
+This checklist supports the broader daily automation chain. The following scheduled
+tasks run automatically and may reference or depend on the permissions configured
+here:
+
+- **6:00 AM** - GitHub PR Summarizer: Creates daily PR summary reports in Notion's
+  "GitHub PRs Daily Reports" database. Requires read access to all repositories.
+- **8:15 AM** - Repository Health Triage: Scans all seven repositories for security
+  issues, risky code, dependency problems, and maintenance signals. Creates entries
+  in Notion's "Repo Issue Candidates" database. Requires read access to all
+  repositories.
+
+Both scheduled tasks analyze the same seven repositories listed in Section 1.
+


### PR DESCRIPTION
This PR updates the PR automation documentation to reference the newly created daily automation workflow:

## Changes

1. **Updated repository list**: All documentation now references all seven priority repositories:
   - personal-config
   - ctrld-sync
   - email-security-pipeline
   - Seatek_Analysis
   - Hydrograph_Versus_Seatek_Sensors_Project
   - series_correction_project_updated
   - repoprompt-ce

2. **Added Daily Automation Chain documentation**: Added new sections describing the scheduled tasks:
   - **6:00 AM** - GitHub PR Summarizer: Creates daily PR summary reports in Notion
   - **8:15 AM** - Repository Health Triage: Scans for security issues and creates issue candidates

3. **Added references to new skills**:
   - [Repository Health Triage Skill](../../skills/repo-health-triage/SKILL.md)
   - [GitHub PR Summarizer Skill](../../skills/github-pr-summarizer/SKILL.md)

4. **Files updated**:
   - docs/automated-pr-review-agent.md
   - docs/automated-pr-salvage-agent.md
   - docs/github-app-pr-automation-checklist.md

## Context

The new automation workflow ensures that PR summaries and repo health reports are available as foundational input for the PR Review and Salvage agents, improving their effectiveness and providing better context for decision-making.

## Testing

- All repository references have been updated to include the complete list of seven repositories
- All preflight commands now include all seven repositories
- Documentation now clearly explains the relationship between scheduled tasks and the PR automation agents