### PR TITLE
🧪 testing: Add tests for execute_configured_commands

### DIFF
--- a/tasks/handoff.md
+++ b/tasks/handoff.md
@@ -1,6 +1,6 @@
 ========== ELIR ==========
-PURPOSE: Optimized the `extract_status_markers` function in `.github/scripts/repository_automation_tasks.py` by extracting the static regular expression and compiling it at the module level using `re.compile(..., re.S)`. This avoids redundant regex compilation on each function call.
-SECURITY: No direct security implications; strictly a performance optimization for text parsing. Assumes `issue_body` is a string (checked by type hinting).
-FAILS IF: The regex syntax was somehow altered, but it was verified to be identical to the original inline regex.
-VERIFY: Check that the compiled regex correctly extracts status markers from test data (verified via `make test-all`).
-MAINTAIN: If the marker format changes (e.g., from `<!-- repository-automation:task-status\n(.*?)\n-->`), update `_STATUS_MARKER_RE` at the module level.
+PURPOSE: Added comprehensive unit tests for `execute_configured_commands` in `repository_automation_tasks.py` which aggregates logic across multithreaded shell execution.
+SECURITY: N/A - Unit test addition. Testing ensures correct behavior of optional vs required logic handling.
+FAILS IF: Shell mocking fails or unexpected properties appear on mocked config structures.
+VERIFY: Check `tests/test_repository_automation_tasks.py` for new assertions handling timeouts and bucket assignments correctly.
+MAINTAIN: New logic branches added to `execute_configured_commands` must have corresponding test scenarios added here.

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -108,5 +108,48 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
         self.assertIn("actions/upload-artifact@v5", result)
 
 
+
+class TestExecuteConfiguredCommands(unittest.TestCase):
+    @unittest.mock.patch("repository_automation_tasks.run_shell_command")
+    def test_execute_configured_commands_success(self, mock_run_shell_command):
+        mock_run_shell_command.side_effect = lambda cmd, timeout: {
+            "exit_code": 0,
+            "stdout": f"ran {cmd}",
+            "stderr": ""
+        }
+
+        section = {
+            "setup_commands": [
+                {"name": "Setup A", "run": "setup_a"}
+            ],
+            "commands": [
+                {"name": "Cmd B", "run": "cmd_b", "timeout_seconds": 60, "optional": True}
+            ]
+        }
+
+        from repository_automation_tasks import execute_configured_commands
+        setup_entries, command_entries = execute_configured_commands(section)
+
+        self.assertEqual(len(setup_entries), 1)
+        self.assertEqual(setup_entries[0]["name"], "Setup A")
+        self.assertEqual(setup_entries[0]["exit_code"], 0)
+        self.assertEqual(setup_entries[0]["stdout"], "ran setup_a")
+        self.assertEqual(setup_entries[0]["optional"], False)
+
+        self.assertEqual(len(command_entries), 1)
+        self.assertEqual(command_entries[0]["name"], "Cmd B")
+        self.assertEqual(command_entries[0]["exit_code"], 0)
+        self.assertEqual(command_entries[0]["stdout"], "ran cmd_b")
+        self.assertEqual(command_entries[0]["optional"], True)
+
+        mock_run_shell_command.assert_any_call("setup_a", 1800)
+        mock_run_shell_command.assert_any_call("cmd_b", 60)
+
+    def test_execute_configured_commands_empty(self):
+        from repository_automation_tasks import execute_configured_commands
+        setup_entries, command_entries = execute_configured_commands({})
+        self.assertEqual(setup_entries, [])
+        self.assertEqual(command_entries, [])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for `execute_configured_commands` in `repository_automation_tasks.py` which is responsible for parallel execution of automation tasks.
📊 **Coverage:** The scenarios now tested include successful shell command execution parsing into separate setup and command entries, correctly retaining the `optional` flag, and handling an empty commands section correctly.
✨ **Result:** Increased code coverage and confidence against regressions in the core automation logic.

---
*PR created automatically by Jules for task [8238795573653933216](https://jules.google.com/task/8238795573653933216) started by @abhimehro*