### PR TITLE
🎨 Palette: Improve CLI screen reader accessibility by conditionally disabling ANSI codes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -310,3 +310,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-07-11 - aria-labelledby on composite UI elements
 **Learning:** When using `aria-labelledby` on a composite UI element (such as a metric card) that contains both a textual label and a dynamically generated value, the attribute must reference the IDs of both the label and the value (e.g., `aria-labelledby="label-id value-id"`). Referencing only the label causes screen readers to skip announcing the actual value, breaking accessibility.
 **Action:** Always verify that `aria-labelledby` attributes point to all relevant text and value IDs within composite components so that screen readers announce the full context.
+## 2026-03-31 - Graceful fallback for non-TTY animations
+**Learning:** Hardcoded ANSI color strings (`\x1b[31m`) in CLI tools degrade to unreadable noise in environments without a TTY or in screen readers. This makes CLI error messages and standard output inaccessible.
+**Action:** Always conditionally apply ANSI color formatting by checking if standard output (`process.stdout.isTTY`) or standard error (`process.stderr.isTTY`) supports it. Provide clean, uncolored string fallbacks for screen reader and CI environments.

--- a/copilot-demo/weather-assistant.ts
+++ b/copilot-demo/weather-assistant.ts
@@ -14,8 +14,11 @@ const RESPONSE_INACTIVITY_TIMEOUT_MS = 10000;
 function getRequiredEnvVar(name: RequiredEnvVar): string {
   const value = process.env[name]?.trim();
   if (!value) {
+    const cRed = process.stderr.isTTY ? "\x1b[31m" : "";
+    const cYellow = process.stderr.isTTY ? "\x1b[33m" : "";
+    const cReset = process.stderr.isTTY ? "\x1b[0m" : "";
     throw new Error(
-      `\n\x1b[31m❌ Missing required environment variable: \x1b[33m${name}\x1b[0m\n\n💡 Please set both \x1b[33mAZURE_OPENAI_ENDPOINT\x1b[0m and \x1b[33mAZURE_DEPLOYMENT_NAME\x1b[0m before running this demo.\n`,
+      `\n${cRed}❌ Missing required environment variable: ${cYellow}${name}${cReset}\n\n💡 Please set both ${cYellow}AZURE_OPENAI_ENDPOINT${cReset} and ${cYellow}AZURE_DEPLOYMENT_NAME${cReset} before running this demo.\n`,
     );
   }
 
@@ -41,7 +44,9 @@ function handleRealtimeError(error: OpenAIRealtimeError): void {
     ? safeError.code
     : "UNKNOWN";
 
-  console.error(`\n\x1b[31m⚠️  Realtime Error (${code}):\x1b[0m ${message}\n`);
+  const cRed = process.stderr.isTTY ? "\x1b[31m" : "";
+  const cReset = process.stderr.isTTY ? "\x1b[0m" : "";
+  console.error(`\n${cRed}⚠️  Realtime Error (${code}):${cReset} ${message}\n`);
 }
 
 async function main() {
@@ -186,6 +191,8 @@ main().catch((error: unknown) => {
   const message = error instanceof Error
     ? error.message
     : "Unknown startup failure";
-  console.error(`\n\x1b[31m❌ Startup failed:\x1b[0m ${message}`);
+  const cRed = process.stderr.isTTY ? "\x1b[31m" : "";
+  const cReset = process.stderr.isTTY ? "\x1b[0m" : "";
+  console.error(`\n${cRed}❌ Startup failed:${cReset} ${message}`);
   process.exitCode = 1;
 });


### PR DESCRIPTION
* 💡 What: Conditionally disable ANSI color formatting in standard output and error in weather-assistant.ts.
* 🎯 Why: Hardcoded ANSI color strings degrade to unreadable noise in non-TTY environments and screen readers, making error messages inaccessible.
* 📸 Before/After: N/A
* ♿ Accessibility: Ensures text fallbacks are clean for screen reader compatibility.

---
*PR created automatically by Jules for task [4778850809269301051](https://jules.google.com/task/4778850809269301051) started by @abhimehro*