### PR TITLE
🧪 Add tests for run_safe_adjustment_commands

### DIFF
--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -19,6 +19,7 @@ sys.path.append(
 from repository_automation_tasks import (  # noqa: E402
     apply_workflow_updates,
     configured_commands,
+    run_safe_adjustment_commands,
 )
 
 
@@ -107,6 +108,61 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
         self.assertIn("actions/checkout@v4", result)
         self.assertIn("actions/upload-artifact@v5", result)
 
+
+
+
+from unittest.mock import patch
+
+class TestRunSafeAdjustmentCommands(unittest.TestCase):
+    @patch("repository_automation_tasks.writes_allowed")
+    def test_writes_not_allowed(self, mock_writes):
+        mock_writes.return_value = False
+        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": True})
+        self.assertEqual(res, [])
+        self.assertEqual(url, "")
+
+    @patch("repository_automation_tasks.writes_allowed")
+    def test_auto_apply_disabled(self, mock_writes):
+        mock_writes.return_value = True
+        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": False})
+        self.assertEqual(res, [])
+        self.assertEqual(url, "")
+
+    @patch("repository_automation_tasks.writes_allowed")
+    @patch("repository_automation_tasks.run_shell_command")
+    @patch("repository_automation_tasks.git_output")
+    def test_no_changes(self, mock_git, mock_shell, mock_writes):
+        mock_writes.return_value = True
+        mock_shell.return_value = {"exit_code": 0}
+        mock_git.return_value = ""
+        section = {
+            "auto_apply_safe_changes": True,
+            "safe_adjustment_commands": [{"name": "cmd", "run": "echo 1"}],
+        }
+        res, url = run_safe_adjustment_commands(section)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "cmd")
+        self.assertEqual(url, "")
+
+    @patch("repository_automation_tasks.writes_allowed")
+    @patch("repository_automation_tasks.run_shell_command")
+    @patch("repository_automation_tasks.git_output")
+    @patch("repository_automation_tasks._cached_matches_any")
+    @patch("repository_automation_tasks.create_pr_for_current_changes")
+    def test_changes_applied(self, mock_pr, mock_matches, mock_git, mock_shell, mock_writes):
+        mock_writes.return_value = True
+        mock_shell.return_value = {"exit_code": 0}
+        mock_git.return_value = " M .github/workflows/main.yml\n"
+        mock_matches.return_value = True
+        mock_pr.return_value = "http://pr-url"
+        section = {
+            "auto_apply_safe_changes": True,
+            "safe_adjustment_commands": [{"name": "cmd", "run": "echo 1"}],
+        }
+        res, url = run_safe_adjustment_commands(section)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "cmd")
+        self.assertEqual(url, "http://pr-url")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -114,52 +114,38 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
 from unittest.mock import patch
 
 class TestRunSafeAdjustmentCommands(unittest.TestCase):
-    @patch("repository_automation_tasks.writes_allowed")
-    def test_writes_not_allowed(self, mock_writes):
-        mock_writes.return_value = False
-        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": True})
-        self.assertEqual(res, [])
-        self.assertEqual(url, "")
-
-    @patch("repository_automation_tasks.writes_allowed")
-    def test_auto_apply_disabled(self, mock_writes):
-        mock_writes.return_value = True
-        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": False})
-        self.assertEqual(res, [])
-        self.assertEqual(url, "")
-
-    @patch("repository_automation_tasks.writes_allowed")
-    @patch("repository_automation_tasks.run_shell_command")
-    @patch("repository_automation_tasks.git_output")
-    def test_no_changes(self, mock_git, mock_shell, mock_writes):
-        mock_writes.return_value = True
-        mock_shell.return_value = {"exit_code": 0}
-        mock_git.return_value = ""
-        section = {
+    def setUp(self):
+        self.section = {
             "auto_apply_safe_changes": True,
             "safe_adjustment_commands": [{"name": "cmd", "run": "echo 1"}],
         }
-        res, url = run_safe_adjustment_commands(section)
+
+    @patch("repository_automation_tasks.writes_allowed", return_value=False)
+    def test_writes_not_allowed(self, mock_writes):
+        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": True})
+        self.assertEqual((res, url), ([], ""))
+
+    @patch("repository_automation_tasks.writes_allowed", return_value=True)
+    def test_auto_apply_disabled(self, mock_writes):
+        res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": False})
+        self.assertEqual((res, url), ([], ""))
+
+    @patch("repository_automation_tasks.writes_allowed", return_value=True)
+    @patch("repository_automation_tasks.run_shell_command", return_value={"exit_code": 0})
+    @patch("repository_automation_tasks.git_output", return_value="")
+    def test_no_changes(self, mock_git, mock_shell, mock_writes):
+        res, url = run_safe_adjustment_commands(self.section)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "cmd")
         self.assertEqual(url, "")
 
