### PR TITLE
perf(maintenance): single-pass vm_stat/df parsing in system_metrics.sh (salvages #1466)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -549,3 +549,8 @@ invocation.
 ## 2026-07-03 - [Optimize ps aux shell pattern gracefully across platforms]
 **Learning:** Replacing `ps aux | grep pattern | grep -v grep | wc -l` with `pgrep -fc pattern` is a great shell optimization to prevent spawning multiple sub-processes. However, on BSD-based systems like macOS, `pgrep` does not support the `-c` flag.
 **Action:** When optimizing process counting in cross-platform or macOS shell scripts, use `pgrep -f "pattern" | wc -l` (and potentially strip whitespace with `tr -d ' '`) instead of `pgrep -fc`.
+
+## 2026-07-03 - [Optimize system_metrics.sh parsing]
+
+**Learning:** Found several spots where the system_metrics script spawns multiple heavy subprocesses in quick succession (e.g. `vm_stat`, `df -h`) to parse different values from the same output. In a shell script, avoiding repeated execution of external commands and pipelining by doing it in a single pass (e.g., using a single `awk` statement and `read -r`) can yield significant performance gains, especially when these commands can be relatively slow and are run periodically.
+**Action:** Always prefer parsing a single invocation of an external command with `awk` to extract multiple metrics at once, rather than spawning the command multiple times.

--- a/maintenance/bin/system_metrics.sh
+++ b/maintenance/bin/system_metrics.sh
@@ -57,13 +57,17 @@ if command -v vm_stat >/dev/null 2>&1; then
 	VM_STAT=$(vm_stat)
 
 	# Extract memory stats
-	FREE_PAGES=$(echo "$VM_STAT" | awk '/Pages free:/ {print $3}' | tr -d '.' || echo "0")
-	ACTIVE_PAGES=$(echo "$VM_STAT" | awk '/Pages active:/ {print $3}' | tr -d '.' || echo "0")
-	INACTIVE_PAGES=$(echo "$VM_STAT" | awk '/Pages inactive:/ {print $3}' | tr -d '.' || echo "0")
-	WIRED_PAGES=$(echo "$VM_STAT" | awk '/Pages wired down:/ {print $4}' | tr -d '.' || echo "0")
-	COMPRESSED_PAGES=$(echo "$VM_STAT" | awk '/Pages stored in compressor:/ {print $5}' | tr -d '.' || echo "0")
-
-	PAGE_SIZE=$(echo "$VM_STAT" | awk '/page size of/ {print $8}' || echo "4096")
+	read -r FREE_PAGES ACTIVE_PAGES INACTIVE_PAGES WIRED_PAGES COMPRESSED_PAGES PAGE_SIZE <<< "$(echo "$VM_STAT" | awk '
+		/Pages free:/ { free=$3; sub(/\./, "", free) }
+		/Pages active:/ { active=$3; sub(/\./, "", active) }
+		/Pages inactive:/ { inactive=$3; sub(/\./, "", inactive) }
+		/Pages wired down:/ { wired=$4; sub(/\./, "", wired) }
+		/Pages stored in compressor:/ { comp=$5; sub(/\./, "", comp) }
+		/page size of/ { size=$8 }
+		END {
+			print (free==""?0:free), (active==""?0:active), (inactive==""?0:inactive), (wired==""?0:wired), (comp==""?0:comp), (size==""?4096:size)
+		}
+	')"
 
 	# Convert to MB
 	FREE_MB=$(((FREE_PAGES * PAGE_SIZE) / 1024 / 1024))
@@ -91,9 +95,12 @@ if command -v vm_stat >/dev/null 2>&1; then
 fi
 
 # Disk Usage Metrics (enhanced)
-ROOT_USAGE=$(df -h / | awk 'NR==2 {print $5}' | tr -d '%')
-ROOT_AVAILABLE_GB=$(df -h / | awk 'NR==2 {print $4}' | sed 's/Gi*//')
-ROOT_USED_GB=$(df -h / | awk 'NR==2 {print $3}' | sed 's/Gi*//')
+read -r ROOT_USED_GB ROOT_AVAILABLE_GB ROOT_USAGE <<< "$(df -h / | awk 'NR==2 {
+	used=$3; sub(/Gi*/, "", used); sub(/Mi*/, "", used); sub(/B/, "", used)
+	avail=$4; sub(/Gi*/, "", avail); sub(/Mi*/, "", avail); sub(/B/, "", avail)
+	usage=$5; sub(/%/, "", usage)
+	print used, avail, usage
+}')"
 
 log_metric "disk_usage_percent" "$ROOT_USAGE" "percent"
 log_metric "disk_available" "$ROOT_AVAILABLE_GB" "GB"


### PR DESCRIPTION
## Salvage of #1466

File-scoped salvage of Jules Bolt PR #1466. Applies only the `system_metrics.sh` performance optimization and journal entry — **excludes** `get_repo_vars.sh` and `gemini-review.yml` changes from the original (trust-boundary / conflict noise).

### Verification
```bash
bash -n maintenance/bin/system_metrics.sh
```

═══ ELIR ═══
**PURPOSE:** Reduce subprocess churn in periodic maintenance metrics collection.
**SECURITY:** Read-only system metrics; no new network or secret access.
**FAILS IF:** awk field positions drift on non-macOS `vm_stat` output.
**VERIFY:** `bash -n maintenance/bin/system_metrics.sh`
**MAINTAIN:** Extend single-pass awk when adding new vm_stat fields.

Refs: #1466 (salvage source)