### PR TITLE
chore: remove obsolete comment in menu_paginated.sh

### DIFF
--- a/configs/.config/mole/lib/ui/menu_paginated.sh
+++ b/configs/.config/mole/lib/ui/menu_paginated.sh
@@ -874,7 +874,6 @@ paginated_multi_select() {
 			;;
 		"ENTER")
 			# Allow empty selection - don't auto-select cursor position
-			# This fixes the bug where unselecting all items would still select the last cursor position
 			local -a selected_indices=()
 			for ((i = 0; i < total_items; i++)); do
 				if [[ ${selected[i]} == true ]]; then


### PR DESCRIPTION
Removes an obsolete comment in menu_paginated.sh regarding fixing a bug where unselecting all items would still select the last cursor position, as the bug has already been resolved.

---
*PR created automatically by Jules for task [5335697534693654407](https://jules.google.com/task/5335697534693654407) started by @abhimehro*