### PR TITLE
perf(ci): cache ShellCheck and Trunk installs (ABHI-1135)

### DIFF
--- a/.github/actions/daily-perf-improver/build-steps/action.yml
+++ b/.github/actions/daily-perf-improver/build-steps/action.yml
@@ -10,6 +10,10 @@ runs:
         echo "Starting at: $(date)" | tee -a build-steps.log
         echo "" | tee -a build-steps.log
 
+    # NOTE: Cached pinned binary; replaces uncached wget install (ABHI-1135).
+    - name: Setup ShellCheck (cached)
+      uses: ./.github/actions/setup-shellcheck
+
     - name: Install system dependencies
       shell: bash
       run: |
@@ -19,16 +23,11 @@ runs:
         mkdir -p ~/.local/bin
         export PATH="$HOME/.local/bin:$PATH"
 
-        # Install ShellCheck (for linting)
-        if ! command -v shellcheck &> /dev/null; then
-          echo "Installing ShellCheck..." | tee -a build-steps.log
-          scversion="v0.10.0"
-          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion}/shellcheck-${scversion}.linux.x86_64.tar.xz" | tar -xJv
-          mv "shellcheck-${scversion}/shellcheck" ~/.local/bin/
-          chmod +x ~/.local/bin/shellcheck
-          echo "ShellCheck installed" | tee -a build-steps.log
+        if command -v shellcheck &> /dev/null; then
+          echo "ShellCheck available: $(shellcheck --version | head -n 1)" | tee -a build-steps.log
         else
-          echo "ShellCheck already available" | tee -a build-steps.log
+          echo "ERROR: ShellCheck missing after setup-shellcheck" | tee -a build-steps.log
+          exit 1
         fi
 
         # Install hyperfine (for benchmarking) - optional

--- a/.github/actions/setup-shellcheck/action.yml
+++ b/.github/actions/setup-shellcheck/action.yml
@@ -1,0 +1,81 @@
+# SECURITY: Pins ShellCheck to a known release; validates version allowlist before
+# interpolating into the download URL (prevents URL injection via action inputs).
+# Cache restores binaries from Actions cache — treat as untrusted until we verify
+# the executable exists and is runnable. Version bumps invalidate the cache key.
+name: Setup ShellCheck
+description: Install a pinned ShellCheck binary with GitHub Actions cache
+
+inputs:
+  version:
+    description: ShellCheck release tag (e.g. v0.11.0). Must match koalaman/shellcheck releases.
+    required: false
+    # NOTE: Keep in sync with .trunk/trunk.yaml lint.shellcheck version when practical.
+    default: "v0.11.0"
+
+outputs:
+  cache-hit:
+    description: Whether the ShellCheck binary was restored from cache
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Cache ShellCheck binary
+      id: cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.local/bin/shellcheck
+        # ASSUMES: version string is the sole install identity (OS + arch + version)
+        key: shellcheck-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - name: Install ShellCheck
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        # SECURITY: Pass via env (not ${{ }} inside shell) so injection surface is explicit.
+        SHELLCHECK_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        # SECURITY: Allowlist version tags before building the download URL.
+        if [[ ! "${SHELLCHECK_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Invalid ShellCheck version '${SHELLCHECK_VERSION}' (expected vMAJOR.MINOR.PATCH)"
+          exit 1
+        fi
+
+        mkdir -p "${HOME}/.local/bin"
+        case "$(uname -s)-$(uname -m)" in
+          Linux-x86_64) platform="linux.x86_64" ;;
+          Linux-aarch64 | Linux-arm64) platform="linux.aarch64" ;;
+          Darwin-x86_64) platform="darwin.x86_64" ;;
+          Darwin-arm64) platform="darwin.aarch64" ;;
+          *)
+            echo "::error::Unsupported platform for ShellCheck: $(uname -s)-$(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        archive="shellcheck-${SHELLCHECK_VERSION}.${platform}.tar.xz"
+        url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${archive}"
+        tmpdir="$(mktemp -d)"
+        # CAUTION: Cleanup must run even if download/extract fails.
+        trap 'rm -rf "${tmpdir}"' EXIT
+
+        echo "Downloading ShellCheck ${SHELLCHECK_VERSION} (${platform})..."
+        curl -fsSL "${url}" -o "${tmpdir}/${archive}"
+        tar -xJf "${tmpdir}/${archive}" -C "${tmpdir}"
+        install -m 0755 "${tmpdir}/shellcheck-${SHELLCHECK_VERSION}/shellcheck" "${HOME}/.local/bin/shellcheck"
+
+    - name: Add ShellCheck to PATH
+      shell: bash
+      run: |
+        set -euo pipefail
+        # CAUTION: Cache restore may drop the executable bit on some runners.
+        if [[ -f "${HOME}/.local/bin/shellcheck" ]]; then
+          chmod +x "${HOME}/.local/bin/shellcheck"
+        fi
+        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        if [[ ! -x "${HOME}/.local/bin/shellcheck" ]]; then
+          echo "::error::shellcheck binary missing after setup"
+          exit 1
+        fi
+        "${HOME}/.local/bin/shellcheck" --version

