### PR TITLE
feat(a11y): add empty state for empty media directories (salvages #1547)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -299,3 +299,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## $(date +%Y-%m-%d) - Semantic Lists for Grouped Data
 **Learning:** When displaying grouped key-value data (like system specs) in bash-generated HTML reports, using generic `<div>` elements causes screen readers to read them as disconnected text nodes. This creates a fragmented audio experience.
 **Action:** Convert sequential `<div>` data blocks into semantic `<ul>` and `<li>` lists to provide screen readers with grouping context and item counts.
+
+## 2026-07-09 - Add Empty State for Directory Listings
+**Learning:** Dynamically generated HTML views for directory structures (like media servers) can leave users confused when folders are empty, as the page appears broken or unpopulated. Providing an explicit empty state with an accessible icon and text confirms the directory is intentionally empty, improving confidence.
+**Action:** Always include a visual empty state (e.g., "📭 This folder is empty") when rendering dynamic lists or directories that contain 0 items.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -267,7 +267,15 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             for item in files
             if item
         ]
-        html_parts.extend(items_html)
+        if items_html:
+            html_parts.extend(items_html)
+        else:
+            html_parts.append(
+                '<div style="text-align: center; padding: 40px 20px; color: #666; background: #f9f9f9; border-radius: 8px; margin-top: 20px;">\n'
+                '    <span aria-hidden="true" style="font-size: 2.5em; display: block; margin-bottom: 10px;">📭</span>\n'
+                '    <p style="margin: 0; font-size: 1.1em;">This folder is empty</p>\n'
+                '</div>\n'
+            )
 
         html_parts.append("""
         </body>

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -201,6 +201,16 @@ class TestMediaServerHandler(unittest.TestCase):
             html_sub,
         )
 
+    def test_generate_directory_listing_empty(self):
+        """
+        Test that generate_directory_listing produces a helpful empty state when
+        no files are present in the directory.
+        """
+        html_empty = self.handler.generate_directory_listing([], "/empty-dir")
+
+        self.assertIn("This folder is empty", html_empty)
+        self.assertIn('<span aria-hidden="true"', html_empty)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Salvages the Palette UX intent from PR #1547 without the `.orig` backup artifacts that blocked merge.

**Changes:**
- `media-streaming/archive/scripts/infuse-media-server.py` — empty-directory HTML state with accessible icon
- `tests/test_infuse_media_server.py` — `test_generate_directory_listing_empty`
- `.jules/palette.md` — append-only journal entry

**Verification:** `python3 -m unittest tests.test_infuse_media_server -v` — 6 passed

Closes superseded original: #1547

═══ ELIR ═══
**PURPOSE:** Confirm intentionally empty media folders instead of showing a blank page.
**SECURITY:** No trust-boundary changes; HTML output uses existing escape patterns.
**FAILS IF:** Empty directories render with no user feedback — mitigated by unit test.
**VERIFY:** Run `python3 -m unittest tests.test_infuse_media_server -v`.
**MAINTAIN:** Keep empty-state markup consistent with other Palette-generated HTML patterns.