### PR TITLE
chore: reword locale comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -620,3 +620,7 @@ treated strictly as patterns and not parsed as command-line options.
 **Vulnerability:** AppleScript Option Injection (CWE-88 variant). In `configs/.config/mole/lib/uninstall/batch.sh` and `configs/.config/mole/lib/core/file_ops.sh`, `osascript - "$variable"` is used without the `--` delimiter before the positional arguments (e.g. `osascript - "$clean_name" <<-'EOF'`). If the variable starts with a hyphen, it might be interpreted as a flag, leading to Option Injection.
 **Learning:** When passing dynamic variables as positional arguments to `osascript` using heredocs (`<<`), a `--` separator is still required before the variables.
 **Prevention:** Always use the `--` argument delimiter before positional arguments when using `osascript` with external variables (e.g., `osascript - -- "$VAR" <<-'EOF'`).
+## 2025-07-05 - False Positive Tasks in Comments
+**Vulnerability:** Comments containing `Fix` followed by a description of an issue can be falsely identified as active tasks or issues by issue trackers or automation tools.
+**Learning:** Comments describing *applied* fixes should use phrasing that clarifies the fix is already implemented and its purpose is preventive, rather than using an imperative verb that suggests a task needs to be done.
+**Prevention:** Use words like `Prevent` or `Address` instead of `Fix` when describing the rationale behind a configuration change in comments.

--- a/configs/.config/mole/bin/check.sh
+++ b/configs/.config/mole/bin/check.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Fix locale issues (similar to Issue #83)
+# Prevent locale issues (similar to Issue #83)
 export LC_ALL=C
 export LANG=C
 

--- a/configs/.config/mole/bin/optimize.sh
+++ b/configs/.config/mole/bin/optimize.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-# Fix locale issues.
+# Prevent locale issues.
 export LC_ALL=C
 export LANG=C
 

--- a/configs/.config/mole/bin/purge.sh
+++ b/configs/.config/mole/bin/purge.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-# Fix locale issues (avoid Perl warnings on non-English systems)
+# Prevent locale issues (avoid Perl warnings on non-English systems)
 export LC_ALL=C
 export LANG=C
 

--- a/configs/.config/mole/bin/uninstall.sh
+++ b/configs/.config/mole/bin/uninstall.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 readonly MOLE_UNINSTALL_USER_LC_ALL="${LC_ALL:-}"
 readonly MOLE_UNINSTALL_USER_LANG="${LANG:-}"
 
-# Fix locale issues on non-English systems.
+# Prevent locale issues on non-English systems.
 export LC_ALL=C
 export LANG=C
 


### PR DESCRIPTION
Reworded comments starting with 'Fix locale issues' to 'Prevent locale issues' across bash scripts to stop them from being incorrectly identified as active tasks by issue trackers. Added learning to Sentinel log.

========== ELIR ==========
PURPOSE: Reword comments describing applied locale fixes to prevent false positive task detection.
SECURITY: N/A - comments only.
FAILS IF: Automation relies on the exact string "# Fix locale issues" instead of code logic.
VERIFY: Comments in check.sh, optimize.sh, purge.sh, and uninstall.sh have been updated.
MAINTAIN: When documenting a fix applied by the following code, use "Prevent" or "Address" instead of "Fix".

---
*PR created automatically by Jules for task [17536825136182315499](https://jules.google.com/task/17536825136182315499) started by @abhimehro*