### PR TITLE
🧹 [code health] Refactor concurrent.futures import

### DIFF
--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
 import datetime
 import json
 import subprocess
@@ -183,7 +183,7 @@ if __name__ == "__main__":
     all_prs = []
     # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR fetching
     # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(repos) or 1, 32)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(repos) or 1, 32)) as executor:
         for repo_prs in executor.map(_fetch_repo_prs, repos):
             all_prs.extend(repo_prs)
 
@@ -206,7 +206,7 @@ if __name__ == "__main__":
 
     # Process Actions
     # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(all_prs) or 1, 32)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(all_prs) or 1, 32)) as executor:
         for pr, action in executor.map(
             _process_pr, sorted(all_prs, key=lambda x: (x["repo"], -x["number"]))
         ):


### PR DESCRIPTION
🎯 What: Changed `import concurrent.futures` to `from concurrent.futures import ThreadPoolExecutor` and updated usage.
💡 Why: Improves readability and aligns with codebase patterns, resolving static analysis confusion regarding unused imports.
✅ Verification: Verified syntax and checked via local tests.
✨ Result: Cleaner code health.

---
*PR created automatically by Jules for task [6133971568541445600](https://jules.google.com/task/6133971568541445600) started by @abhimehro*