### PR TITLE
🧹 Refactor http.server import to resolve static analysis warnings

### DIFF
--- a/media-streaming/archive/scripts/alldebrid-server.py
+++ b/media-streaming/archive/scripts/alldebrid-server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import base64
-import http.server
+from http.server import SimpleHTTPRequestHandler
 import os
 import secrets
 import socketserver
@@ -17,7 +17,7 @@ AUTH_PASS = None
 EXPECTED_AUTH_TOKEN = None
 
 
-class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+class CustomHTTPRequestHandler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=MOUNT_DIR, **kwargs)
 

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -3,7 +3,7 @@
 import argparse
 import base64
 import html
-import http.server
+from http.server import SimpleHTTPRequestHandler
 import os
 import secrets
 import socketserver
@@ -22,7 +22,7 @@ EXPECTED_AUTH_TOKEN = None
 FAILED_AUTH_ATTEMPTS = {}
 
 
-class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
+class MediaServerHandler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         self.rclone_remote = "media:"
         super().__init__(*args, **kwargs)
@@ -33,7 +33,6 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
         super().do_HEAD()
 
     def check_auth(self):
-        global AUTH_USER, AUTH_PASS, EXPECTED_AUTH_TOKEN, FAILED_AUTH_ATTEMPTS
 
         if not AUTH_USER or not AUTH_PASS:
             return True
@@ -85,7 +84,6 @@ class MediaServerHandler(http.server.SimpleHTTPRequestHandler):
 
     def _record_auth_failure(self, ip, now):
         """Helper to record failed auth attempts for rate limiting."""
-        global FAILED_AUTH_ATTEMPTS
         if ip not in FAILED_AUTH_ATTEMPTS:
             FAILED_AUTH_ATTEMPTS[ip] = {"count": 0, "last_attempt": now}
         FAILED_AUTH_ATTEMPTS[ip]["count"] += 1

--- a/tests/test_http_response_splitting.py
+++ b/tests/test_http_response_splitting.py
@@ -97,7 +97,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -138,7 +138,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
 
         # Mock super().end_headers() to prevent actual header sending
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -180,7 +180,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -218,7 +218,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -258,7 +258,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -297,7 +297,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 
@@ -351,7 +351,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
         handler.send_header = track_headers
 
         with patch.object(
-            alldebrid_server.http.server.SimpleHTTPRequestHandler, "end_headers"
+            alldebrid_server.SimpleHTTPRequestHandler, "end_headers"
         ):
             handler.end_headers()
 


### PR DESCRIPTION
* 🎯 **What:** Changed `import http.server` to `from http.server import SimpleHTTPRequestHandler` and updated class definitions. Also removed unused `global` declarations that were triggering `flake8` warnings.
* 💡 **Why:** Static analysis tools flagged `import http.server` as unused. Instead of completely deleting it (which caused a `NameError` since `http.server.SimpleHTTPRequestHandler` was in use), updating the import explicitly imports the required class. Removing the unused globals cleans up dead code.
* ✅ **Verification:** Ran `flake8` and confirmed no more `unused import` or `unused global` warnings. Ran the full python and shell test suite (`make test-all`) and confirmed that `tests/test_http_response_splitting.py` passes successfully with the updated patching path.
* ✨ **Result:** Improved static analysis compliance and code readability without changing the underlying behavior.

---
*PR created automatically by Jules for task [13433486146734437518](https://jules.google.com/task/13433486146734437518) started by @abhimehro*