### PR TITLE
🧪 Add tests for process_denylist_files

### DIFF
--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -16,6 +16,7 @@ from adguard.scripts.extract_domains import (
     _is_allowlist_rule,
     extract_allowlist_domains_from_file,
     extract_domains_from_file,
+    process_denylist_files,
 )
 
 
@@ -213,6 +214,45 @@ class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
             self.assertIn(f"Error reading {temp_path}", mock_print.call_args[0][0])
         finally:
             os.remove(temp_path)
+
+
+
+import concurrent.futures
+
+class TestProcessDenylistFiles(unittest.TestCase):
+    def test_happy_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file1 = os.path.join(temp_dir, "CD-Microsoft-Tracker.json")
+            with open(file1, "w", encoding="utf-8") as f:
+                json.dump({"rules": [{"PK": "ms1.com"}, {"PK": "ms2.com"}]}, f)
+
+            file2 = os.path.join(temp_dir, "CD-Apple-Tracker.json")
+            with open(file2, "w", encoding="utf-8") as f:
+                json.dump({"rules": [{"PK": "apple1.com"}]}, f)
+
+            result = process_denylist_files(temp_dir)
+            self.assertEqual(result, {"ms1.com", "ms2.com", "apple1.com"})
+
+    def test_no_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = process_denylist_files(temp_dir)
+            self.assertEqual(result, set())
+
+    @patch("adguard.scripts.extract_domains.concurrent.futures.ProcessPoolExecutor")
+    def test_worker_exception(self, mock_executor_class):
+        # Use a ThreadPoolExecutor so mocking works without pickle issues
+        mock_executor_class.return_value = concurrent.futures.ThreadPoolExecutor()
+
+        with patch("adguard.scripts.extract_domains.extract_domains_from_file") as mock_extract:
+            mock_extract.side_effect = Exception("Mocked exception")
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                file1 = os.path.join(temp_dir, "CD-Microsoft-Tracker.json")
+                with open(file1, "w", encoding="utf-8") as f:
+                    f.write("mock")
+
+                result = process_denylist_files(temp_dir)
+                self.assertEqual(result, set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `process_denylist_files` in `adguard/scripts/extract_domains.py`.
📊 **Coverage:** Tests cover the happy path (combining multiple valid denylist JSONs), the missing/no files scenario, and exception handling when `extract_domains_from_file` fails.
✨ **Result:** Increased test coverage and improved reliability of denylist domain extraction.

---
*PR created automatically by Jules for task [7291818286569862075](https://jules.google.com/task/7291818286569862075) started by @abhimehro*