### PR TITLE
🧪 Add unit tests for run_process in repository_automation_common.py

### DIFF
--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import unittest
+from unittest.mock import patch, MagicMock
 
 # Ensure the scripts directory is in the path
 sys.path.insert(
@@ -55,6 +56,68 @@ class TestTruncate(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertLessEqual(len(result), 4000)
 
+
+
+
+
+class TestRunProcess(unittest.TestCase):
+    def setUp(self):
+        self.original_env = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    @patch("subprocess.run")
+    def test_run_process_basic(self, mock_run):
+        mock_completed = MagicMock()
+        mock_run.return_value = mock_completed
+
+        result = rac.run_process(["echo", "hello"])
+
+        self.assertEqual(result, mock_completed)
+        mock_run.assert_called_once_with(
+            ["echo", "hello"],
+            cwd=rac.ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            input=None,
+            timeout=None,
+            env=rac.command_env(),
+        )
+
+    @patch("subprocess.run")
+    def test_run_process_with_args(self, mock_run):
+        mock_completed = MagicMock()
+        mock_run.return_value = mock_completed
+
+        result = rac.run_process(
+            ["cat"],
+            input_text="hello world",
+            timeout=10,
+            check=True
+        )
+
+        self.assertEqual(result, mock_completed)
+        mock_run.assert_called_once_with(
+            ["cat"],
+            cwd=rac.ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            input="hello world",
+            timeout=10,
+            env=rac.command_env(),
+        )
+
+    def test_run_process_real(self):
+        # Do a real call just to ensure it doesn't crash on a trivial command
+        # if the environment is somewhat sane.
+        if sys.platform != "win32":
+            result = rac.run_process(["echo", "real"])
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout.strip(), "real")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -60,6 +60,7 @@ class TestTruncate(unittest.TestCase):
 
 
 
+
 class TestRunProcess(unittest.TestCase):
     def setUp(self):
         self.original_env = os.environ.copy()
@@ -68,47 +69,38 @@ class TestRunProcess(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self.original_env)
 
-    @patch("subprocess.run")
-    def test_run_process_basic(self, mock_run):
+    def _assert_mock_run(self, mock_run, cmd, **kwargs):
         mock_completed = MagicMock()
         mock_run.return_value = mock_completed
 
-        result = rac.run_process(["echo", "hello"])
+        result = rac.run_process(cmd, **kwargs)
 
         self.assertEqual(result, mock_completed)
         mock_run.assert_called_once_with(
-            ["echo", "hello"],
+            cmd,
             cwd=rac.ROOT,
-            check=False,
+            check=kwargs.get('check', False),
             capture_output=True,
             text=True,
-            input=None,
-            timeout=None,
+            input=kwargs.get('input_text', None),
+            timeout=kwargs.get('timeout', None),
             env=rac.command_env(),
         )
 
     @patch("subprocess.run")
-    def test_run_process_with_args(self, mock_run):
-        mock_completed = MagicMock()
-        mock_run.return_value = mock_completed
+    def test_run_process_scenarios(self, mock_run):
+        # Basic scenario
+        self._assert_mock_run(mock_run, ["echo", "hello"])
 
-        result = rac.run_process(
+        mock_run.reset_mock()
+
+        # Scenario with extra args
+        self._assert_mock_run(
+            mock_run,
             ["cat"],
             input_text="hello world",
             timeout=10,
             check=True
-        )
-
-        self.assertEqual(result, mock_completed)
-        mock_run.assert_called_once_with(
-            ["cat"],
-            cwd=rac.ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-            input="hello world",
-            timeout=10,
-            env=rac.command_env(),
         )
 
     def test_run_process_real(self):


### PR DESCRIPTION
* 🎯 **What:** The run_process function was previously missing tests, making regression tracking for high-level runner functions difficult.
* 📊 **Coverage:** Added basic execution tests verifying the correct arguments are delegated to subprocess.run, including checking custom input parameters like check, input_text, and timeout. Added a real command test (echo) for sanity checking.
* ✨ **Result:** Increased test coverage for the repository_automation_common module, providing a safety net against future refactorings of process execution.

---
*PR created automatically by Jules for task [13851950344174782766](https://jules.google.com/task/13851950344174782766) started by @abhimehro*