### PR TITLE
🧹 Code Health: Remove unused clear_gh_token_cache function

### DIFF
--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -86,11 +86,6 @@ def load_gh_token_env(base: Mapping[str, str] | None = None) -> dict[str, str]:
     return env
 
 
-def clear_gh_token_cache() -> None:
-    """Clear cached file reads (for tests after changing GH_TOKEN_ENV_FILE)."""
-    _get_parsed_env_vars_from_file.cache_clear()
-
-
 def gh_token_configured() -> bool:
     """True when GH_TOKEN is available from the environment or a config file."""
     if os.environ.get("GH_TOKEN"):

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from gh_token_env import (
+    _get_parsed_env_vars_from_file,
     _read_env_file,
-    clear_gh_token_cache,
     gh_token_configured,
     load_gh_token_env,
     missing_gh_token_message,
@@ -17,7 +17,7 @@ from gh_token_env import (
 
 class TestGhTokenEnv(unittest.TestCase):
     def setUp(self):
-        clear_gh_token_cache()
+        _get_parsed_env_vars_from_file.cache_clear()
 
     def test_parse_env_line_basic(self):
         env: dict[str, str] = {}
@@ -34,9 +34,10 @@ class TestGhTokenEnv(unittest.TestCase):
     def test_read_env_file_oserror(self):
         self.assertEqual(_read_env_file(Path("/does/not/exist/ever.env")), {})
 
-        with patch.object(Path, "open", side_effect=PermissionError("Permission denied")):
+        with patch.object(
+            Path, "open", side_effect=PermissionError("Permission denied")
+        ):
             self.assertEqual(_read_env_file(Path("some_file.env")), {})
-
 
     def test_env_var_takes_precedence_over_file(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
🎯 **What:** Removed unused function `clear_gh_token_cache` from `gh_token_env.py` and updated test dependencies.
💡 **Why:** `clear_gh_token_cache` was only a wrapper for `_get_parsed_env_vars_from_file.cache_clear()` used exclusively in testing, contributing to dead/unused code in the main application. Calling the cache clearing method directly in tests improves code clarity and removes an unneeded public-facing utility.
✅ **Verification:** Updated `tests/test_gh_token_env.py` to use `_get_parsed_env_vars_from_file.cache_clear()` and verified the full test suite runs cleanly.
✨ **Result:** A leaner `gh_token_env.py` module with test-specific wrappers correctly localized to the tests.

---
*PR created automatically by Jules for task [9711836448758412342](https://jules.google.com/task/9711836448758412342) started by @abhimehro*