### PR TITLE
🧹 Code Health: Export escape_spreadsheet_formula to resolve unused function warning

### DIFF
--- a/spreadsheet_safety.py
+++ b/spreadsheet_safety.py
@@ -5,6 +5,8 @@
 # (CWE-1236). Prefix with a single quote to force literal interpretation.
 _FORMULA_PREFIX_CHARS = "=+-@\t\r"  # ⚡ Bolt Optimization: Use string for O(1)-like C-level character lookup
 
+__all__ = ["escape_spreadsheet_formula"]
+
 
 def escape_spreadsheet_formula(value: str) -> str:
     """Return *value* safe for spreadsheet cells sourced from untrusted text.


### PR DESCRIPTION
🎯 **What:** Added `__all__ = ["escape_spreadsheet_formula"]` to `spreadsheet_safety.py` to explicitly export the function.
💡 **Why:** This clarifies the public API of the module and prevents dead code analyzers (like Vulture) from incorrectly flagging it as unused.
✅ **Verification:** Verified by checking that `vulture spreadsheet_safety.py` no longer flags the function as unused, and ran `python3 -m unittest discover -s tests -p "test_*.py"` to ensure no regressions.
✨ **Result:** The codebase is cleaner and static analysis tools produce fewer false positive warnings without any change in functionality.

---
*PR created automatically by Jules for task [7444089683418027357](https://jules.google.com/task/7444089683418027357) started by @abhimehro*