### PR TITLE
🎨 Palette: Fix accessibility structure for metric cards in analytics dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -310,3 +310,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-07-11 - aria-labelledby on composite UI elements
 **Learning:** When using `aria-labelledby` on a composite UI element (such as a metric card) that contains both a textual label and a dynamically generated value, the attribute must reference the IDs of both the label and the value (e.g., `aria-labelledby="label-id value-id"`). Referencing only the label causes screen readers to skip announcing the actual value, breaking accessibility.
 **Action:** Always verify that `aria-labelledby` attributes point to all relevant text and value IDs within composite components so that screen readers announce the full context.
+
+## $(date +%Y-%m-%d) - HTML List Role Overrides
+**Learning:** Applying `role="group"` to `<li>` elements within a `<ul>` list is a common mistake when trying to associate ARIA labels with the entire list item. Doing so overrides the implicit `listitem` role, creating an invalid semantic structure for the parent `<ul>` and breaking standard list navigation for screen readers.
+**Action:** Do not use `role="group"` on `<li>` tags. Allow them to use their implicit `listitem` role to maintain proper list semantics.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -409,7 +409,7 @@ generate_dashboard() {
         
         <main>
         <ul class="metrics-grid">
-            <li class="metric-card success" role="group" aria-labelledby="health-score-label health-score-value">
+            <li class="metric-card success" aria-labelledby="health-score-label health-score-value">
                 <div class="metric-value" id="health-score-value">${current_health}</div>
                 <div class="metric-label" id="health-score-label">Health Score</div>
             </li>
@@ -425,15 +425,15 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <li class="metric-card" role="group" aria-labelledby="performance-score-label performance-score-value">
+            <li class="metric-card" aria-labelledby="performance-score-label performance-score-value">
                 <div class="metric-value" id="performance-score-value">${avg_performance}</div>
                 <div class="metric-label" id="performance-score-label">Performance Score</div>
             </li>
-            <li class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" role="group" aria-labelledby="disk-usage-label disk-usage-value">
+            <li class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" aria-labelledby="disk-usage-label disk-usage-value">
                 <div class="metric-value" id="disk-usage-value">${avg_disk}%</div>
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
             </li>
-            <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" role="group" aria-labelledby="total-warnings-label total-warnings-value">
+            <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
                 <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
             </li>


### PR DESCRIPTION
* 💡 What: Removed `role="group"` from `<li>` metric cards within the `<ul class="metrics-grid">` list.
* 🎯 Why: Using `role="group"` on a list item overrides its implicit `listitem` role, creating an invalid semantic structure for the parent `<ul>` and breaking navigation for screen readers.
* 📸 Before/After: Before: `<li class="metric-card" role="group" ...>`. After: `<li class="metric-card" ...>`.
* ♿ Accessibility: Restored proper list semantics for screen readers navigating the metrics grid.

---
*PR created automatically by Jules for task [15589065552626418377](https://jules.google.com/task/15589065552626418377) started by @abhimehro*