### PR TITLE
perf(automation): eliminate ThreadPoolExecutor batching latency (salvages #1568)

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -68,9 +68,14 @@ def execute_configured_commands(
     setup_entries = []
     command_entries = []
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    commands = list(configured_commands(section))
+    if not commands:
+        return setup_entries, command_entries
+
+    # ⚡ Bolt Optimization: Increase max_workers to the number of commands (up to a safe limit of 32) to eliminate batching latency without exhausting runner resources
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(commands), 32)) as executor:
         futures = []
-        for bucket_name, item in configured_commands(section):
+        for bucket_name, item in commands:
             timeout = int(item.get("timeout_seconds", 1800))
             future = executor.submit(run_shell_command, item["run"], timeout)
             futures.append((bucket_name, item, future))

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -584,3 +584,7 @@ invocation.
 ## 2026-03-10 - Short-Circuit Expensive Datetime Parsing
 **Learning:** Eager evaluation of `datetime.fromisoformat()` and timezone manipulations inside frequently called functions (like PR categorization loops) creates a massive performance bottleneck due to unnecessary object allocation and parsing overhead.
 **Action:** Always short-circuit expensive datetime operations by placing them behind faster boolean checks (like simple string matching) so they only execute when absolutely required.
+
+## 2026-07-10 - Eliminate ThreadPoolExecutor batching latency
+**Learning:** `concurrent.futures.ThreadPoolExecutor` defaults to `min(32, os.cpu_count() + 4)` workers. For I/O-bound tasks like shelling out multiple concurrent processes, this low default artificial limits concurrency and adds batching latency (e.g. if you have 40 shell commands to run, it takes multiple batches).
+**Action:** Always explicitly set `max_workers` on `ThreadPoolExecutor` for pure I/O or shell dispatch tasks to exactly match the number of jobs (or a high ceiling like 100) to ensure immediate dispatch without batching latency.


### PR DESCRIPTION
## Summary

Salvages Bolt performance optimization from PR #1568 onto current `main` after merge conflict with #1567.

## Changes

- Set `max_workers=min(len(commands), 32)` in `execute_configured_commands`
- Early-return when no commands configured
- Append Bolt journal learning (append-only)

## Verification

```bash
python3 -m py_compile .github/scripts/repository_automation_tasks.py
```

═══ ELIR ═══
PURPOSE: Recover ThreadPoolExecutor concurrency tuning for PR automation shell dispatch after conflict with merged #1567.
SECURITY: Trust-boundary file (`.github/scripts/`); no credential handling changes.
FAILS IF: Worker ceiling exceeds runner capacity or empty-command path regresses.
VERIFY: `python3 -m py_compile .github/scripts/repository_automation_tasks.py`
MAINTAIN: T2 trust-boundary — human review required before merge.