### PR TITLE
chore: rewrite comment to avoid false positive fix task

### DIFF
--- a/adguard/scripts/import_fix_allowlist_format.py
+++ b/adguard/scripts/import_fix_allowlist_format.py
@@ -3,7 +3,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
-# Get absolute path to fix-allowlist-format.py
+# Get absolute path to the target script
 current_dir = Path(__file__).resolve().parent
 script_path = current_dir / "fix-allowlist-format.py"
 


### PR DESCRIPTION
Rewrote the comment in adguard/scripts/import_fix_allowlist_format.py to say "target script" instead of "fix-allowlist-format.py" to avoid triggering task trackers for the word "fix".

---
*PR created automatically by Jules for task [12857248948704637490](https://jules.google.com/task/12857248948704637490) started by @abhimehro*