### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection (CWE-78) via eval in repair script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -641,3 +641,8 @@ treated strictly as patterns and not parsed as command-line options.
 **Vulnerability:** Option Injection (CWE-88 variant). Found that some scripts using `pkill` for process management did not include the `--` delimiter before the process name argument when other flags were present. For instance, `pkill -f "ctrld"` was changed to `pkill -f -- "ctrld"`. If an attacker controls the variable and starts it with a hyphen, `pkill` may interpret the variable as a command-line flag rather than a positional argument, leading to option injection or unintended execution.
 **Learning:** When invoking `pkill` with dynamic variables from bash, you must explicitly separate options from arguments using the `--` delimiter before positional arguments to prevent them from being parsed as flags.
 **Prevention:** Always use the `--` argument delimiter before positional arguments when using `pkill` with external variables (e.g., `pkill -f -- "ctrld"`).
+
+## 2026-07-15 - Command Injection Risk via eval in Home Directory Resolution
+**Vulnerability:** Found `USER_HOME="${SUDO_USER:+$(eval echo "~$SUDO_USER")}"` in `scripts/repair-controld-keepalive.sh`. This pattern evaluates `SUDO_USER`, allowing arbitrary command execution if an attacker controls `SUDO_USER`.
+**Learning:** Evaluating environment variables like `SUDO_USER` using `eval` for home directory resolution is an unsafe pattern that can lead to arbitrary code execution.
+**Prevention:** Use standard OS tools like `dscl` or `id -P` which do not execute strings directly to resolve paths.

--- a/scripts/repair-controld-keepalive.sh
+++ b/scripts/repair-controld-keepalive.sh
@@ -113,7 +113,13 @@ if [[ -L /etc/controld/ctrld.toml ]]; then
 fi
 
 # Quarantine user-level static free-DNS config that bypasses profile IDs.
-USER_HOME="${SUDO_USER:+$(eval echo "~$SUDO_USER")}"
+# SECURITY: avoid eval command injection.
+if [[ -n "${SUDO_USER:-}" ]]; then
+	USER_HOME=$(dscl . -read "/Users/$SUDO_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}' | head -1 || true)
+	if [[ -z "$USER_HOME" ]]; then
+		USER_HOME=$(id -P "$SUDO_USER" 2>/dev/null | cut -d: -f9 || true)
+	fi
+fi
 USER_HOME="${USER_HOME:-$HOME}"
 STATIC_USER_TOML="$USER_HOME/.config/controld/ctrld.toml"
 if [[ -f $STATIC_USER_TOML ]]; then


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Command injection (CWE-78) via eval of SUDO_USER in scripts/repair-controld-keepalive.sh
* 🎯 Impact: Arbitrary code execution if an attacker controls the SUDO_USER variable.
* 🔧 Fix: Replaced eval with safe system calls (dscl or id -P).
* ✅ Verification: Tested locally via make test-all and verified the output does not contain the eval pattern.

---
*PR created automatically by Jules for task [9980320629886378227](https://jules.google.com/task/9980320629886378227) started by @abhimehro*