### PR TITLE
fix: avoid issue miners flagging implemented feature as TODO

### DIFF
--- a/ELIR.md
+++ b/ELIR.md
@@ -1,0 +1,6 @@
+========== ELIR ==========
+PURPOSE: Changed `# Try to fix permissions` to `# Automatically correct permissions` to prevent issue miners from incorrectly flagging the implemented functionality as a TODO.
+SECURITY: No security implications. This is a non-functional comment change.
+FAILS IF: The change does not correctly replace the text.
+VERIFY: The comment no longer uses the word "fix" or "todo" in a way that triggers issue miners.
+MAINTAIN: When adding comments about implemented functionality, avoid phrasing that sounds like a pending task (e.g., "Try to...").

--- a/scripts/verify_all_configs.sh
+++ b/scripts/verify_all_configs.sh
@@ -95,7 +95,7 @@ verify_file_link() {
 
 		if [[ $actual_perms_normalized != "$expected_perms_normalized" ]]; then
 			warn "$name target file permissions are $actual_perms (expected $expected_perms)"
-			# Try to fix permissions
+			# Automatically correct permissions
 			log "Attempting to fix permissions on target file..."
 			if chmod "$expected_perms" "$expected_target" 2>/dev/null; then
 				success "Fixed permissions"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,3 +6,4 @@
 - [x] Analyze `gh_token_env.py` for missing OSError test in `_read_env_file`.
 - [x] Write `test_read_env_file_oserror` to cover `FileNotFoundError` and `PermissionError` paths.
 - [x] Run full tests to ensure no regressions.
+- [x] Replace `# Try to fix permissions` with `# Automatically correct permissions` in `scripts/verify_all_configs.sh`.


### PR DESCRIPTION
T2 - Refactor

This PR updates a comment in `scripts/verify_all_configs.sh` that was being incorrectly flagged as a pending task by issue miners.

========== ELIR ==========
PURPOSE: Changed `# Try to fix permissions` to `# Automatically correct permissions` to prevent issue miners from incorrectly flagging the implemented functionality as a TODO.
SECURITY: No security implications. This is a non-functional comment change.
FAILS IF: The change does not correctly replace the text.
VERIFY: The comment no longer uses the word "fix" or "todo" in a way that triggers issue miners.
MAINTAIN: When adding comments about implemented functionality, avoid phrasing that sounds like a pending task (e.g., "Try to...").

---
*PR created automatically by Jules for task [9499779029070463831](https://jules.google.com/task/9499779029070463831) started by @abhimehro*