### PR TITLE
🎨 Palette: Add semantic section landmarks to Morning Brief HTML

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -569,8 +569,9 @@ def html_ul(items: Iterable[str]) -> str:
     return f"<ul>{''.join(items)}</ul>"
 
 
-def _render_heading(level: int, title: str) -> str:
+def _render_heading(level: int, title: str, id_attr: str = "") -> str:
     safe_title = sanitize_text(title)
+    id_str = f' id="{id_attr}"' if id_attr else ""
 
     # Safely target emojis specifically by checking unicode ranges where emojis reside
     # rather than all non-ASCII characters. This includes Emoticons, Misc Symbols,
@@ -583,18 +584,24 @@ def _render_heading(level: int, title: str) -> str:
         icon = match.group(1)
         clean_title = match.group(2)
         return (
-            f'<h{level}><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
+            f'<h{level}{id_str}><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
         )
 
-    return f"<h{level}>{safe_title}</h{level}>"
+    return f"<h{level}{id_str}>{safe_title}</h{level}>"
 
 
 def html_section(title: str, body: str) -> str:
-    return f"{_render_heading(3, title)}{body}"
+    section_id = re.sub(r'[^a-z0-9]+', '-', sanitize_text(title).lower()).strip('-')
+    if not section_id:
+        section_id = "section"
+    return f'<section role="region" aria-labelledby="{section_id}">\n{_render_heading(3, title, section_id)}\n{body}\n</section>'
 
 
 def html_subsection(title: str, body: str) -> str:
-    return f"{_render_heading(4, title)}{body}"
+    section_id = re.sub(r'[^a-z0-9]+', '-', sanitize_text(title).lower()).strip('-')
+    if not section_id:
+        section_id = "subsection"
+    return f'<section role="region" aria-labelledby="{section_id}">\n{_render_heading(4, title, section_id)}\n{body}\n</section>'
 
 
 # ============================================================

--- a/tests/test_morning_brief.py
+++ b/tests/test_morning_brief.py
@@ -165,25 +165,28 @@ class TestHtmlHelpers(unittest.TestCase):
 
     def test_html_section(self):
         result = mb.html_section("Title", "<p>body</p>")
-        assert "<h3>Title</h3>" in result
+        assert '<section role="region" aria-labelledby="title">' in result
+        assert '<h3 id="title">Title</h3>' in result
         assert "<p>body</p>" in result
 
     def test_html_section_escapes_title(self):
         result = mb.html_section("<script>", "<p>safe</p>")
         assert "<script>" not in result
         assert "&lt;script&gt;" in result
+        assert '<section role="region" aria-labelledby="lt-script-gt">' in result
 
     def test_html_section_with_emoji(self):
         result = mb.html_section("🌅 Good Morning", "<p>body</p>")
-        assert "aria-label" not in result
+        assert "aria-label=" not in result
         assert '<span aria-hidden="true">🌅</span>' in result
+        assert 'id="good-morning"' in result
         assert "Good Morning</h3>" in result
 
     def test_html_section_non_ascii_text(self):
         result = mb.html_section("Café Menu", "<p>body</p>")
-        assert "aria-label" not in result
+        assert "aria-label=" not in result
         assert '<span aria-hidden="true">' not in result
-        assert "<h3>Café Menu</h3>" in result
+        assert '<h3 id="caf-menu">Café Menu</h3>' in result
 
 
 # ============================================================


### PR DESCRIPTION
* 💡 What: Wrapped HTML sections generated in `morning-brief.py` with `<section role="region" aria-labelledby="...">` and added IDs to headings.
* 🎯 Why: To improve screen reader navigation by providing clear semantic landmarks and named regions for discrete content areas.
* 📸 Before/After: N/A
* ♿ Accessibility: Screen reader users can now easily jump between sections and hear contextual announcements for each section.

---
*PR created automatically by Jules for task [14325711132699068534](https://jules.google.com/task/14325711132699068534) started by @abhimehro*