### PR TITLE
perf: tuple fallbacks in PR parsing helpers (salvages #1623)

### DIFF
--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -52,7 +52,7 @@ def _process_pr_result(res, file_groups):
         return
     repo, info = res
     # ⚡ Bolt Optimization: Removed intermediate dictionary wrappers to allow direct sorting of strings
-    files = tuple(sorted(info.get("files", [])))
+    files = tuple(sorted(info.get("files", ())))
     file_groups[(repo, files)].append(info)
 
 

--- a/generate_report.py
+++ b/generate_report.py
@@ -30,7 +30,7 @@ The automated PR review agent successfully processed the backlog across 5 reposi
 
 def process_draft_fixes(results, draft_fixes):
     new_escalated = []
-    for e in results.get("escalated", []):
+    for e in results.get("escalated", ()):
         if f"{e[0]}#{e[1]}" in draft_fixes:
             results["merged"].append((e[0], e[1], e[2]))
         else:

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -165,7 +165,7 @@ def _is_checks_failing(checks):
 
 
 def _get_pr_category(info, checks, now=None):
-    if not info.get("files", []):
+    if not info.get("files", ()):
         return "SUPERSEDED"
 
     merge_status = info.get("mergeStateStatus", "")

--- a/scripts/get_prs_summarize.py
+++ b/scripts/get_prs_summarize.py
@@ -142,9 +142,9 @@ def fetch_details(repo: str, num: int) -> str:
         return "_Could not load details_"
     data = json.loads(raw)
     lines: list[str] = []
-    reviews = data.get("reviews") or []
-    latest = data.get("latestReviews") or []
-    comments = data.get("comments") or []
+    reviews = data.get("reviews") or ()
+    latest = data.get("latestReviews") or ()
+    comments = data.get("comments") or ()
     rd = data.get("reviewDecision") or ""
     if rd:
         lines.append(f"- reviewDecision: `{rd}`")
@@ -176,7 +176,7 @@ def _format_pr_row(pr: dict) -> str:
     author = pr.get("author")
     login = (author.get("login") if author else None) or "?"
     draft = "yes" if pr.get("isDraft") else "no"
-    checks = check_summary(pr.get("statusCheckRollup") or [])
+    checks = check_summary(pr.get("statusCheckRollup") or ())
     merge = f"{pr.get('mergeable') or '?'}"
     mss = pr.get("mergeStateStatus") or ""
     if mss and mss != "UNKNOWN":


### PR DESCRIPTION
## What
Applies the valuable immutable empty tuple fallbacks from #1623 to PR parsing/reporting helpers.

## Why
Supersedes conflicted PR #1623 with a fresh branch from current `main` while avoiding unrelated changes.

## How
- Changes empty collection fallbacks from `[]` to `()` in:
  - `detect_duplicates.py`
  - `generate_report.py`
  - `parse_inventory.py`
  - `scripts/get_prs_summarize.py`
- Does not take #1623 changes to `scripts/_load_pr_review_agent_config.py`.
- Does not take `.jules/bolt.md` wholesale or append journal content.
- Does not take the unrelated `scripts/get_prs_summarize.py` row-print refactor or thread-pool changes.

## Testing
- `python3 -m py_compile detect_duplicates.py generate_report.py parse_inventory.py scripts/get_prs_summarize.py`

## Security
No security impact. Behavior remains read-only and data-shape compatible; empty fallbacks are immutable tuples.

---

## Checklist
- [ ] `make test-quick` passes locally
- [ ] `make lint` reports no new errors
- [x] No secrets, tokens, or `.env` files included
- [ ] Documentation updated if behaviour changed
- [x] Branch name follows the salvage convention requested for this run

═══ ELIR ═══
PURPOSE: Retain the low-risk performance/immutability improvement from #1623 while discarding unrelated conflicted edits.
SECURITY: No trust boundaries change; inputs are still parsed from existing GitHub/report data structures.
FAILS IF: A caller mutates one of these fallback collections in place; current call sites only iterate, sort, take length, or slice.
VERIFY: Confirm the PR diff excludes `_load_pr_review_agent_config.py` and `.jules/bolt.md`, and that `py_compile` passes.
MAINTAIN: Prefer tuple fallbacks only for read-only empty collection defaults; use lists when code needs mutation.