### PR TITLE
🎨 Palette: Convert system specs to semantic list

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -296,3 +296,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## $(date "+%Y-%m-%d") - ARIA landmarks on semantic HTML elements
 **Learning:** While named `<section>` elements with an `aria-labelledby` attribute implicitly have the `region` role in modern browsers according to W3C HTML5/ARIA specifications, explicitly defining `role="region"` is a valid, harmless practice that can improve compatibility with older screen readers. However, it's technically redundant in modern contexts and should be weighed against reducing HTML bloat.
 **Action:** When adding semantic HTML elements like `<section>`, prioritize `aria-labelledby` for clear naming. Only add explicit `role="region"` if compatibility with older assistive technologies is a stated requirement for the project.
+## $(date +%Y-%m-%d) - Semantic Lists for Grouped Data
+**Learning:** When displaying grouped key-value data (like system specs) in bash-generated HTML reports, using generic `<div>` elements causes screen readers to read them as disconnected text nodes. This creates a fragmented audio experience.
+**Action:** Convert sequential `<div>` data blocks into semantic `<ul>` and `<li>` lists to provide screen readers with grouping context and item counts.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -470,10 +470,12 @@ generate_performance_report() {
     <main>
     <section class="section" aria-labelledby="sys-info-heading" role="region">
         <h2 id="sys-info-heading"><span aria-hidden="true">💻</span> System Information</h2>
-        <div class="metric">System: $system_info</div>
-        <div class="metric">CPU: $cpu_info</div>
-        <div class="metric">Memory: ${memory_info} GB</div>
-        <div class="metric">Disk: $disk_info</div>
+        <ul aria-labelledby="sys-info-heading">
+            <li class="metric"><strong>System:</strong> $system_info</li>
+            <li class="metric"><strong>CPU:</strong> $cpu_info</li>
+            <li class="metric"><strong>Memory:</strong> ${memory_info} GB</li>
+            <li class="metric"><strong>Disk:</strong> $disk_info</li>
+        </ul>
     </section>
     
     <section class="section" aria-labelledby="perf-metrics-heading" role="region">

--- a/test-ux.sh
+++ b/test-ux.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-# Test file
+echo "Testing HTML reports generation..."
+mkdir -p /tmp/reports
+maintenance/bin/analytics_dashboard.sh --test || true
+maintenance/bin/performance_optimizer.sh --test || true
+ls -al /tmp/reports


### PR DESCRIPTION
* 💡 What: Converted system information metric divs to a semantic unordered list.
* 🎯 Why: Improves screen reader grouping and announces the number of items.
* 📸 Before/After: N/A
* ♿ Accessibility: Added `<ul>` list semantics replacing flat `<div>`s for system info.

---
*PR created automatically by Jules for task [2867344502078694708](https://jules.google.com/task/2867344502078694708) started by @abhimehro*