### PR TITLE
fix: improve stale mount cleanup and error reporting

### DIFF
--- a/media-streaming/scripts/check-stale-mounts.sh
+++ b/media-streaming/scripts/check-stale-mounts.sh
@@ -92,9 +92,11 @@ check_mount_point() {
 			else
 				log "   ❌ Cleanup failed - manual intervention required"
 				log "      Run: rm -rf \"$mount_point\""
+				return 1
 			fi
 		else
 			log "   💡 Run with --fix to attempt cleanup"
+			return 1
 		fi
 	else
 		log "✅ $mount_point: Empty directory (safe)"
@@ -108,12 +110,17 @@ cleanup_stale_mount() {
 	local max_retries=3
 	local retry_delay=2
 
+	# First try to force unmount in case it's a hung FUSE mount
+	umount -f "$mount_point" 2>/dev/null || diskutil unmount force "$mount_point" 2>/dev/null || fusermount -uz "$mount_point" 2>/dev/null || true
+
 	for ((retry = 0; retry < max_retries; retry++)); do
 		if rm -rf "$mount_point" 2>/dev/null; then
 			mkdir -p "$mount_point"
 			return 0
 		else
 			log "   ⚠️  Attempt $((retry + 1))/$max_retries: Could not remove (files may be busy)"
+			# Try unmounting again just in case
+			umount -f "$mount_point" 2>/dev/null || diskutil unmount force "$mount_point" 2>/dev/null || fusermount -uz "$mount_point" 2>/dev/null || true
 			sleep $retry_delay
 		fi
 	done


### PR DESCRIPTION
**Fix check_mount_point return status**
- Ensure that `check_mount_point` returns `1` when a stale mount is found and `--fix` isn't used, or when `--fix` fails to clean it up. Right now, it always returns `0` at the end, so `issues_found` never increments and the script always reports success.

**Improve cleanup_stale_mount logic**
- In `cleanup_stale_mount`, `rm -rf` will fail with "Device or resource busy" if the FUSE mount is stuck or orphaned but still technically mounted. We should add `umount -f`, `diskutil unmount force`, and `fusermount -uz` before the loop and inside the retry loop to forcibly unmount it before attempting `rm -rf`.

========== ELIR ==========
PURPOSE: The `check-stale-mounts.sh` script previously failed to properly record when it found issues because `check_mount_point` always returned 0, and `rm -rf` in `cleanup_stale_mount` would fail for stuck FUSE mounts due to "Device or resource busy".
SECURITY: Ensure that scripts report failure status codes so external orchestration can respond appropriately.
FAILS IF: A FUSE mount is completely hung in kernel space where even `umount -f` or `diskutil unmount force` hangs.
VERIFY: The exit code of `check-stale-mounts.sh` correctly reflects the number of stale mount issues found.
MAINTAIN: Be aware that FUSE mounts sometimes cannot be forcefully unmounted easily and may require system reboot.

---
*PR created automatically by Jules for task [16397201442419765499](https://jules.google.com/task/16397201442419765499) started by @abhimehro*