### PR TITLE
🧪 [Test] Add unit tests for run_quality_assurance

### DIFF
--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -112,48 +112,44 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
 class TestRunQualityAssurance(unittest.TestCase):
     @patch("repository_automation_tasks.run_command_set")
     @patch("repository_automation_tasks.write_result")
-    def test_run_quality_assurance(self, mock_write_result, mock_run_command_set):
-        config = {"quality_assurance": {"commands": [{"run": "echo test"}]}}
-        mock_run_command_set.return_value = (
-            "success",
-            "1 passed",
-            {"body": "test output", "command_results": [{"cmd": "echo test", "exit": 0}]}
-        )
-        mock_write_result.return_value = {"status": "success"}
+    def test_run_quality_assurance_cases(self, mock_write_result, mock_run_command_set):
+        cases = [
+            (
+                "with_config",
+                {"quality_assurance": {"commands": [{"run": "echo test"}]}},
+                {"commands": [{"run": "echo test"}]},
+                [{"cmd": "echo test", "exit": 0}],
+            ),
+            (
+                "default_config",
+                {},
+                {},
+                [],
+            ),
+        ]
 
-        result = run_quality_assurance(config)
+        for name, config, expected_arg, command_results in cases:
+            with self.subTest(name=name):
+                mock_run_command_set.reset_mock()
+                mock_write_result.reset_mock()
 
-        mock_run_command_set.assert_called_once_with(
-            "quality-assurance", {"commands": [{"run": "echo test"}]}
-        )
-        mock_write_result.assert_called_once_with(
-            "quality-assurance",
-            ("success", "1 passed"),
-            "test output",
-            {"command_results": [{"cmd": "echo test", "exit": 0}]}
-        )
-        self.assertEqual(result, {"status": "success"})
+                mock_run_command_set.return_value = (
+                    "success",
+                    "1 passed",
+                    {"body": "test output", "command_results": command_results}
+                )
+                mock_write_result.return_value = {"status": "success"}
 
-    @patch("repository_automation_tasks.run_command_set")
-    @patch("repository_automation_tasks.write_result")
-    def test_run_quality_assurance_default_config(self, mock_write_result, mock_run_command_set):
-        mock_run_command_set.return_value = (
-            "success",
-            "1 passed",
-            {"body": "test output", "command_results": []}
-        )
-        mock_write_result.return_value = {"status": "success"}
+                result = run_quality_assurance(config)
 
-        result = run_quality_assurance({})
-
-        mock_run_command_set.assert_called_once_with("quality-assurance", {})
-        mock_write_result.assert_called_once_with(
-            "quality-assurance",
-            ("success", "1 passed"),
-            "test output",
-            {"command_results": []}
-        )
-        self.assertEqual(result, {"status": "success"})
+                mock_run_command_set.assert_called_once_with("quality-assurance", expected_arg)
+                mock_write_result.assert_called_once_with(
+                    "quality-assurance",
+                    ("success", "1 passed"),
+                    "test output",
+                    {"command_results": command_results}
+                )
+                self.assertEqual(result, {"status": "success"})
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Stub out the optional third-party `yaml` dependency so this test remains
 # stdlib-only (per AGENTS.md / CONTRIBUTING.md: tests must not require pip
@@ -19,6 +19,7 @@ sys.path.append(
 from repository_automation_tasks import (  # noqa: E402
     apply_workflow_updates,
     configured_commands,
+    run_quality_assurance,
 )
 
 
@@ -106,6 +107,53 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
         plan["path"].unlink()
         self.assertIn("actions/checkout@v4", result)
         self.assertIn("actions/upload-artifact@v5", result)
+
+
+class TestRunQualityAssurance(unittest.TestCase):
+    @patch("repository_automation_tasks.run_command_set")
+    @patch("repository_automation_tasks.write_result")
+    def test_run_quality_assurance(self, mock_write_result, mock_run_command_set):
+        config = {"quality_assurance": {"commands": [{"run": "echo test"}]}}
+        mock_run_command_set.return_value = (
+            "success",
+            "1 passed",
+            {"body": "test output", "command_results": [{"cmd": "echo test", "exit": 0}]}
+        )
+        mock_write_result.return_value = {"status": "success"}
+
+        result = run_quality_assurance(config)
+
+        mock_run_command_set.assert_called_once_with(
+            "quality-assurance", {"commands": [{"run": "echo test"}]}
+        )
+        mock_write_result.assert_called_once_with(
+            "quality-assurance",
+            ("success", "1 passed"),
+            "test output",
+            {"command_results": [{"cmd": "echo test", "exit": 0}]}
+        )
+        self.assertEqual(result, {"status": "success"})
+
+    @patch("repository_automation_tasks.run_command_set")
+    @patch("repository_automation_tasks.write_result")
+    def test_run_quality_assurance_default_config(self, mock_write_result, mock_run_command_set):
+        mock_run_command_set.return_value = (
+            "success",
+            "1 passed",
+            {"body": "test output", "command_results": []}
+        )
+        mock_write_result.return_value = {"status": "success"}
+
+        result = run_quality_assurance({})
+
+        mock_run_command_set.assert_called_once_with("quality-assurance", {})
+        mock_write_result.assert_called_once_with(
+            "quality-assurance",
+            ("success", "1 passed"),
+            "test output",
+            {"command_results": []}
+        )
+        self.assertEqual(result, {"status": "success"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `run_quality_assurance` function in `github/scripts/repository_automation_tasks.py`, covering a missing testing gap.
📊 **Coverage:** Tests verify the `run_quality_assurance` function processes its configuration mapping, invokes `run_command_set`, and writes the correct formatted result via `write_result`, covering both the happy path with commands and the default empty-config fallback path.
✨ **Result:** Test coverage for the automation script is improved, adding safety nets around the high-level quality assurance runner function so that refactoring of the command glue can proceed with confidence.

---
*PR created automatically by Jules for task [1520077359086475627](https://jules.google.com/task/1520077359086475627) started by @abhimehro*