### PR TITLE
chore: reword VPN binding comment to prevent false positive

### DIFF
--- a/windscribe-controld/controld-service-manager.sh
+++ b/windscribe-controld/controld-service-manager.sh
@@ -180,7 +180,7 @@ EOF
 start_vpn_compatible_service() {
 	print_status "Starting VPN-compatible Control D service..."
 
-	# Apply VPN binding fix to current config
+	# Apply VPN-compatible binding to current config
 	apply_vpn_binding_fix "$CONTROLD_CONFIG"
 
 	# Load the VPN-compatible daemon


### PR DESCRIPTION
Reword the comment in `controld-service-manager.sh` to replace the word 'fix', preventing it from being incorrectly flagged by issue scanners.

========== ELIR ==========
PURPOSE: Reworded the inline comment 'Apply VPN binding fix to current config' to 'Apply VPN-compatible binding to current config'.
SECURITY: Remediates a false positive issue scanner alert that incorrectly flagged the comment as an actionable FIXME/TODO due to the keyword "fix". No security logic changed.
FAILS IF: The scanner regex changes to match other words in the comment.
VERIFY: Confirm the false positive scanner no longer flags line 183 of `windscribe-controld/controld-service-manager.sh`.
MAINTAIN: Be cautious with keywords like "fix" or "todo" in comments to avoid triggering automated scanners unnecessarily.

---
*PR created automatically by Jules for task [1086243680181984772](https://jules.google.com/task/1086243680181984772) started by @abhimehro*