### PR TITLE
docs(agents): encode PR salvage preferences from continual learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,6 @@ venv/
 *.tfvars
 *.tfvars.*
 
+
+# Continual-learning local incremental index (do not commit)
+.cursor/hooks/state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,3 +506,13 @@ updates a directory when **both** hook files are already present as **regular**
 (non-symlink) files—matching Cursor’s layout—and uses `install -m 0755` so
 symlink destinations are never followed. To target one hash directory:
 `CURSOR_AGENT_HOOKS_DIR=~/.cursor/agent-hooks/<hash> ./scripts/install_cursor_cloud_agent_hooks.sh`.
+
+## Learned User Preferences
+
+- Phase 2 PR salvage must never autonomously merge; open draft salvage or infra-fix PRs and leave merge decisions to a human.
+- Security, auth, secrets, and trust-boundary PRs stay escalated for human review even when CI is green.
+
+## Learned Workspace Facts
+
+- Sibling Bolt/Jules PRs that both touch `.jules/bolt.md` often conflict on the journal only after one merges; salvage remaining source changes and resolve the journal by taking `main`'s `.jules/bolt.md` (Lesson 0cs).
+- Multi-repo cloud PR sessions often leave dirty tracked `seatek_series_correction.egg-info/` files under `series_correction_project_updated` after editable installs; restore or discard those changes and do not commit them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continual-learning pass over recent PR review/salvage cloud sessions. Encodes durable agent preferences into `AGENTS.md` and ignores the local continual-learning index.

## Changes

- **Learned User Preferences:** Phase 2 salvage never autonomously merges; security/auth/secrets/trust-boundary PRs stay human-escalated even when CI is green.
- **Learned Workspace Facts:** Bolt/Jules sibling PRs often conflict only on `.jules/bolt.md` (take `main` journal — Lesson 0cs); do not commit dirty tracked `seatek_series_correction.egg-info/` from editable installs.
- **`.gitignore`:** ignore `.cursor/hooks/state/` (local incremental index).

## Evidence

Mined parent cloud transcripts from the last ~7 days of automated PR review/salvage runs (no Vercel-related content; no new skills/rules beyond AGENTS.md).

## Test plan

- [ ] Skim `## Learned User Preferences` / `## Learned Workspace Facts` for accuracy against salvage policy docs
- [ ] Confirm `.cursor/hooks/state/` remains untracked

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-291ed5fb-e755-417e-86cd-57fc49d6aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-291ed5fb-e755-417e-86cd-57fc49d6aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

