### PR TITLE
🧪 [testing improvement] Add tests for process_allowlist_files

### DIFF
--- a/.submit_details.json
+++ b/.submit_details.json
@@ -1,4 +1,5 @@
 {
-  "title": "🛡️ Sentinel: [Low] Fix false positive FIX comment and improve symlink handling",
-  "description": "🚨 Severity: Low\n💡 Vulnerability: Broken symlinks were not correctly identified as existing lock files by `[[ -e $LOCK_DIR ]]`, falling through to an inaccurate error message.\n🎯 Impact: Improved robustness of the lock acquisition mechanism to properly detect broken symlink locks and display accurate error messages.\n🔧 Fix: Updated the existence check to `[[ -e $LOCK_DIR || -L $LOCK_DIR ]]` to cover broken symlinks and marked the Sentinel FIX comment as Fixed.\n✅ Verification: Tested lock creation with regular files, broken symlinks, and directory symlinks, confirming that the script now consistently identifies them and prevents execution."
+  "branch_name": "testing-improvement-allowlist-files",
+  "pr_title": "🧪 [testing improvement] Add tests for process_allowlist_files",
+  "pr_body": "* 🎯 **What:** The testing gap in process_allowlist_files within adguard/scripts/extract_domains.py was addressed.\n* 📊 **Coverage:** The scenarios covered include when both bypass and most abused TLDs files are present, when only bypass is present, and when no files are present.\n* ✨ **Result:** The test coverage was improved, ensuring that domain extracting logic handles multiple allowlist file presence properly."
 }

--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -16,6 +16,7 @@ from adguard.scripts.extract_domains import (
     _is_allowlist_rule,
     extract_allowlist_domains_from_file,
     extract_domains_from_file,
+    process_allowlist_files,
 )
 
 
@@ -217,3 +218,34 @@ class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestProcessAllowlistFiles(unittest.TestCase):
+    @patch("builtins.print")
+    def test_process_allowlist_files_all_exist(self, mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bypass_data = json.dumps({"rules": [{"PK": "bypass.com", "action": {"do": 1}}]})
+            with open(os.path.join(temp_dir, "CD-Control-D-Bypass.json"), "w") as f:
+                f.write(bypass_data)
+
+            tlds_data = json.dumps({"rules": [{"PK": "tld.com", "action": {"do": 1}}]})
+            with open(os.path.join(temp_dir, "CD-Most-Abused-TLDs.json"), "w") as f:
+                f.write(tlds_data)
+
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, {"bypass.com", "tld.com"})
+
+    @patch("builtins.print")
+    def test_process_allowlist_files_missing_file(self, mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bypass_data = json.dumps({"rules": [{"PK": "bypass.com", "action": {"do": 1}}]})
+            with open(os.path.join(temp_dir, "CD-Control-D-Bypass.json"), "w") as f:
+                f.write(bypass_data)
+
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, {"bypass.com"})
+
+    @patch("builtins.print")
+    def test_process_allowlist_files_no_files(self, mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, set())


### PR DESCRIPTION
* 🎯 **What:** The testing gap in process_allowlist_files within adguard/scripts/extract_domains.py was addressed.
* 📊 **Coverage:** The scenarios covered include when both bypass and most abused TLDs files are present, when only bypass is present, and when no files are present.
* ✨ **Result:** The test coverage was improved, ensuring that domain extracting logic handles multiple allowlist file presence properly.

---
*PR created automatically by Jules for task [15621576340847785348](https://jules.google.com/task/15621576340847785348) started by @abhimehro*