### PR TITLE
🧹 Code Health: Remove unused calendar focus logic

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -139,20 +139,7 @@ LINEAR_LABEL_BONUSES: dict[str, int] = {
 LINEAR_LABEL_BONUSES_ITEMS = tuple(LINEAR_LABEL_BONUSES.items())
 LINEAR_PRIORITY_SCORES = {1: 80, 2: 60, 3: 30, 4: 10}
 
-CALENDAR_ADMIN_KEYWORDS = (
-    ("maintenance", 6),
-    ("cleanup", 6),
-    ("health check", 5),
-    ("report", 5),
-    ("review", 4),
-    ("admin", 4),
-    ("system", 3),
-    ("monitor", 3),
-    ("schedule", 3),
-    ("planning", 3),
-    ("homebrew", 3),
-    ("deals", 1),
-)
+
 
 HOROSCOPE_ENDPOINTS_TEMPLATE = [
     {
@@ -215,9 +202,6 @@ class AppConfig:
     readwise_token: str
     perplexity_api_key: str = ""
     linear_api_key: str = ""
-    google_calendar_api_key: str = ""
-    google_calendar_email: str = ""
-    google_calendar_timezone: str = "America/Chicago"
     timezone_offset: str = "-05:00"
     focus_max_items: int = DEFAULT_FOCUS_MAX_ITEMS
     lat: float = DEFAULT_LAT
@@ -267,11 +251,6 @@ class AppConfig:
                 os.getenv("LINEAR_API_KEY", "").strip()
                 or os.getenv("LINEAR_TOKEN", "").strip()
             ),
-            google_calendar_api_key=os.getenv("GOOGLE_CALENDAR_API_KEY", "").strip(),
-            google_calendar_email=os.getenv("GOOGLE_CALENDAR_EMAIL", "").strip(),
-            google_calendar_timezone=os.getenv(
-                "GOOGLE_CALENDAR_TIMEZONE", "America/Chicago"
-            ).strip(),
             timezone_offset=os.getenv("MORNING_BRIEF_TZ_OFFSET", "-05:00").strip(),
             focus_max_items=_safe_int(
                 "MORNING_BRIEF_FOCUS_MAX_ITEMS", DEFAULT_FOCUS_MAX_ITEMS
@@ -346,8 +325,6 @@ class LinearQueueSnapshot:
 class DailyContext:
     today: dt.date
     today_iso: str
-    calendar_time_min: str
-    calendar_time_max: str
 
     @classmethod
     def build(cls, timezone_offset: str) -> "DailyContext":
@@ -356,8 +333,6 @@ class DailyContext:
         return cls(
             today=today,
             today_iso=today_iso,
-            calendar_time_min=f"{today_iso}T00:00:00{timezone_offset}",
-            calendar_time_max=f"{today_iso}T23:59:59{timezone_offset}",
         )
 
 
@@ -633,12 +608,6 @@ def is_due_today(date_str: str, today_iso: str) -> bool:
     return bool(date_str) and date_str == today_iso
 
 
-def format_time_label(start_raw: str) -> str:
-    if not start_raw:
-        return "Anytime"
-    return start_raw[11:16] if "T" in start_raw else "All day"
-
-
 def extract_horoscope_text(data: dict[str, Any]) -> str | None:
     if not isinstance(data, dict):
         return None
@@ -728,11 +697,6 @@ def score_linear_issue(
         score += 15
 
     return max(score, 0)
-
-
-def calendar_admin_score(title: str, description: str = "") -> int:
-    text = f"{title} {description}".lower()
-    return sum(weight for kw, weight in CALENDAR_ADMIN_KEYWORDS if kw in text)
 
 
 def build_focus_meta_parts(item: FocusItem, today_iso: str) -> list[str]:
@@ -1100,64 +1064,6 @@ def fetch_linear_queue_snapshot(
     except Exception as exc:
         logger.error("Linear queue snapshot error: %s", exc)
         return LinearQueueSnapshot()
-
-
-def fetch_calendar_focus_items(
-    session: requests.Session,
-    config: AppConfig,
-    daily: DailyContext,
-) -> list[FocusItem]:
-    if not config.google_calendar_api_key or not config.google_calendar_email:
-        return []
-    if config.google_calendar_api_key.startswith("GOCSPX-"):
-        logger.warning("GOOGLE_CALENDAR_API_KEY is an OAuth secret; skipping calendar.")
-        return []
-
-    encoded = requests.utils.quote(config.google_calendar_email, safe="")
-    url = f"https://www.googleapis.com/calendar/v3/calendars/{encoded}/events"
-    params = {
-        "key": config.google_calendar_api_key,
-        "timeMin": daily.calendar_time_min,
-        "timeMax": daily.calendar_time_max,
-        "singleEvents": "true",
-        "orderBy": "startTime",
-        "maxResults": "10",
-        "timeZone": config.google_calendar_timezone,
-    }
-
-    try:
-        response = session.get(url, params=params, timeout=DEFAULT_TIMEOUT)
-        response.raise_for_status()
-        events = response.json().get("items", [])
-
-        items: list[FocusItem] = []
-        for event in events:
-            title = event.get("summary", "Calendar event")
-            desc = event.get("description", "")
-            start_raw = (
-                event.get("start", {}).get("dateTime")
-                or event.get("start", {}).get("date")
-                or ""
-            )
-
-            items.append(
-                FocusItem(
-                    kind="calendar",
-                    identifier="Calendar",
-                    title=title,
-                    url=event.get("htmlLink", "#"),
-                    time_label=format_time_label(start_raw),
-                    badge="admin",
-                    score=calendar_admin_score(title, desc),
-                    description=desc,
-                )
-            )
-
-        items.sort(key=lambda i: (-i.score, i.time_label or "99:99", i.title))
-        return items[: config.focus_max_items]
-    except Exception as exc:
-        logger.error("Calendar focus error: %s", exc)
-        return []
 
 
 def fetch_single_feed(

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -205,26 +205,6 @@ class TestIsDueToday(unittest.TestCase):
         assert mb.is_due_today(None, "2026-03-25") is False
 
 
-class TestFormatTimeLabel(unittest.TestCase):
-    def test_datetime(self):
-        assert mb.format_time_label("2026-03-25T09:30:00-05:00") == "09:30"
-
-    def test_date_only(self):
-        assert mb.format_time_label("2026-03-25") == "All day"
-
-    def test_empty(self):
-        assert mb.format_time_label("") == "Anytime"
-
-    def test_none(self):
-        assert mb.format_time_label(None) == "Anytime"
-
-    def test_whitespace(self):
-        assert mb.format_time_label("   ") == "All day"
-
-    def test_short_string_with_t(self):
-        assert mb.format_time_label("T") == ""
-
-
 # ============================================================
 # Horoscope Extraction
 # ============================================================
@@ -387,21 +367,6 @@ class TestScoreLinearIssue(unittest.TestCase):
 # ============================================================
 # Calendar Admin Scoring
 # ============================================================
-
-
-class TestCalendarAdminScore(unittest.TestCase):
-    def test_strong_keywords(self):
-        assert mb.calendar_admin_score("System Maintenance") > 0
-
-    def test_no_keywords(self):
-        assert mb.calendar_admin_score("Coffee with Sarah") == 0
-
-    def test_description_included(self):
-        assert mb.calendar_admin_score("Meeting", "health check on servers") > 0
-
-    def test_multiple_keywords(self):
-        score = mb.calendar_admin_score("Admin Review and Cleanup")
-        assert score >= 14  # admin(4) + review(4) + cleanup(6)
 
 
 # ============================================================
@@ -659,8 +624,6 @@ class TestDailyContext(unittest.TestCase):
     def test_build(self):
         ctx = mb.DailyContext.build("-05:00")
         assert ctx.today == dt.date.today()
-        assert "-05:00" in ctx.calendar_time_min
-        assert "-05:00" in ctx.calendar_time_max
 
 
 # ============================================================


### PR DESCRIPTION
🎯 **What:** Removed unused Google Calendar fetching logic (`fetch_calendar_focus_items`) along with its associated helper functions (`format_time_label`, `calendar_admin_score`), tests, configuration keywords, and unused calendar context properties from `AppConfig` and `DailyContext`.
💡 **Why:** This logic was unreachable, as `calendar_items` was statically populated as an empty list inside the main brief generation, rendering all related fetching functions dead code. Cleaning it up reduces the complexity and maintenance footprint of the application without affecting existing behaviors.
✅ **Verification:** Verified by running the test suite (`make test-all`), observing successful tests, and ensuring all referenced `AppConfig` attributes were appropriately removed.
✨ **Result:** Improved codebase cleanliness and reduced cognitive load for future maintainers.

---
*PR created automatically by Jules for task [12491361228455321034](https://jules.google.com/task/12491361228455321034) started by @abhimehro*