### PR TITLE
⚡ Bolt: Eliminate ThreadPoolExecutor batching latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -608,3 +608,6 @@ invocation.
 ## 2026-11-20 - Ensure ThreadPoolExecutor max_workers is greater than 0
 **Learning:** Python's `ThreadPoolExecutor` strictly enforces that `max_workers` must be greater than 0. If it receives `0` (e.g., when dynamic calculation like `min(len(tasks), 32)` evaluates an empty list), it raises a `ValueError: max_workers must be greater than 0`, causing a crash.
 **Action:** When dynamically calculating `max_workers` based on the length of a list, always ensure it handles the `0` case by using an explicit fallback (e.g., `max_workers=min(len(tasks) or 1, 32)`) to safely process empty inputs without throwing exceptions.
+## 2026-11-20 - Ensure functions aren't overly complex for CodeScene
+**Learning:** The CodeScene code health checker flagged `print_table` in `scripts/get_prs_summarize.py` as having a "Complex Method". To maintain good code health, functions shouldn't have too many responsibilities.
+**Action:** When working on large functions, always try to refactor them into smaller, more focused helper functions to improve maintainability and avoid CodeScene complexity violations.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -602,3 +602,9 @@ invocation.
 ## 2024-07-12 - Eliminate repetitive datetime evaluations inside mapping loops
 **Learning:** Calling `now_utc()` repeatedly inside a mapping loop or list comprehension (such as during PR triage categorization) creates an accumulated bottleneck due to repetitive object allocation and time generation.
 **Action:** Replace `now_utc()` calls inside list comprehensions and iterative generators with a hoisted variable evaluation before the loop (e.g. `_now = now_utc()`) and pass `_now` as an argument to downstream filters to prevent redundant datetime allocations.
+## 2026-11-20 - Eliminate ThreadPoolExecutor batching latency (continued)
+**Learning:** `concurrent.futures.ThreadPoolExecutor` defaults to `min(32, os.cpu_count() + 4)` workers. Setting `max_workers=10` limits concurrency when tasks exceed 10. To allow for faster dispatch of I/O bound tasks, we should set `max_workers=min(len(tasks), 32)`.
+**Action:** When using `concurrent.futures.ThreadPoolExecutor` for I/O bound tasks with a variable number of items, always calculate `max_workers` using `min(len(tasks), 32)` to provide immediate dispatch up to 32 concurrent threads instead of a static smaller limit.
+## 2026-11-20 - Ensure ThreadPoolExecutor max_workers is greater than 0
+**Learning:** Python's `ThreadPoolExecutor` strictly enforces that `max_workers` must be greater than 0. If it receives `0` (e.g., when dynamic calculation like `min(len(tasks), 32)` evaluates an empty list), it raises a `ValueError: max_workers must be greater than 0`, causing a crash.
+**Action:** When dynamically calculating `max_workers` based on the length of a list, always ensure it handles the `0` case by using an explicit fallback (e.g., `max_workers=min(len(tasks) or 1, 32)`) to safely process empty inputs without throwing exceptions.

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -125,7 +125,8 @@ def fetch_pr_info(pr):
     return pr, info
 
 
-with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(ready_prs) or 1, 32)) as executor:
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls while preserving order using map()
     results = executor.map(fetch_pr_info, ready_prs)
 

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -231,7 +231,8 @@ def main():
     now = datetime.now(timezone.utc)
     tasks = [(repo, pr_info, now) for repo, prs in repos.items() for pr_info in prs]
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with ThreadPoolExecutor(max_workers=min(len(tasks) or 1, 32)) as executor:
         for result in executor.map(_categorize_pr_task, tasks):
             if result:
                 category, pr_str = result

--- a/run_merges.py
+++ b/run_merges.py
@@ -70,7 +70,8 @@ def _fetch_pr_data(item):
 def _fetch_all_pr_data_parallel(queue_items):
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR data fetching
     # This mitigates network latency and execution time by querying github concurrently
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(queue_items) or 1, 32)) as executor:
         return list(executor.map(_fetch_pr_data, queue_items))
 
 

--- a/scratch_inventory.py
+++ b/scratch_inventory.py
@@ -37,7 +37,8 @@ def _fetch_repo_prs(repo):
 def fetch_prs(repos):
     all_prs = []
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR fetching
-    with ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with ThreadPoolExecutor(max_workers=min(len(repos) or 1, 32)) as executor:
         for repo_prs in executor.map(_fetch_repo_prs, repos):
             all_prs.extend(repo_prs)
     return all_prs

--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -182,7 +182,8 @@ def _process_pr(pr):
 if __name__ == "__main__":
     all_prs = []
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR fetching
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(repos) or 1, 32)) as executor:
         for repo_prs in executor.map(_fetch_repo_prs, repos):
             all_prs.extend(repo_prs)
 
