### PR TITLE
🎨 Palette: Add fallback item for empty list in performance report

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -321,3 +321,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-07-14 - Avoid list semantics for metric cards
 **Learning:** Wrapping a single label and its corresponding value in an unordered list (`<ul>`/`<li>`) inside composite UI elements like metric cards introduces unnecessary verbosity for screen readers and misuses list semantics.
 **Action:** Prefer `<div>` or `<span>` wrappers, or a description list (`<dl>`), for metric cards to improve screen reader accessibility.
+## $(date +%Y-%m-%d) - Empty List State Fallbacks
+**Learning:** Dynamically generated HTML lists (`<ul>`) in shell scripts (like `performance_optimizer.sh`) can become completely empty if conditional `<li>` items fail to render, creating invalid HTML structure and confusing screen readers.
+**Action:** Always provide a fallback empty state list item (e.g., `<li class="empty-state">No items found</li>`) when rendering conditional lists to maintain valid HTML5 list semantics and improve accessibility.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -515,9 +515,11 @@ EOF
 EOF
 
 	# Add recommendations based on current state
-	[[ $(echo "$cpu_load > 2" | bc -l) == "1" ]] && echo "            <li>Consider reducing CPU-intensive background tasks</li>" >>"$report_file"
-	[[ $disk_usage -gt 80 ]] && echo "            <li>Disk usage is high - consider cleaning up old files</li>" >>"$report_file"
-	[[ $disk_usage -le 60 ]] && echo "            <li>Disk usage is optimal</li>" >>"$report_file"
+	local has_recs=0
+	[[ $(echo "$cpu_load > 2" | bc -l) == "1" ]] && { echo "            <li>Consider reducing CPU-intensive background tasks</li>" >>"$report_file"; has_recs=1; }
+	[[ $disk_usage -gt 80 ]] && { echo "            <li>Disk usage is high - consider cleaning up old files</li>" >>"$report_file"; has_recs=1; }
+	[[ $disk_usage -le 60 ]] && { echo "            <li>Disk usage is optimal</li>" >>"$report_file"; has_recs=1; }
+	[[ $has_recs -eq 0 ]] && echo "            <li>System performance is optimal - no specific recommendations at this time.</li>" >>"$report_file"
 
 	cat >>"$report_file" <<EOF
         </ul>


### PR DESCRIPTION
* 💡 What: Added a fallback list item when no specific optimization recommendations are generated in the HTML report.
* 🎯 Why: To prevent rendering an empty <ul> element, which breaks HTML structure and provides poor feedback for screen reader users.
* 📸 Before/After: N/A
* ♿ Accessibility: Improved screen reader experience by ensuring the list is never empty, maintaining valid HTML5 list semantics.

---
*PR created automatically by Jules for task [18016441607058207305](https://jules.google.com/task/18016441607058207305) started by @abhimehro*