--- a/.github/actions/setup-trunk/action.yml
+++ b/.github/actions/setup-trunk/action.yml
@@ -1,0 +1,59 @@
+# SECURITY: Caches Trunk CLI launcher + tool downloads. Cache keys include
+# hashFiles('.trunk/trunk.yaml') so CLI/linter version bumps invalidate the cache.
+# The trunk.io launcher URL is fixed (not user-controlled); restored cache contents
+# are untrusted blobs until trunk itself verifies tool digests on use.
+name: Setup Trunk
+description: Install Trunk CLI launcher and cache ~/.cache/trunk tool downloads
+
+inputs:
+  cache-tools:
+    description: Whether to restore/save the Trunk tool cache under ~/.cache/trunk
+    required: false
+    default: "true"
+
+outputs:
+  cache-hit:
+    description: Whether the Trunk cache was restored
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Trunk tools and launcher
+      id: cache
+      if: inputs.cache-tools == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/.cache/trunk
+          ~/.local/bin/trunk
+        # NOTE: Invalidates when trunk.yaml changes (CLI version, linters, plugins).
+        key: trunk-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.trunk/trunk.yaml') }}
+        restore-keys: |
+          trunk-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install Trunk CLI launcher
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${HOME}/.local/bin" "${HOME}/.cache/trunk"
+        if [[ -x "${HOME}/.local/bin/trunk" ]]; then
+          echo "Trunk launcher restored from cache"
+          chmod +x "${HOME}/.local/bin/trunk"
+        else
+          echo "Downloading Trunk CLI launcher..."
+          # ASSUMES: https://trunk.io/releases/trunk is the official launcher endpoint.
+          curl -fsSL https://trunk.io/releases/trunk -o "${HOME}/.local/bin/trunk"
+          chmod +x "${HOME}/.local/bin/trunk"
+        fi
+        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        "${HOME}/.local/bin/trunk" version || "${HOME}/.local/bin/trunk" --help >/dev/null
+
+    - name: Prefetch Trunk tools (cache miss)
+      if: inputs.cache-tools == 'true' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Populate ~/.cache/trunk so subsequent jobs/runs hit a warm cache.
+        # Non-fatal if install is slow or partially fails — trunk check will retry.
+        "${HOME}/.local/bin/trunk" install || echo "::warning::trunk install returned non-zero; tools may download on first check"

--- a/.github/copilot/instructions/ci-performance.md
+++ b/.github/copilot/instructions/ci-performance.md
@@ -8,45 +8,47 @@ This repository uses GitHub Actions for code quality checks, complexity analysis
 
 ### code-quality.yml
 
-- **ShellCheck complexity:** Lints 117+ shell scripts
-- **Python complexity:** Analyzes Python files with radon
-- **Trunk check:** Runs multiple linters (shellcheck, shfmt, markdownlint, etc.)
-- **Duration:** Currently 2-3 minutes per run
+- **Shell quality:** Lint/correctness gate via cached ShellCheck (`./.github/actions/setup-shellcheck`)
+- **Python quality:** Analyzes Python files with radon/ruff/bandit
+- **Tests:** `make test-all`
+- **Duration target:** <2 minutes on warm cache
 
