### PR TITLE
🛡️ Sentinel: [HIGH] Fix Option Injection Risk (CWE-88) in pgrep wrappers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -613,3 +613,10 @@ treated strictly as patterns and not parsed as command-line options.
 **Vulnerability:** AppleScript Option Injection (CWE-74/CWE-88 variant). Even when passing dynamic variables safely to `osascript` using `-e 'on run argv'`, the variables were passed directly after the script string without the `--` delimiter (e.g. `osascript -e 'on run argv' ... -e 'end run' "$msg" "$title"`). If an attacker controls the variable and starts it with a hyphen, `osascript` may interpret the variable as a command-line flag rather than a positional argument, leading to option injection or unintended execution.
 **Learning:** When invoking `osascript` with dynamic variables from bash, you must explicitly separate options from arguments using the `--` delimiter before positional arguments to prevent them from being parsed as flags.
 **Prevention:** Always use the `--` argument delimiter before positional arguments when using `osascript` with external variables (e.g., `osascript -e 'on run argv' ... -- "$VAR"`).
+
+
+## 2026-06-27 - AppleScript Option Injection in Batch Uninstaller
+
+**Vulnerability:** AppleScript Option Injection (CWE-88 variant). In `configs/.config/mole/lib/uninstall/batch.sh` and `configs/.config/mole/lib/core/file_ops.sh`, `osascript - "$variable"` is used without the `--` delimiter before the positional arguments (e.g. `osascript - "$clean_name" <<-'EOF'`). If the variable starts with a hyphen, it might be interpreted as a flag, leading to Option Injection.
+**Learning:** When passing dynamic variables as positional arguments to `osascript` using heredocs (`<<`), a `--` separator is still required before the variables.
+**Prevention:** Always use the `--` argument delimiter before positional arguments when using `osascript` with external variables (e.g., `osascript - -- "$VAR" <<-'EOF'`).

--- a/maintenance/bin/archive/onedrive_monitor 2.sh
+++ b/maintenance/bin/archive/onedrive_monitor 2.sh
@@ -16,7 +16,7 @@ fi
 log_info "OneDrive root: $ONEDRIVE_ROOT"
 
 # Check if OneDrive process is running
-ONEDRIVE_PID=$(pgrep -f "/OneDrive$" 2>/dev/null)
+ONEDRIVE_PID=$(pgrep -f -- "/OneDrive$" 2>/dev/null)
 if [[ -n $ONEDRIVE_PID ]]; then
 	log_info "OneDrive process running (PID: $ONEDRIVE_PID)"
 	process_running=true
@@ -118,7 +118,7 @@ if [[ $process_running == "false" ]] || [[ $recent_activity == "false" && $netwo
 			sleep 5
 
 			# Verify process started
-			if pgrep -f "/OneDrive$" >/dev/null 2>&1; then
+			if pgrep -f -- "/OneDrive$" >/dev/null 2>&1; then
 				log_info "OneDrive process started successfully"
 				process_running=true
 				((issues--)) # Reduce issue count since we fixed process

--- a/scripts/appstoreagent-watchdog.sh
+++ b/scripts/appstoreagent-watchdog.sh
@@ -33,7 +33,7 @@ log() {
 }
 
 get_pid() {
-	pgrep -x "$PROCESS_NAME" 2>/dev/null | head -n1
+	pgrep -x -- "$PROCESS_NAME" 2>/dev/null | head -n1
 }
 
 get_cpu_percent() {

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -446,7 +446,7 @@ is_process_running() {
     process_name="$1"
     
     if command -v pgrep >/dev/null 2>&1; then
-        pgrep -f "$process_name" >/dev/null 2>&1
+        pgrep -f -- "$process_name" >/dev/null 2>&1
     elif [[ "$(uname)" == "Darwin" ]]; then
         ps aux | grep -v grep | grep -q "$process_name"
     else
@@ -462,7 +462,7 @@ get_pid() {
     process_name="$1"
     
     if command -v pgrep >/dev/null 2>&1; then
-        pgrep -f "$process_name" | head -1
+        pgrep -f -- "$process_name" | head -1
     elif [[ "$(uname)" == "Darwin" ]]; then
         ps aux | grep -v grep | grep "$process_name" | awk '{print $2}' | head -1
     else


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Option injection (CWE-88) vulnerability existed in `pgrep` wrapper functions (`is_process_running`, `get_pid`) in `scripts/lib/utils.sh` and `scripts/appstoreagent-watchdog.sh`. They did not use the `--` delimiter before passing variables, allowing variables starting with hyphens to be treated as `pgrep` options instead of search patterns.
* 🎯 Impact: High. An attacker controlling the process name passed to these utilities could inject `pgrep` options, potentially bypassing checks, enumerating unrelated processes, or altering execution flow.
* 🔧 Fix: Added the `--` delimiter to all `pgrep` calls with variable arguments to strictly enforce treating the variable as a positional argument (pattern).
* ✅ Verification: Verified locally by running the full test suite (`./tests/run_all_tests.sh`) to ensure that adding `--` did not break existing expected functionality for these utilities.

ELIR Handoff Summary
========== ELIR ==========
PURPOSE: Fix option injection in pgrep calls by strictly separating flags and arguments.
SECURITY: Prevents option injection (CWE-88) when searching for process names containing untrusted characters.
FAILS IF: A script passes an invalid process name pattern that still matches multiple processes incorrectly.
VERIFY: Confirm all `pgrep` calls in modified files use `--` before dynamic variables.
MAINTAIN: Always use the `--` separator before variables in `pgrep`, `pkill`, and similar commands.

Note: The `osascript` AppleScript Option Injection issue was already properly documented in `.jules/sentinel.md` as of `2026-06-25` and should be addressed in a follow-up task.

---
*PR created automatically by Jules for task [7917677198761689714](https://jules.google.com/task/7917677198761689714) started by @abhimehro*