### PR TITLE
⚡ Bolt: Combine uptime parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -554,3 +554,7 @@ invocation.
 
 **Learning:** Found several spots where the system_metrics script spawns multiple heavy subprocesses in quick succession (e.g. `vm_stat`, `df -h`) to parse different values from the same output. In a shell script, avoiding repeated execution of external commands and pipelining by doing it in a single pass (e.g., using a single `awk` statement and `read -r`) can yield significant performance gains, especially when these commands can be relatively slow and are run periodically.
 **Action:** Always prefer parsing a single invocation of an external command with `awk` to extract multiple metrics at once, rather than spawning the command multiple times.
+
+## 2026-07-04 - [Optimize system_metrics.sh parsing further by combining uptime awk passes]
+**Learning:** Checking `uptime` twice using two different pipe chains (one for load averages, one for system uptime days) spawns multiple redundant subprocesses.
+**Action:** Extract all necessary fields (load averages and days) using a single `awk` pass over `uptime` and populate them with `read -r` to minimize execution time and subprocess counts in shell scripts.

--- a/maintenance/bin/system_metrics.sh
+++ b/maintenance/bin/system_metrics.sh
@@ -38,8 +38,19 @@ fi
 log_info "System metrics collection started"
 
 # CPU and Load Metrics
-# Read uptime once to avoid spawning multiple processes
-read -r LOAD_1MIN LOAD_5MIN LOAD_15MIN <<< "$(uptime | awk -F'load averages:' '{print $2}' | tr -d ',' | awk '{print $1, $2, $3}')"
+# Read uptime once to avoid spawning multiple processes and extract load + days together
+read -r LOAD_1MIN LOAD_5MIN LOAD_15MIN UPTIME_DAYS <<< "$(uptime | awk '{
+	l15=$NF; l5=$(NF-1); l1=$(NF-2);
+	gsub(/,/, "", l15); gsub(/,/, "", l5); gsub(/,/, "", l1);
+	days="0";
+	for (i=1; i<=NF; i++) {
+		if ($i ~ /^days?,?$/) {
+			days=$(i-1);
+			break;
+		}
+	}
+	print l1, l5, l15, days;
+}')"
 LOAD_1MIN=${LOAD_1MIN:-0}
 LOAD_5MIN=${LOAD_5MIN:-0}
 LOAD_15MIN=${LOAD_15MIN:-0}
@@ -200,7 +211,6 @@ if command -v brew >/dev/null 2>&1; then
 fi
 
 # System Uptime
-UPTIME_DAYS=$(uptime | awk -F'up ' '{print $2}' | awk '{print $1}' | grep -o '[0-9]\+' | head -1 || echo "0")
 log_metric "system_uptime_days" "${UPTIME_DAYS:-0}" "days"
 
 # Temperature Monitoring (if available)


### PR DESCRIPTION
💡 What: Combined the extraction of load averages and uptime days into a single awk pass over `uptime`.
🎯 Why: Avoids spawning multiple sub-shells (`awk`, `grep`, `head`) by reusing the output of a single `uptime` command.
📊 Impact: Eliminates ~4 subprocess spawns during metrics collection, incrementally reducing system overhead.
🔬 Measurement: The test suite in `./tests/run_all_tests.sh` verifies metric output formatting is unaffected.

---
*PR created automatically by Jules for task [15793182967617773236](https://jules.google.com/task/15793182967617773236) started by @abhimehro*