### PR TITLE
⚡ Bolt: Speed up PR details fetching

### DIFF
--- a/scripts/get_prs_summarize.py
+++ b/scripts/get_prs_summarize.py
@@ -6,6 +6,7 @@ The second argument is include_details ("true" / "false").
 """
 
 
+import concurrent.futures
 import json
 import os
 import subprocess
@@ -222,7 +223,10 @@ def _print_details_section(data: list) -> None:
     print("\n#### Review / comment context\n")
 
     tasks = [(repo, pr) for pr in data]
-    results = map(_fetch_task_wrapper, tasks)
+
+    # ⚡ Bolt Optimization: Use ThreadPoolExecutor for concurrent I/O-bound GitHub API calls
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(tasks) or 1, 32)) as executor:
+        results = list(executor.map(_fetch_task_wrapper, tasks))
 
     for res in results:
         if res:


### PR DESCRIPTION
* 💡 What: Used ThreadPoolExecutor to fetch PR details concurrently
* 🎯 Why: Previously, fetching details for multiple PRs using the `gh` CLI was done sequentially, which caused significant delay proportional to the number of PRs.
* 📊 Impact: O(1) latency relative to PR count (up to 32 parallel requests) rather than O(N).
* 🔬 Measurement: Observe total run time of the script on repositories with multiple PRs; execution should be near-instantaneous.

---
*PR created automatically by Jules for task [13297645654717579286](https://jules.google.com/task/13297645654717579286) started by @abhimehro*