### PR TITLE
🎨 Palette: Add semantic HTML and ARIA landmarks to media server directory listing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -299,3 +299,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## $(date +%Y-%m-%d) - Semantic Lists for Grouped Data
 **Learning:** When displaying grouped key-value data (like system specs) in bash-generated HTML reports, using generic `<div>` elements causes screen readers to read them as disconnected text nodes. This creates a fragmented audio experience.
 **Action:** Convert sequential `<div>` data blocks into semantic `<ul>` and `<li>` lists to provide screen readers with grouping context and item counts.
+
+## 2026-07-09 - Semantic HTML for Directory Listings
+**Learning:** When generating directory or file listings in HTML (like in python scripts generating directory trees), consecutive `<a>` tags lack grouping and context for screen reader users. Screen readers won't announce the number of files in the directory.
+**Action:** Wrap sequential file links in semantic `<ul>` and `<li>` tags and use `<nav>` with `aria-label` to give screen readers proper context and item count announcements for directory structures.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -226,10 +226,17 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
                 .file:hover, .file:focus-visible {{ background: #f0f0f0; outline: 2px solid #0066cc; outline-offset: -2px; }}
                 .directory {{ font-weight: bold; color: #0066cc; }}
                 .video {{ color: #c04c00; }}
+                ul {{ list-style-type: none; padding-left: 0; margin: 0; }}
+                li {{ margin: 0; padding: 0; }}
             </style>
         </head>
         <body>
-            <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            <header>
+                <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            </header>
+            <main>
+                <nav aria-label="Directory listing">
+                    <ul>
         """]
 
         # Add parent directory link if not root
@@ -238,7 +245,7 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
             # Parent path is constructed safely from split, but escaping is good hygiene
             safe_parent = html.escape(parent)
             html_parts.append(
-                f'<a href="/{safe_parent}" class="file directory"><span aria-hidden="true">\U0001f4c1</span> .. (Parent Directory)</a>\n'
+                f'                        <li><a href="/{safe_parent}" class="file directory"><span aria-hidden="true">\U0001f4c1</span> .. (Parent Directory)</a></li>\n'
             )
 
         # ⚡ Performance: tuple for fast C-level endswith checking
@@ -255,13 +262,13 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         items_html = [
             (
                 (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file directory">'
-                    f'<span aria-hidden="true">\U0001f4c1</span> {html.escape(item)[:-1]}</a>\n'
+                    f'                        <li><a href="/{safe_base_path}{html.escape(item)}" class="file directory">'
+                    f'<span aria-hidden="true">\U0001f4c1</span> {html.escape(item)[:-1]}</a></li>\n'
                 )
                 if item.endswith("/")
                 else (
-                    f'<a href="/{safe_base_path}{html.escape(item)}" class="file video">'
-                    f'<span aria-hidden="true">{"\U0001f3ac" if item.lower().endswith(video_exts) else "\U0001f4c4"}</span> {html.escape(item)}</a>\n'
+                    f'                        <li><a href="/{safe_base_path}{html.escape(item)}" class="file video">'
+                    f'<span aria-hidden="true">{"\U0001f3ac" if item.lower().endswith(video_exts) else "\U0001f4c4"}</span> {html.escape(item)}</a></li>\n'
                 )
             )
             for item in files
@@ -270,6 +277,9 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         html_parts.extend(items_html)
 
         html_parts.append("""
+                    </ul>
+                </nav>
+            </main>
         </body>
         </html>
         """)

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -145,19 +145,19 @@ class TestMediaServerHandler(unittest.TestCase):
 
         # File checks with escaped characters
         self.assertIn(
-            '<a href="/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
+            '<li><a href="/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a></li>',
             html_root,
         )
         self.assertIn(
-            '<a href="/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
+            '<li><a href="/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a></li>',
             html_root,
         )
         self.assertIn(
-            '<a href="/document &amp; file.txt" class="file video"><span aria-hidden="true">\U0001f4c4</span> document &amp; file.txt</a>',
+            '<li><a href="/document &amp; file.txt" class="file video"><span aria-hidden="true">\U0001f4c4</span> document &amp; file.txt</a></li>',
             html_root,
         )
         self.assertIn(
-            '<a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video"><span aria-hidden="true">\U0001f3ac</span> &lt;script&gt;alert(1)&lt;/script&gt;.avi</a>',
+            '<li><a href="/&lt;script&gt;alert(1)&lt;/script&gt;.avi" class="file video"><span aria-hidden="true">\U0001f3ac</span> &lt;script&gt;alert(1)&lt;/script&gt;.avi</a></li>',
             html_root,
         )
 
@@ -187,17 +187,17 @@ class TestMediaServerHandler(unittest.TestCase):
         # Let's check code: parent = "/".join(current_path.rstrip("/").split("/")[:-1]) -> "/Movies & TV"
         # safe_parent = html.escape(parent) -> "/Movies &amp; TV"
         self.assertIn(
-            '<a href="//Movies &amp; TV" class="file directory"><span aria-hidden="true">',
+            '<li><a href="//Movies &amp; TV" class="file directory"><span aria-hidden="true">',
             html_sub,
         )
 
         # Check files in subdirectory (href should append to the escaped base_path)
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a>',
+            '<li><a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/video.mp4" class="file video"><span aria-hidden="true">\U0001f3ac</span> video.mp4</a></li>',
             html_sub,
         )
         self.assertIn(
-            '<a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a>',
+            '<li><a href="//Movies &amp; TV/Action &lt;Sci-Fi&gt;/folder with &lt;tag&gt;/" class="file directory"><span aria-hidden="true">\U0001f4c1</span> folder with &lt;tag&gt;</a></li>',
             html_sub,
         )
 


### PR DESCRIPTION
* 💡 What: Added semantic HTML landmarks (`<header>`, `<main>`, `<nav>`) and structured directory listings into a semantic list (`<ul>`, `<li>`) in the Python media server script.
* 🎯 Why: Consecutive link tags for file items cause screen readers to treat them as disconnected nodes. A semantic list groups items together and provides users with a helpful count of the files in the directory.
* 📸 Before/After: Before: `<a class="file">...</a>`. After: `<nav aria-label="Directory listing"><ul><li><a class="file">...</a></li></ul></nav>`.
* ♿ Accessibility: Improves screen reader navigation context by using `<nav>` and structural lists, allowing users to easily navigate, skip, and understand the size of the directory listing.

---
*PR created automatically by Jules for task [13892750793186034962](https://jules.google.com/task/13892750793186034962) started by @abhimehro*