### PR TITLE
🎨 Palette: Fix screen reader omission of metric values in dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -306,3 +306,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-03-10 - Semantic Lists for Grouped Data
 **Learning:** When generating HTML directory or file listings, using consecutive `<a>` tags causes them to be read as disconnected links by screen readers, lacking grouping context.
 **Action:** Wrap sequential file links in semantic `<ul>` and `<li>` tags (removing default list styling via CSS) and enclose them in a `<nav>` element to provide proper item count announcements and structural context.
+## $(date "+%Y-%m-%d") - ARIA aria-labelledby on Grouped Data Needs Both Label and Value
+**Learning:** When using `aria-labelledby` on a parent element (like a metric card), screen readers will *only* announce the elements explicitly referenced by ID. If you only reference the label's ID, the screen reader will skip reading the actual data value entirely, resulting in an inaccessible experience.
+**Action:** Always ensure that `aria-labelledby` references *both* the label's ID and the value's ID (e.g., `aria-labelledby="label-id value-id"`) when describing grouped UI components that contain a key and a value.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -409,8 +409,8 @@ generate_dashboard() {
         
         <main>
         <ul class="metrics-grid">
-            <li class="metric-card success" role="group" aria-labelledby="health-score-label">
-                <div class="metric-value">${current_health}</div>
+            <li class="metric-card success" role="group" aria-labelledby="health-score-label health-score-value">
+                <div class="metric-value" id="health-score-value">${current_health}</div>
                 <div class="metric-label" id="health-score-label">Health Score</div>
             </li>
 EOF
@@ -425,16 +425,16 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <li class="metric-card" role="group" aria-labelledby="performance-score-label">
-                <div class="metric-value">${avg_performance}</div>
+            <li class="metric-card" role="group" aria-labelledby="performance-score-label performance-score-value">
+                <div class="metric-value" id="performance-score-value">${avg_performance}</div>
                 <div class="metric-label" id="performance-score-label">Performance Score</div>
             </li>
-            <li class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" role="group" aria-labelledby="disk-usage-label">
-                <div class="metric-value">${avg_disk}%</div>
+            <li class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" role="group" aria-labelledby="disk-usage-label disk-usage-value">
+                <div class="metric-value" id="disk-usage-value">${avg_disk}%</div>
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
             </li>
-            <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" role="group" aria-labelledby="total-warnings-label">
-                <div class="metric-value">${total_warnings}</div>
+            <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" role="group" aria-labelledby="total-warnings-label total-warnings-value">
+                <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
             </li>
 EOF


### PR DESCRIPTION
* 💡 What: Updated metric cards in `maintenance/bin/analytics_dashboard.sh` to include both the label and value IDs in their `aria-labelledby` attribute.
* 🎯 Why: Previously, `aria-labelledby` only pointed to the label, causing screen readers to completely skip announcing the actual metric values.
* 📸 Before/After: N/A (Visuals remain the same, accessibility improved)
* ♿ Accessibility: Screen reader users can now hear both the metric's name and its value when navigating through the dashboard cards.

---
*PR created automatically by Jules for task [5735073594931196831](https://jules.google.com/task/5735073594931196831) started by @abhimehro*