-    @patch("repository_automation_tasks.writes_allowed")
-    @patch("repository_automation_tasks.run_shell_command")
-    @patch("repository_automation_tasks.git_output")
-    @patch("repository_automation_tasks._cached_matches_any")
-    @patch("repository_automation_tasks.create_pr_for_current_changes")
+    @patch("repository_automation_tasks.writes_allowed", return_value=True)
+    @patch("repository_automation_tasks.run_shell_command", return_value={"exit_code": 0})
+    @patch("repository_automation_tasks.git_output", return_value=" M .github/workflows/main.yml\n")
+    @patch("repository_automation_tasks._cached_matches_any", return_value=True)
+    @patch("repository_automation_tasks.create_pr_for_current_changes", return_value="http://pr-url")
     def test_changes_applied(self, mock_pr, mock_matches, mock_git, mock_shell, mock_writes):
-        mock_writes.return_value = True
-        mock_shell.return_value = {"exit_code": 0}
-        mock_git.return_value = " M .github/workflows/main.yml\n"
-        mock_matches.return_value = True
-        mock_pr.return_value = "http://pr-url"
-        section = {
-            "auto_apply_safe_changes": True,
-            "safe_adjustment_commands": [{"name": "cmd", "run": "echo 1"}],
-        }
-        res, url = run_safe_adjustment_commands(section)
+        res, url = run_safe_adjustment_commands(self.section)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "cmd")
         self.assertEqual(url, "http://pr-url")

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -121,19 +121,19 @@ class TestRunSafeAdjustmentCommands(unittest.TestCase):
         }
 
     @patch("repository_automation_tasks.writes_allowed", return_value=False)
-    def test_writes_not_allowed(self, mock_writes):
+    def test_writes_not_allowed(self, *mocks):
         res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": True})
         self.assertEqual((res, url), ([], ""))
 
     @patch("repository_automation_tasks.writes_allowed", return_value=True)
-    def test_auto_apply_disabled(self, mock_writes):
+    def test_auto_apply_disabled(self, *mocks):
         res, url = run_safe_adjustment_commands({"auto_apply_safe_changes": False})
         self.assertEqual((res, url), ([], ""))
 
     @patch("repository_automation_tasks.writes_allowed", return_value=True)
     @patch("repository_automation_tasks.run_shell_command", return_value={"exit_code": 0})
     @patch("repository_automation_tasks.git_output", return_value="")
-    def test_no_changes(self, mock_git, mock_shell, mock_writes):
+    def test_no_changes(self, *mocks):
         res, url = run_safe_adjustment_commands(self.section)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "cmd")
@@ -144,7 +144,7 @@ class TestRunSafeAdjustmentCommands(unittest.TestCase):
     @patch("repository_automation_tasks.git_output", return_value=" M .github/workflows/main.yml\n")
     @patch("repository_automation_tasks._cached_matches_any", return_value=True)
     @patch("repository_automation_tasks.create_pr_for_current_changes", return_value="http://pr-url")
-    def test_changes_applied(self, mock_pr, mock_matches, mock_git, mock_shell, mock_writes):
+    def test_changes_applied(self, *mocks):
         res, url = run_safe_adjustment_commands(self.section)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "cmd")


### PR DESCRIPTION
🎯 What: The `run_safe_adjustment_commands` function in `.github/scripts/repository_automation_tasks.py` acts as a high-level orchestrator and previously lacked unit test coverage.
📊 Coverage: Added mock-based test cases to cover:
* Early returns when writes are disallowed.
* Early returns when `auto_apply_safe_changes` is disabled.
* Execution resulting in no code changes (empty git output).
* Execution resulting in code changes and PR generation (mocking `create_pr_for_current_changes` and `git_output`).
✨ Result: Increased test suite reliability by ensuring these workflow adjustment commands behave deterministically.

---
*PR created automatically by Jules for task [18019509427579788660](https://jules.google.com/task/18019509427579788660) started by @abhimehro*