-## Performance Goals
+### repository-automation-daily.yml (quality_assurance)
 
-- **PR feedback:** <2 minutes from push to completion
-- **Cache hit rate:** >80% on repeated runs
-- **Resource efficiency:** Minimize GitHub Actions minutes
-- **Incremental checks:** Only analyze changed files when possible
+- **ShellCheck:** Cached pinned binary via `setup-shellcheck`
+- **Trunk:** Cached CLI + `~/.cache/trunk` via `setup-trunk` (key includes `hashFiles('.trunk/trunk.yaml')`)
+- Runs `make lint-errors`, smoke tests, full suite, optional `make lint`
 
 ## Key Optimization Strategies
 
-### 1. Effective Caching
+### 1. Effective Caching (ABHI-1135)
 
-The code-quality workflow already implements caching:
+Reusable composite actions centralize install + cache:
 
-**ShellCheck cache:**
-
-```yaml
-- name: Cache ShellCheck
-  uses: actions/cache@v3
-  with:
-    path: ~/.local/bin/shellcheck
-    key: shellcheck-${{ runner.os }}-v0.10.0
-```
-
-**Trunk cache:**
+**ShellCheck** — `.github/actions/setup-shellcheck`:
 
 ```yaml
-- name: Cache Trunk
-  uses: actions/cache@v3
-  with:
-    path: |
-      ~/.cache/trunk
-      .trunk/out
-    key: trunk-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
+- name: Setup ShellCheck (cached)
+  uses: ./.github/actions/setup-shellcheck
+  # optional: with: { version: v0.11.0 }
 ```
+
+- Path: `~/.local/bin/shellcheck`
+- Key: `shellcheck-${{ runner.os }}-${{ runner.arch }}-<version>`
+- Invalidates when the `version` input changes
+- Downloads from `koalaman/shellcheck` releases (not apt) for pin + cacheability
+
+**Trunk** — `.github/actions/setup-trunk`:
+
+```yaml
+- name: Setup Trunk (cached)
+  uses: ./.github/actions/setup-trunk
+```
+
+- Paths: `~/.cache/trunk`, `~/.local/bin/trunk`
+- Key: `trunk-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.trunk/trunk.yaml') }}`
+- Invalidates when CLI/linter/plugin versions in `.trunk/trunk.yaml` change
+- On cache miss, runs `trunk install` to warm the tool cache
 
 **Python pip cache (built-in):**
 
@@ -60,33 +62,15 @@ The code-quality workflow already implements caching:
 
 ### 2. Parallel Job Execution
 
-Current workflow runs 3 jobs in parallel:
-
-- `shellcheck-complexity`
-- `python-complexity`
-- `trunk-check`
-
-This is optimal - they're independent and maximize throughput.
+`code-quality.yml` runs independent jobs in parallel (`shell-quality`, `python-quality`, `test`).
 
 ### 3. Path-Based Triggering
 
-Workflow only runs when relevant files change:
-
-```yaml
-on:
-  pull_request:
-    paths:
-      - "**.sh"
-      - "**.py"
-      - "**.bash"
-      - "scripts/**"
-```
-
-**Improvement opportunity:** Add more specific patterns to skip docs-only changes.
+Workflows only run when relevant files change (e.g. `**.sh`, `mac-audit/**`).
 
 ### 4. Concurrency Control
 
-Already implemented to cancel stale runs:
+Prefer canceling stale runs:
 
 ```yaml
 concurrency:
@@ -95,8 +79,6 @@ concurrency:
 ```
 
 ## Performance Measurement
-
-### Measure Workflow Duration
 
 ```bash
 # Get workflow run times
@@ -107,143 +89,15 @@ gh api "repos/abhimehro/personal-config/actions/workflows/code-quality.yml/runs"
   | jq '.workflow_runs[:10] | map(.run_duration_ms / 1000) | add / length'
 ```
 