@@ -204,7 +205,8 @@ if __name__ == "__main__":
     group_prs(all_prs, triage_md)
 
     # Process Actions
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(all_prs) or 1, 32)) as executor:
         for pr, action in executor.map(
             _process_pr, sorted(all_prs, key=lambda x: (x["repo"], -x["number"]))
         ):

--- a/scripts/get_prs_summarize.py
+++ b/scripts/get_prs_summarize.py
@@ -217,7 +217,8 @@ def print_table(data: list, include_details: bool) -> None:
     print("\n#### Review / comment context\n")
 
     tasks = [(repo, pr) for pr in data]
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(tasks) or 1, 32)) as executor:
         # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls while preserving PR order using map()
         results = executor.map(_fetch_task_wrapper, tasks)
 

--- a/scripts/get_prs_summarize.py
+++ b/scripts/get_prs_summarize.py
@@ -173,42 +173,31 @@ def _fetch_task_wrapper(args: tuple[str, dict]) -> tuple[int, str] | None:
     return num, fetch_details(repo, int(num))
 
 
-def print_table(data: list, include_details: bool) -> None:
-    print(
-        "| # | Draft | Title | Author | Branch | Merge | Checks | "
-        "Automation hints | URL |"
-    )
-    print("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
-    for pr in data:
-        author = pr.get("author")
-        login = (author.get("login") if author else None) or "?"
-        draft = "yes" if pr.get("isDraft") else "no"
-        checks = check_summary(pr.get("statusCheckRollup") or [])
-        merge = f"{pr.get('mergeable') or '?'}"
-        mss = pr.get("mergeStateStatus") or ""
-        if mss and mss != "UNKNOWN":
-            merge = f"{merge} ({mss})"
-        print(
-            "| "
-            + " | ".join(
-                [
-                    str(pr.get("number")),
-                    draft,
-                    esc_cell(pr.get("title") or "", 40),
-                    esc_cell(login, 18),
-                    esc_cell(pr.get("headRefName") or "", 28),
-                    esc_cell(merge, 24),
-                    checks,
-                    esc_cell(automation_hints(pr), 56),
-                    esc_cell(pr.get("url") or "", 40),
-                ]
-            )
-            + " |"
-        )
+def _format_pr_row(pr: dict) -> str:
+    author = pr.get("author")
+    login = (author.get("login") if author else None) or "?"
+    draft = "yes" if pr.get("isDraft") else "no"
+    checks = check_summary(pr.get("statusCheckRollup") or [])
+    merge = f"{pr.get('mergeable') or '?'}"
+    mss = pr.get("mergeStateStatus") or ""
+    if mss and mss != "UNKNOWN":
+        merge = f"{merge} ({mss})"
 
-    if not include_details:
-        return
+    row_parts = [
+        str(pr.get("number")),
+        draft,
+        esc_cell(pr.get("title") or "", 40),
+        esc_cell(login, 18),
+        esc_cell(pr.get("headRefName") or "", 28),
+        esc_cell(merge, 24),
+        checks,
+        esc_cell(automation_hints(pr), 56),
+        esc_cell(pr.get("url") or "", 40),
+    ]
+    return "| " + " | ".join(row_parts) + " |"
 
+
+def _print_details_section(data: list) -> None:
     repo = os.environ.get("GH_DETAIL_REPO", "")
     if not repo:
         print("\n_Details skipped: internal error (no repo env)._")
@@ -228,6 +217,19 @@ def print_table(data: list, include_details: bool) -> None:
             print(f"**PR #{num}**\n")
             print(details)
             print()
+
+
+def print_table(data: list, include_details: bool) -> None:
+    print(
+        "| # | Draft | Title | Author | Branch | Merge | Checks | "
+        "Automation hints | URL |"
+    )
+    print("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    for pr in data:
+        print(_format_pr_row(pr))
+
+    if include_details:
+        _print_details_section(data)
 
 
 def main() -> int:


### PR DESCRIPTION
* 💡 What: Replaced static max_workers=10 with max_workers=min(len(tasks) or 1, 32) across concurrent.futures.ThreadPoolExecutor usages in Python API/triage scripts, and added mandatory Bolt optimization comments.
* 🎯 Why: ThreadPoolExecutor limits concurrency. For IO-bound tasks like shelling out multiple concurrent processes (GitHub API calls), a low static limit adds artificial batching latency. Using a dynamic ceiling ensures immediate dispatch, while fallback `or 1` avoids ValueError on empty inputs.
* 📊 Impact: Significantly speeds up execution of automation scripts dealing with large payloads of PRs across repositories by executing requests concurrently instead of in batches of 10.
* 🔬 Measurement: Observe reduced wall-clock time when running PR triage and automation scripts (e.g. parse_inventory.py, scratch_triage.py).

---
*PR created automatically by Jules for task [634123577392472882](https://jules.google.com/task/634123577392472882) started by @abhimehro*