### PR TITLE
chore: sync spaced-name comment in commit-msg hook

### DIFF
--- a/scripts/cursor_cloud_agent_commit_msg.sh
+++ b/scripts/cursor_cloud_agent_commit_msg.sh
@@ -21,7 +21,10 @@ FINDINGS=""
 IFS=',' read -ra SECRET_NAMES <<<"$CLOUD_AGENT_INJECTED_SECRET_NAMES"
 
 for raw_name in "${SECRET_NAMES[@]}"; do
-	# NOTE: Trim whitespace; labels may contain spaces — use printenv, not ${!var}.
+	# NOTE: Comma-split entries may include leading/trailing whitespace; trim so
+	# lookup matches the actual environment variable name.
+	# SECURITY: Bash indirect expansion (${!var}) only allows identifier-shaped names.
+	# Injected secret labels may contain spaces (e.g. "GitHub SSH Key"); use printenv.
 	SECRET_NAME="$(printf '%s' "$raw_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 	if [ -z "$SECRET_NAME" ]; then
 		continue


### PR DESCRIPTION
Syncs the spaced-name historical context comment from `scripts/cursor_cloud_agent_pre_commit.sh` into `scripts/cursor_cloud_agent_commit_msg.sh` to properly document the rationale for the implementation.

---
*PR created automatically by Jules for task [9201336668215731485](https://jules.google.com/task/9201336668215731485) started by @abhimehro*