-### Identify Slow Steps
+## Cache Invalidation
 
-Look at individual step timings in Actions UI or via API:
-
-```bash
-gh run view <run-id> --log
-```
-
-Common bottlenecks:
-
-- Installing tools (solved by caching)
-- Finding all files (use incremental checking)
-- Running linters on all files (use changed files only)
-
-## Advanced Optimization Techniques
-
-### Technique 1: Incremental Linting
-
-Currently Trunk attempts this with `--upstream`, but can be more aggressive:
-
-**Before:**
-
-```bash
-trunk check --all --upstream origin/main
-```
-
-**Optimized:**
-
-```bash
-# Only check files changed in this PR
-git diff --name-only origin/main...HEAD \
-  | grep -E '\.(sh|bash|py)$' \
-  | xargs trunk check
-```
-
-**Impact:** 80% faster for small PRs (only checks 5 files instead of 117)
-
-### Technique 2: Fast-Fail Strategy
-
-Exit early on first critical error to save time:
-
-```yaml
-- name: Quick syntax check
-  run: |
-    # Fast shell syntax check before expensive linting
-    find . -name '*.sh' -exec bash -n {} \; || exit 1
-```
-
-### Technique 3: Matrix Parallelization
-
-For very large repos, split work across matrix:
-
-```yaml
-strategy:
-  matrix:
-    directory: [scripts, maintenance, tests, controld-system]
-jobs:
-  lint:
-    steps:
-      - run: trunk check ${{ matrix.directory }}
-```
-
-**Trade-off:** More parallelism but higher startup overhead
-
-## Real-World Optimization Example
-
-### Scenario: ShellCheck Taking 45 Seconds
-
-**Problem:** Running shellcheck on all 117 scripts sequentially
-
-**Optimization:**
-
-```bash
-# Parallel shellcheck with xargs
-find . -name '*.sh' -print0 \
-  | xargs -0 -P 4 -I {} shellcheck {}
-```
-
-**Result:** 45s → 15s (3x faster)
-
-**Implementation in workflow:**
-
-```yaml
-- name: Run ShellCheck in parallel
-  run: |
-    find . -name '*.sh' -print0 > /tmp/shell_files.txt
-    xargs -0 -P 4 -I {} shellcheck {} < /tmp/shell_files.txt
-```
-
-## Cache Validation and Monitoring
-
-### Check Cache Hit Rate
-
-```bash
-# Get recent runs with cache info
-gh api "repos/abhimehro/personal-config/actions/workflows/code-quality.yml/runs" \
-  | jq '.workflow_runs[0].jobs | map(select(.name | contains("Cache"))) | .[].conclusion'
-```
-
-### Invalidate Cache When Needed
-
-Change cache key when dependencies change:
-
-```yaml
-key: shellcheck-${{ runner.os }}-v0.11.0 # Bumped version
-```
-
-## When to Optimize CI
-
-✅ **Optimize when:**
-
-- Workflow takes >3 minutes consistently
-- Developers complain about slow feedback
-- GitHub Actions minutes approaching limit
-- Same work repeated across multiple jobs
-
-❌ **Don't optimize when:**
-
-- Already under 2 minutes
-- Complexity outweighs benefit
-- Caching already optimal
+| Tool       | Change this                         | Effect                          |
+| ---------- | ----------------------------------- | ------------------------------- |
+| ShellCheck | `version` input on setup-shellcheck | New cache key; fresh download   |
+| Trunk      | `.trunk/trunk.yaml`                 | New cache key; `trunk install`  |
 
 ## Success Metrics
 
