### PR TITLE
🎨 Palette: Improve metric card accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -317,3 +317,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-03-31 - Graceful fallback for non-TTY animations
 **Learning:** Hardcoded ANSI color strings (`\x1b[31m`) in CLI tools degrade to unreadable noise in environments without a TTY or in screen readers. This makes CLI error messages and standard output inaccessible.
 **Action:** Always conditionally apply ANSI color formatting by checking if standard output (`process.stdout.isTTY`) or standard error (`process.stderr.isTTY`) supports it. Provide clean, uncolored string fallbacks for screen reader and CI environments.
+
+## 2026-07-14 - Avoid list semantics for metric cards
+**Learning:** Wrapping a single label and its corresponding value in an unordered list (`<ul>`/`<li>`) inside composite UI elements like metric cards introduces unnecessary verbosity for screen readers and misuses list semantics.
+**Action:** Prefer `<div>` or `<span>` wrappers, or a description list (`<dl>`), for metric cards to improve screen reader accessibility.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -408,11 +408,11 @@ generate_dashboard() {
         </header>
         
         <main>
-        <ul class="metrics-grid">
-            <li class="metric-card success" aria-labelledby="health-score-label health-score-value">
+        <div class="metrics-grid">
+            <div class="metric-card success" aria-labelledby="health-score-label health-score-value">
                 <div class="metric-value" id="health-score-value">${current_health}</div>
                 <div class="metric-label" id="health-score-label">Health Score</div>
-            </li>
+            </div>
 EOF
 
 	# Add more metric cards based on available data
@@ -425,23 +425,23 @@ EOF
 		total_warnings=$(jq -r '.summary.total_warnings // 0' "$metrics_report")
 
 		cat >>"$dashboard_file" <<EOF
-            <li class="metric-card" aria-labelledby="performance-score-label performance-score-value">
+            <div class="metric-card" aria-labelledby="performance-score-label performance-score-value">
                 <div class="metric-value" id="performance-score-value">${avg_performance}</div>
                 <div class="metric-label" id="performance-score-label">Performance Score</div>
-            </li>
-            <li class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" aria-labelledby="disk-usage-label disk-usage-value">
+            </div>
+            <div class="metric-card $([ "${avg_disk:-0}" -gt 85 ] && echo "warning" || echo "success")" aria-labelledby="disk-usage-label disk-usage-value">
                 <div class="metric-value" id="disk-usage-value">${avg_disk}%</div>
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
-            </li>
-            <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
+            </div>
+            <div class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
                 <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
-            </li>
+            </div>
 EOF
 	fi
 
 	cat >>"$dashboard_file" <<EOF
-        </ul>
+        </div>
         
         <section class="section" aria-labelledby="insights-heading" role="region">
             <h2 id="insights-heading"><span aria-hidden="true">📊</span> System Insights</h2>


### PR DESCRIPTION
* 💡 What: Changed metric card wrappers from `<ul>`/`<li>` to `<div>`.
* 🎯 Why: Unordered lists misuses list semantics for single label-value pairs and introduces unnecessary verbosity for screen readers.
* 📸 Before/After: N/A
* ♿ Accessibility: Improved screen reader navigation by using semantic `<div>` wrappers for composite UI elements.

---
*PR created automatically by Jules for task [17986551913367040174](https://jules.google.com/task/17986551913367040174) started by @abhimehro*