### PR TITLE
🧹 Refactor concurrent.futures import in run_merges.py to explicit ThreadPoolExecutor

### DIFF
--- a/run_merges.py
+++ b/run_merges.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import subprocess
@@ -71,7 +71,7 @@ def _fetch_all_pr_data_parallel(queue_items):
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR data fetching
     # This mitigates network latency and execution time by querying github concurrently
     # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(queue_items) or 1, 32)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(queue_items) or 1, 32)) as executor:
         return list(executor.map(_fetch_pr_data, queue_items))
 
 


### PR DESCRIPTION
🎯 **What:** Modified `import concurrent.futures` to `from concurrent.futures import ThreadPoolExecutor`.
💡 **Why:** Makes the dependency explicit, satisfies static analysis flagging an unused root module import, and preserves the parallel PR fetching functionality.
✅ **Verification:** Verified by checking `git diff`, ensuring the script doesn't fail with a NameError, and running the full test suite (`make test-all`).
✨ **Result:** Improved code clarity and removed the linting warning while maintaining functionality.

---
*PR created automatically by Jules for task [17066060507086700598](https://jules.google.com/task/17066060507086700598) started by @abhimehro*