### PR TITLE
test(adguard): allowlist file processing coverage (salvages #1663)

### DIFF
--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -16,6 +16,7 @@ from adguard.scripts.extract_domains import (
     _is_allowlist_rule,
     extract_allowlist_domains_from_file,
     extract_domains_from_file,
+    process_allowlist_files,
     process_denylist_files,
 )
 
@@ -215,6 +216,49 @@ class TestExtractAllowlistDomainsFromFile(unittest.TestCase):
         finally:
             os.remove(temp_path)
 
+
+
+
+
+class TestProcessAllowlistFiles(unittest.TestCase):
+    @patch("builtins.print")
+    def test_process_allowlist_files_all_exist(self, _mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(
+                os.path.join(temp_dir, "CD-Control-D-Bypass.json"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                json.dump({"rules": [{"PK": "bypass.com", "action": {"do": 1}}]}, file)
+
+            with open(
+                os.path.join(temp_dir, "CD-Most-Abused-TLDs.json"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                json.dump({"rules": [{"PK": "tld.com", "action": {"do": 1}}]}, file)
+
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, {"bypass.com", "tld.com"})
+
+    @patch("builtins.print")
+    def test_process_allowlist_files_missing_file(self, _mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(
+                os.path.join(temp_dir, "CD-Control-D-Bypass.json"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                json.dump({"rules": [{"PK": "bypass.com", "action": {"do": 1}}]}, file)
+
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, {"bypass.com"})
+
+    @patch("builtins.print")
+    def test_process_allowlist_files_no_files(self, _mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = process_allowlist_files(temp_dir)
+            self.assertEqual(result, set())
 
 
 class TestProcessDenylistFiles(unittest.TestCase):


### PR DESCRIPTION
## TL;DR
Salvages allowlist coverage from DIRTY [#1663](https://github.com/abhimehro/personal-config/pull/1663) onto fresh `main`. Skips the stale ProcessPoolExecutor rewrite already landed.

## Core files
- `tests/test_extract_domains.py` — `TestProcessAllowlistFiles` (3 cases)

## Verify
```bash
python3 -m pytest tests/test_extract_domains.py::TestProcessAllowlistFiles -q
```

## ELIR
- **PURPOSE:** Cover `process_allowlist_files` (exist / missing / empty).
- **SECURITY:** Tests only; no runtime change.
- **FAILS IF:** Allowlist filenames or `extract_allowlist_domains_from_file` contract drift.
- **VERIFY:** pytest command above (3 passed).
- **MAINTAIN:** Keep filenames in sync with `adguard/scripts/extract_domains.py`.

Refs: #1663 (salvage source)