### PR TITLE
🧹 Refactor extract_domains.py to sequential loop and remove concurrent.futures

### DIFF
--- a/adguard/scripts/extract_domains.py
+++ b/adguard/scripts/extract_domains.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 from pathlib import Path
 import json
 import os
@@ -74,18 +73,13 @@ def process_denylist_files(base_dir):
         for f in tracker_files
         if os.path.exists(os.path.join(base_dir, f))
     ]
-    with concurrent.futures.ProcessPoolExecutor() as executor:
-        future_to_file = {
-            executor.submit(extract_domains_from_file, path): path for path in filepaths
-        }
-        for future in concurrent.futures.as_completed(future_to_file):
-            filepath = future_to_file[future]
-            try:
-                domains = future.result()
-                denylist_domains.update(domains)
-                print(f"{os.path.basename(filepath)}: {len(domains)} domains")
-            except Exception as exc:
-                print(f"{os.path.basename(filepath)} generated an exception: {exc}")
+    for filepath in filepaths:
+        try:
+            domains = extract_domains_from_file(filepath)
+            denylist_domains.update(domains)
+            print(f"{os.path.basename(filepath)}: {len(domains)} domains")
+        except Exception as exc:
+            print(f"{os.path.basename(filepath)} generated an exception: {exc}")
 
     print(f"\nTotal denylist domains: {len(denylist_domains)}")
     return denylist_domains


### PR DESCRIPTION
🎯 **What:** Removed the `concurrent.futures` import and replaced the `ProcessPoolExecutor` with a sequential `for` loop in `adguard/scripts/extract_domains.py`.
💡 **Why:** Reduces overhead for processing small local JSON files, eliminating the unnecessary dependency and simplifying the code structure for better maintainability and readability.
✅ **Verification:** Verified that the python script runs successfully after the refactor. Installed `pyyaml` and `pytest` for testing. Note: local python test suite has unrelated failures.
✨ **Result:** A cleaner, sequential script that achieves the same functionality with less complexity and no unneeded module dependencies.

---
*PR created automatically by Jules for task [14203448759887350190](https://jules.google.com/task/14203448759887350190) started by @abhimehro*