### PR TITLE
chore: reword autofix comments

### DIFF
--- a/configs/.config/mole/lib/manage/autofix.sh
+++ b/configs/.config/mole/lib/manage/autofix.sh
@@ -133,7 +133,7 @@ perform_auto_fix() {
         fi
     fi
 
-    # Fix Firewall
+    # Enable Firewall
     if [[ -n "${FIREWALL_DISABLED:-}" && "${FIREWALL_DISABLED}" == "true" ]]; then
         echo -e "${BLUE}Enabling Firewall...${NC}"
         if sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on > /dev/null 2>&1; then
@@ -146,7 +146,7 @@ perform_auto_fix() {
         echo ""
     fi
 
-    # Fix Touch ID
+    # Configure Touch ID
     if [[ -n "${TOUCHID_NOT_CONFIGURED:-}" && "${TOUCHID_NOT_CONFIGURED}" == "true" ]]; then
         echo -e "${BLUE}${ICON_ARROW}${NC} Configuring Touch ID for sudo..."
         local pam_file="/etc/pam.d/sudo"


### PR DESCRIPTION
Changed `# Fix Touch ID` to `# Configure Touch ID` and `# Fix Firewall` to `# Enable Firewall` to prevent them from being flagged as unresolved issues/TODOs.

---
*PR created automatically by Jules for task [7608110226251605070](https://jules.google.com/task/7608110226251605070) started by @abhimehro*