-**Target benchmarks:**
-
-- **Cold cache (first run):** <4 minutes
-- **Warm cache (subsequent runs):** <2 minutes
-- **Cache hit rate:** >80%
-- **Changed files only:** <1 minute
-
-**Monitoring:**
-
-```bash
-# Create performance tracking
-echo "$(date): $(gh run list --workflow=code-quality.yml --limit 1 --json conclusion,durationMs | jq '.[] | .durationMs')" \
-  >> .github/workflows/performance-log.txt
-```
-
-**Key principle:** Optimize for the common case (incremental changes on PRs with warm cache). First-time setup can be slower since it's rare.
+- **Cold cache (first run):** same as pre-cache baseline (download + install)
+- **Warm cache (subsequent runs):** ~30–60s faster (skip apt/curl tool downloads)
+- **Cache hit rate:** >80% on repeated runs

--- a/.github/repository-automation.yml
+++ b/.github/repository-automation.yml
@@ -46,10 +46,12 @@ automation:
   quality_assurance:
     enabled: true
     setup_commands:
-      - name: install shellcheck
-        run: python -m pip install --upgrade shellcheck-py
+      # ShellCheck is provided by .github/actions/setup-shellcheck in the
+      # quality_assurance workflow job (cached pinned binary). Verify only.
+      - name: verify shellcheck
+        run: command -v shellcheck && shellcheck --version
         optional: false
-        timeout_seconds: 900
+        timeout_seconds: 60
     commands:
       - name: shellcheck regression gate
         run: make lint-errors

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,10 +27,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install ShellCheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+      - name: Setup ShellCheck (cached)
+        uses: ./.github/actions/setup-shellcheck
+
       - name: ShellCheck correctness gate (SC2155/SC2145)
         run: make lint-errors
 

