### PR TITLE
🛡️ Sentinel: [HIGH] Fix Terminal Injection (CWE-150) in logging functions

### DIFF
--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -63,45 +63,45 @@ fi
 # Log an informational message
 # Usage: log_info "message"
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $*"
+    printf "%b %s\n" "${BLUE}[INFO]${NC}" "$*"
 }
 
 # Log a success message
 # Usage: log_ok "message"
 log_ok() {
-    echo -e "${GREEN}[OK]${NC} $*"
+    printf "%b %s\n" "${GREEN}[OK]${NC}" "$*"
 }
 
 # Log a warning message
 # Usage: log_warn "message"
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $*" >&2
+    printf "%b %s\n" "${YELLOW}[WARN]${NC}" "$*" >&2
 }
 
 # Log an error message
 # Usage: log_err "message"
 log_err() {
-    echo -e "${RED}[ERR]${NC} $*" >&2
+    printf "%b %s\n" "${RED}[ERR]${NC}" "$*" >&2
 }
 
 # Log a debug message (only if DEBUG is set)
 # Usage: log_debug "message"
 log_debug() {
     if [[ -n "${DEBUG:-}" ]]; then
-        echo -e "${CYAN}[DEBUG]${NC} $*"
+        printf "%b %s\n" "${CYAN}[DEBUG]${NC}" "$*"
     fi
 }
 
 # Log a header/section title
 # Usage: log_header "Section Title"
 log_header() {
-    echo -e "\n${BOLD}${BLUE}=== $* ===${NC}"
+    printf "\n%b %s %b\n" "${BOLD}${BLUE}===" "$*" "===${NC}"
 }
 
 # Log a horizontal rule
 # Usage: log_hr
 log_hr() {
-    echo -e "${BLUE}────────────────────────────────────────────────────────────────${NC}"
+    printf "%b\n" "${BLUE}────────────────────────────────────────────────────────────────${NC}"
 }
 
 # =============================================================================

--- a/scripts/macos/ipv6-manager.sh
+++ b/scripts/macos/ipv6-manager.sh
@@ -21,13 +21,13 @@ E_INFO="ℹ️"
 E_IPV6="🌐"
 
 # Helpers
-log() { echo -e "${BLUE}${E_INFO} [INFO]${NC}" "$@"; }
-success() { echo -e "${GREEN}${E_PASS} [OK]${NC}" "$@"; }
+log() { printf "%b %s\n" "${BLUE}${E_INFO} [INFO]${NC}" "$*"; }
+success() { printf "%b %s\n" "${GREEN}${E_PASS} [OK]${NC}" "$*"; }
 error() {
-	echo -e "${RED}${E_FAIL} [ERR]${NC}" "$@" >&2
+	printf "%b %s\n" "${RED}${E_FAIL} [ERR]${NC}" "$*" >&2
 	exit 1
 }
-warn() { echo -e "${YELLOW}${E_WARN} [WARN]${NC}" "$@"; }
+warn() { printf "%b %s\n" "${YELLOW}${E_WARN} [WARN]${NC}" "$*"; }
 header() {
 	# Print a blank line, then a bold blue header built from all arguments.
 	# We avoid $* to preserve argument boundaries and any embedded whitespace.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Terminal Injection (CWE-150) exists in `scripts/macos/ipv6-manager.sh` and `scripts/lib/logging.sh` due to the use of `echo -e` to print user input or external variables. `echo -e` evaluates escape sequences within its arguments, allowing malicious output to alter the terminal display or spoof log entries.
🎯 Impact: An attacker who can control log messages or environment variables could inject arbitrary terminal escape sequences. While this is primarily a display issue, terminal manipulation can trick users into interacting with malicious output, hiding important warnings, or executing spoofed commands.
🔧 Fix: Replaced `echo -e` with safe `printf` implementations (`printf "%b %s\n" ...`) that output colors explicitly using `%b` but treat all user variables strictly as literal strings (`%s`).
✅ Verification: Ran `./tests/run_all_tests.sh` to ensure the logging functions still function correctly and no tests fail.

---
*PR created automatically by Jules for task [17173575699946744045](https://jules.google.com/task/17173575699946744045) started by @abhimehro*