### PR TITLE
Fix locale issues in bin scripts

### DIFF
--- a/configs/.config/mole/bin/analyze.sh
+++ b/configs/.config/mole/bin/analyze.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# Fix locale issues.
+export LC_ALL=C
+export LANG=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GO_BIN="$SCRIPT_DIR/analyze-go"
 if [[ -x "$GO_BIN" ]]; then

--- a/configs/.config/mole/bin/completion.sh
+++ b/configs/.config/mole/bin/completion.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fix locale issues.
+export LC_ALL=C
+export LANG=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/configs/.config/mole/bin/status.sh
+++ b/configs/.config/mole/bin/status.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# Fix locale issues.
+export LC_ALL=C
+export LANG=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GO_BIN="$SCRIPT_DIR/status-go"
 if [[ -x "$GO_BIN" ]]; then

--- a/configs/.config/mole/bin/touchid.sh
+++ b/configs/.config/mole/bin/touchid.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# Fix locale issues.
+export LC_ALL=C
+export LANG=C
+
 # Determine script location and source common functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../lib" && pwd)"


### PR DESCRIPTION
Sets LC_ALL and LANG to C in analyze.sh, status.sh, completion.sh, and touchid.sh to avoid locale-related issues, aligning with the existing fixes in scripts like optimize.sh.

========== ELIR ==========
PURPOSE: Set LC_ALL and LANG to C across analyze.sh, status.sh, completion.sh, and touchid.sh to fix locale issues.
SECURITY: Prevents script parsing errors and string manipulation inconsistencies on non-English locales by enforcing the C locale.
FAILS IF: Tools invoked by these scripts strictly require an interactive Unicode-compatible environment rather than POSIX standard behavior.
VERIFY: Ensure the prepended lines `export LC_ALL=C` and `export LANG=C` are correctly positioned at the top of each script and no syntax errors were introduced.
MAINTAIN: New bash scripts in the `bin` directory should continue to export these variables to prevent locale-specific bugs.

---
*PR created automatically by Jules for task [15381127667642775561](https://jules.google.com/task/15381127667642775561) started by @abhimehro*