### PR TITLE
🎨 Palette: Add fallback empty state for directory listing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -328,3 +328,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-07-16 - Prevent Empty Lists for Better Accessibility (Reiteration)
 **Learning:** Dynamically generated `<ul>` elements without `<li>` children are invalid HTML5 and confuse screen readers, causing them to ambiguously skip regions or misreport empty lists.
 **Action:** When creating HTML list generators (e.g., `html_ul`), explicitly evaluate the iterable before formatting. If the list is empty, inject a fallback empty state list item (like `<li class="empty-state">No items</li>`) instead of returning `<ul></ul>`.
+
+## 2026-03-10 - Empty Lists Accessibility
+**Learning:** When dynamically generating HTML lists (e.g., `<ul>`), rendering an empty list (e.g., `<ul></ul>`) creates an invalid HTML5 structure and disrupts screen reader experiences. Always providing a fallback empty state list item (`<li>`) is necessary to maintain proper list semantics.
+**Action:** Add a fallback empty state `<li>` whenever conditional list items are absent.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -269,6 +269,8 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             for item in files
             if item
         ]
+        if not items_html:
+            items_html.append('<li><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>\n')
         html_parts.extend(items_html)
 
         html_parts.append("""

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -161,6 +161,14 @@ class TestMediaServerHandler(unittest.TestCase):
             html_root,
         )
 
+    def test_generate_directory_listing_empty(self):
+        """
+        Test that generate_directory_listing produces a fallback empty state
+        list item when the directory contains no files.
+        """
+        html_empty = self.handler.generate_directory_listing([], "/empty_folder")
+        self.assertIn('<li><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>', html_empty)
+
     def test_generate_directory_listing_subdirectory(self):
         """
         Test that generate_directory_listing produces correct HTML output,


### PR DESCRIPTION
* 💡 What: Added a fallback empty state list item (<li>) to the directory listing generation when the directory contains no files.
* 🎯 Why: To prevent generating an invalid empty <ul> element which disrupts list semantics and screen reader accessibility when viewing an empty media folder.
* 📸 Before/After: The <ul> tag now displays an informative <li> with 'Directory is empty' instead of being completely empty.
* ♿ Accessibility: Maintains valid HTML5 list structure and provides clear context to screen reader users that the directory was successfully loaded but contains no items.

---
*PR created automatically by Jules for task [11589857578754942457](https://jules.google.com/task/11589857578754942457) started by @abhimehro*