--- a/.github/workflows/mac-audit.yml
+++ b/.github/workflows/mac-audit.yml
@@ -25,10 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install shellcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+      - name: Setup ShellCheck (cached)
+        uses: ./.github/actions/setup-shellcheck
       - name: Lint scripts
         run: shellcheck mac-audit/audit.sh mac-audit/lib/*.sh
 

--- a/.github/workflows/repository-automation-daily.yml
+++ b/.github/workflows/repository-automation-daily.yml
@@ -135,13 +135,11 @@ jobs:
       - name: Install automation runner dependencies
         run: python -m pip install --upgrade pip pyyaml
 
-      - name: Install Trunk CLI (for make lint / trunk check)
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.local/bin"
-          curl -fsSL https://trunk.io/releases/trunk -o "${HOME}/.local/bin/trunk"
-          chmod +x "${HOME}/.local/bin/trunk"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+      - name: Setup ShellCheck (cached)
+        uses: ./.github/actions/setup-shellcheck
+
+      - name: Setup Trunk (cached)
+        uses: ./.github/actions/setup-trunk
 
       - name: Execute quality assurance task
         continue-on-error: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -75,10 +75,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install ShellCheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+      - name: Setup ShellCheck (cached)
+        uses: ./.github/actions/setup-shellcheck
 
       - name: Run ShellCheck on all scripts
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+      - name: Setup ShellCheck (cached)
+        uses: ./.github/actions/setup-shellcheck
       - run: shellcheck --severity=warning mac-audit/audit.sh mac-audit/lib/*.sh

--- a/tasks/handoff.md
+++ b/tasks/handoff.md
@@ -1,6 +1,41 @@
-========== ELIR ==========
-PURPOSE: Optimized the `extract_status_markers` function in `.github/scripts/repository_automation_tasks.py` by extracting the static regular expression and compiling it at the module level using `re.compile(..., re.S)`. This avoids redundant regex compilation on each function call.
-SECURITY: No direct security implications; strictly a performance optimization for text parsing. Assumes `issue_body` is a string (checked by type hinting).
-FAILS IF: The regex syntax was somehow altered, but it was verified to be identical to the original inline regex.
-VERIFY: Check that the compiled regex correctly extracts status markers from test data (verified via `make test-all`).
-MAINTAIN: If the marker format changes (e.g., from `<!-- repository-automation:task-status\n(.*?)\n-->`), update `_STATUS_MARKER_RE` at the module level.
+# Handoff: ABHI-1135 — CI caching for ShellCheck and Trunk
+
+## ELIR
+
+### Purpose
+Add reusable GitHub Actions composite actions that install pinned ShellCheck and Trunk with `actions/cache`, and wire them into every workflow that previously re-downloaded these tools on every run.
+
+### Security
+- SHA-pinned `actions/cache@55cc834…` (v6.1.0), matching existing repo pinact style.
+- ShellCheck version allowlisted (`^v[0-9]+\.[0-9]+\.[0-9]+$`) before URL construction; version passed via `env`, not interpolated into shell from untrusted expressions beyond the input.
+- Cache keys contain only OS/arch/version or `hashFiles('.trunk/trunk.yaml')` — no secrets.
+- Trust boundary: Actions cache restores opaque binaries; we verify executability and rely on pinned release URLs / Trunk’s own tool digests.
+
+### Failure Modes
+| Failure | Consequence | Mitigation |
+| --- | --- | --- |
+| Cache miss | Same latency as before | Install path unchanged |
+| Cache restores non-executable blob | Job fails at verify step | `chmod +x` + explicit existence check |
+| Malicious `version` input | Would craft arbitrary URL | Allowlist rejects non-semver tags |
+| `trunk.yaml` bump | Cache miss + `trunk install` | Expected; warm cache on next run |
+
+### Review Checklist
+- [ ] Confirm workflows reference `./.github/actions/setup-shellcheck` / `setup-trunk`
+- [ ] First CI run after merge may be cache-miss (baseline); second run should show cache hits
+- [ ] Bumping ShellCheck: change default `version` in setup-shellcheck (and ideally align `.trunk/trunk.yaml`)
+- [ ] Bumping Trunk tools: edit `.trunk/trunk.yaml` (auto-invalidates cache key)
+
+### Maintenance
+- Keep ShellCheck default version aligned with `lint.enabled: shellcheck@…` in `.trunk/trunk.yaml` when practical.
+- Do not switch back to uncached `apt-get install shellcheck` in these workflows.
+- Docs: `.github/copilot/instructions/ci-performance.md`
+
+## Files touched
+- `.github/actions/setup-shellcheck/action.yml` (new)
+- `.github/actions/setup-trunk/action.yml` (new)
+- `.github/workflows/{code-quality,shellcheck,mac-audit,security-scan,repository-automation-daily}.yml`
+- `.github/actions/daily-perf-improver/build-steps/action.yml`
+- `.github/repository-automation.yml` (verify shellcheck instead of pip install shellcheck-py)
+- `.github/copilot/instructions/ci-performance.md`
+- `tests/test_setup_shellcheck_action.sh`
+- `tasks/todo.md`, `tasks/handoff.md`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,28 +1,18 @@
-- [x] Use `run_in_bash_session` to execute a python script that will remove the unused `import concurrent.futures` and the usage of `concurrent.futures.ThreadPoolExecutor` in `scripts/get_prs_summarize.py`. The executor map will be replaced with a simple sequential `map(_fetch_task_wrapper, tasks)`.
-- [x] Use `run_in_bash_session` to run `git diff scripts/get_prs_summarize.py` to visually verify the modifications.
-- [x] Use `run_in_bash_session` to execute `flake8 scripts/get_prs_summarize.py` to verify the code passes linting.
-- [x] Use `run_in_bash_session` to install the required testing dependencies and run the full test suite to ensure no functionality is broken by the refactoring: `sudo apt-get install -y bc && pip install pyyaml pytest && make test-all`.
-- [x] Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-- [x] Use the `submit` tool to create the PR with the requested format.
+# ABHI-1135 — CI caching for ShellCheck and Trunk
 
----
+## Approach
 
-# Session: Snyk Secure-at-Inception project hooks (2026-07-16)
+Centralize install+cache in reusable composite actions (DRY across workflows), pin tool versions for supply-chain + cache invalidation, replace apt installs with cached binaries.
+
+**Trust boundary:** Cache restores untrusted blobs from GitHub Actions cache; mitigate by pinning download URLs to known versions and validating version input allowlists. Prefer SHA-pinned `actions/cache`.
+
+**Security:** No secrets in cache keys/paths. Validate version strings before interpolating into download URLs. Do not weaken existing lint gates.
 
 ## Checklist
 
-- [x] Vendor SAI scripts under `.cursor/hooks/snyk/`
-- [x] Add wrapper + dependency-install reminder hook
-- [x] Update `.cursor/hooks.json`
-- [x] Write design + operator docs
-- [x] Add shell smoke tests (`tests/test_cursor_snyk_hooks.sh` — 7/7)
-- [x] Commit, push, open draft PR (#1629)
-- [x] Refactor for CodeScene complexity gates (PR CI green)
-- [x] Merge latest `origin/main`; resolve `tasks/todo.md` journal conflict
-
-## Validation notes
-
-- Live Snyk CLI / MCP auth unavailable in this cloud session (`SNYK_TOKEN` unset).
-- `/snyk-fix` + `/snyk-batch-fix`: no remediations (no vuln table / no auth).
-- docs-canvas: canvas SDK unavailable; shipped `docs/snyk-secure-at-inception.md`.
-- Journal merge: took `main`'s current `tasks/todo.md` (Bolt session checklist from #1655) and appended this SAI section; did not resurrect the pre-#1655 LaunchAgents/Control D checklist that `main` replaced.
+- [x] Create `.github/actions/setup-shellcheck` (cache + pinned binary install)
+- [x] Create `.github/actions/setup-trunk` (cache `~/.cache/trunk` + CLI launcher)
+- [x] Wire into: `code-quality.yml`, `shellcheck.yml`, `mac-audit.yml`, `security-scan.yml`, `repository-automation-daily.yml`, `daily-perf-improver/build-steps`
+- [x] Align `ci-performance.md` with actual implementation
+- [x] Validate YAML; smoke-test ShellCheck install (`tests/test_setup_shellcheck_action.sh` 7/7)
+- [ ] Commit, push, open draft PR; comment on Linear ABHI-1135

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,4 +15,5 @@ Centralize install+cache in reusable composite actions (DRY across workflows), p
 - [x] Wire into: `code-quality.yml`, `shellcheck.yml`, `mac-audit.yml`, `security-scan.yml`, `repository-automation-daily.yml`, `daily-perf-improver/build-steps`
 - [x] Align `ci-performance.md` with actual implementation
 - [x] Validate YAML; smoke-test ShellCheck install (`tests/test_setup_shellcheck_action.sh` 7/7)
-- [ ] Commit, push, open draft PR; comment on Linear ABHI-1135
+- [x] Commit, push, open draft PR; comment on Linear ABHI-1135
+  - PR: https://github.com/abhimehro/personal-config/pull/1669

--- a/tests/test_setup_shellcheck_action.sh
+++ b/tests/test_setup_shellcheck_action.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Smoke-test ShellCheck install allowlist + download used by setup-shellcheck.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() {
+	echo "PASS: $1"
+	PASS=$((PASS + 1))
+}
+
+fail() {
+	echo "FAIL: $1"
+	FAIL=$((FAIL + 1))
+}
+
+# SECURITY: Same allowlist as .github/actions/setup-shellcheck/action.yml
+is_valid_shellcheck_version() {
+	[[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+echo "=== setup-shellcheck version allowlist ==="
+
+if is_valid_shellcheck_version "v0.11.0"; then
+	pass "accepts v0.11.0"
+else
+	fail "should accept v0.11.0"
+fi
+
+if is_valid_shellcheck_version "v0.10.0"; then
+	pass "accepts v0.10.0"
+else
+	fail "should accept v0.10.0"
+fi
+
+if ! is_valid_shellcheck_version "0.11.0"; then
+	pass "rejects missing v prefix"
+else
+	fail "should reject 0.11.0"
+fi
+
+if ! is_valid_shellcheck_version "v0.11.0;curl evil"; then
+	pass "rejects injection payload"
+else
+	fail "should reject injection payload"
+fi
+
+if ! is_valid_shellcheck_version "../etc/passwd"; then
+	pass "rejects path traversal"
+else
+	fail "should reject path traversal"
+fi
+
+if ! is_valid_shellcheck_version "latest"; then
+	pass "rejects floating tag"
+else
+	fail "should reject latest"
+fi
+
+# Optional live download (skip on network failure)
+SHELLCHECK_VERSION="v0.11.0"
+case "$(uname -s)-$(uname -m)" in
+Linux-x86_64) platform="linux.x86_64" ;;
+Linux-aarch64 | Linux-arm64) platform="linux.aarch64" ;;
+Darwin-x86_64) platform="darwin.x86_64" ;;
+Darwin-arm64) platform="darwin.aarch64" ;;
+*)
+	echo "SKIP: live download (unsupported platform)"
+	platform=""
+	;;
+esac
+
+if [[ -n "${platform}" ]]; then
+	TEST_DIR="$(mktemp -d)"
+	trap 'rm -rf "${TEST_DIR}"' EXIT
+	archive="shellcheck-${SHELLCHECK_VERSION}.${platform}.tar.xz"
+	url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/${archive}"
+	if curl -fsSL --max-time 30 "${url}" -o "${TEST_DIR}/${archive}"; then
+		tar -xJf "${TEST_DIR}/${archive}" -C "${TEST_DIR}"
+		bin="${TEST_DIR}/shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+		if [[ -x "${bin}" ]] && "${bin}" --version >/dev/null; then
+			pass "downloads and runs ShellCheck ${SHELLCHECK_VERSION} (${platform})"
+		else
+			fail "extracted binary missing or not runnable"
+		fi
+	else
+		echo "SKIP: could not download ShellCheck release (network)"
+	fi
+fi
+
+echo ""
+echo "Passed: ${PASS}  Failed: ${FAIL}"
+if [[ "${FAIL}" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speeds up CI by caching ShellCheck and Trunk instead of re-downloading them on every run (GitHub issue #283).

### Changes
- **New** `.github/actions/setup-shellcheck` — pinned binary (`v0.11.0`) + `actions/cache` (key: OS/arch/version)
- **New** `.github/actions/setup-trunk` — launcher + `~/.cache/trunk` (key: OS/arch + `hashFiles('.trunk/trunk.yaml')`)
- Wired into: `code-quality.yml`, `shellcheck.yml`, `mac-audit.yml`, `security-scan.yml`, `repository-automation-daily.yml`, daily-perf-improver build-steps
- Daily QA config now verifies ShellCheck on PATH instead of `pip install shellcheck-py`
- Updated `.github/copilot/instructions/ci-performance.md` to match reality
- Smoke test: `tests/test_setup_shellcheck_action.sh` (allowlist + live download)

### Security
- SHA-pinned `actions/cache@55cc834…` (v6.1.0)
- ShellCheck version allowlisted before URL construction
- Cache keys contain no secrets; invalidate on version / `trunk.yaml` changes

### ELIR (quick)
- **PURPOSE:** Cache ShellCheck/Trunk installs across CI runs via reusable actions
- **SECURITY:** Pinned cache action + version allowlist; fail if binary missing after restore
- **FAILS IF:** Cache restores a non-executable blob (job fails at verify)
- **VERIFY:** Second CI run on this branch shows cache hits for setup-shellcheck / setup-trunk
- **MAINTAIN:** Bump ShellCheck via action `version` input; Trunk via `.trunk/trunk.yaml`

## Test plan
- [x] YAML parse of all touched workflow/action files
- [x] `bash tests/test_setup_shellcheck_action.sh` (7/7)
- [x] `make test-quick`
- [x] `python3 -m unittest tests.test_repository_automation_tasks tests.test_repository_automation_common`
- [ ] After push: confirm Actions cache hit on a second workflow run

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ABHI-1135](https://linear.app/abhis-space/issue/ABHI-1135/code-quality-add-ci-caching-for-shellcheck-and-trunk-installations)

<div><a href="https://cursor.com/agents/bc-f384adc3-2522-409a-abfb-5bc40afd6b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f384adc3-2522-409a-abfb-5bc40afd6b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

