### PR TITLE
fix(tests): resolve missing CONTROLD_REPO in controld_validation test

### DIFF
--- a/tests/test_controld_validation.sh
+++ b/tests/test_controld_validation.sh
@@ -9,6 +9,9 @@ CONTROLD_DIR="$(mktemp -d)"
 export LOG_FILE
 LOG_FILE="$(mktemp)"
 
+export CONTROLD_REPO
+CONTROLD_REPO="$(pwd)"
+
 LIB_FILE="$(mktemp)"
 cp controld-system/scripts/controld-manager "$LIB_FILE"
 


### PR DESCRIPTION
### 📋 Purpose
This PR fixes a failing test in `tests/test_controld_validation.sh`. The test simulates a temporary environment but failed to provide the `CONTROLD_REPO` environment variable, causing the `controld-manager` script to fail when attempting to source shared libraries. This fix exports `CONTROLD_REPO="$(pwd)"` before sourcing the script, ensuring it can locate the libraries correctly.

### 🛡️ Security
No security implications. The change is isolated to a test script and simply configures an environment variable correctly for the test context.

### ⚠️ Failure Modes
- The test previously failed because it created a temporary `/etc/controld` mock environment but didn't tell the script where the root of the repository was.
- Fix: The `CONTROLD_REPO` variable explicitly tells the script where to find `scripts/lib/`.

### ✅ Review Checklist
- [x] Test failure resolved.
- [x] `make test-all` passes locally.
- [x] No unrelated artifacts or temporary files are included in this PR.

### 🔧 Maintenance
When mocking execution contexts for `controld-manager`, always ensure `CONTROLD_REPO` is set if the script is not being run from its expected path relative to the repository root.

---
*PR created automatically by Jules for task [4393494363973152547](https://jules.google.com/task/4393494363973152547) started by @abhimehro*