### PR TITLE
🎨 Palette: Add skip-to-content links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -332,3 +332,9 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-03-10 - Empty Lists Accessibility
 **Learning:** When dynamically generating HTML lists (e.g., `<ul>`), rendering an empty list (e.g., `<ul></ul>`) creates an invalid HTML5 structure and disrupts screen reader experiences. Always providing a fallback empty state list item (`<li>`) is necessary to maintain proper list semantics.
 **Action:** Add a fallback empty state `<li>` whenever conditional list items are absent.
+## $(date +%Y-%m-%d) - Skip-to-content links for generated HTML
+**Learning:** Shell scripts that generate static HTML reports often omit essential keyboard accessibility features like skip-to-content links, making navigation tedious for keyboard and screen reader users.
+**Action:** Always include a visually hidden, focusable skip link (`<a href="#main-content" class="skip-link">Skip to main content</a>`) at the top of the `<body>` and ensure the `<main>` tag has a matching `id="main-content"`.
+## $(date +%Y-%m-%d) - Preserve list semantics for groups
+**Learning:** When grouping multiple related UI elements (such as a grid of metric cards), replacing the unordered list container (`<ul>`) with a generic `<div>` degrades accessibility by preventing screen readers from announcing the group context and item count.
+**Action:** Always use `<ul>` and `<li>` to group related repeating UI elements. Do not flatten them into generic `<div>` tags in the name of simplicity.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -410,6 +410,8 @@ generate_dashboard() {
     <title>System Maintenance Dashboard - ${cap_period}</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+        .skip-link { position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }
+        .skip-link:focus { top: 0; }
         .container { max-width: 1200px; margin: 0 auto; background: white; border-radius: 10px; padding: 30px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
         .header { text-align: center; margin-bottom: 40px; }
         .header h1 { color: #333; margin-bottom: 10px; }
@@ -431,13 +433,14 @@ generate_dashboard() {
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="container">
         <header class="header">
             <h1><span aria-hidden="true">🔧</span> System Maintenance Dashboard</h1>
             <div class="date">$(date "+%B %d, %Y at %H:%M") - ${cap_period} Report</div>
         </header>
         
-        <main>
+        <main id="main-content">
         <ul class="metrics-grid">
             <li class="metric-card success" aria-labelledby="health-score-label health-score-value">
                 <div class="metric-value" id="health-score-value">${current_health}</div>

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -488,6 +488,8 @@ generate_performance_report() {
     <title>Performance Report - $(date +%Y-%m-%d)</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
+        .skip-link { position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }
+        .skip-link:focus { top: 0; }
         .header { background-color: #f0f0f0; padding: 10px; border-radius: 5px; }
         .section { margin: 20px 0; padding: 15px; border: 1px solid #ccc; border-radius: 5px; }
         dl.metric-list { margin: 0; padding: 0; }
@@ -503,12 +505,13 @@ generate_performance_report() {
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <header class="header">
         <h1><span aria-hidden="true">🚀</span> Performance Report</h1>
         <p>Generated: $(date)</p>
     </header>
     
-    <main>
+    <main id="main-content">
     <section class="section" aria-labelledby="sys-info-heading" role="region">
         <h2 id="sys-info-heading"><span aria-hidden="true">💻</span> System Information</h2>
         <dl class="metric-list">


### PR DESCRIPTION
* 💡 What: Added skip-to-content links at the top of the HTML reports in analytics_dashboard.sh and performance_optimizer.sh, and added `id="main-content"` to their `<main>` tags.
* 🎯 Why: Keyboard-only and screen reader users need a way to bypass repetitive headers and navigation to jump straight to the primary content.
* 📸 Before/After: A visually hidden link now appears on focus at the top of the page.
* ♿ Accessibility: Improves keyboard navigation support and provides a standard skip link mechanism.

---
*PR created automatically by Jules for task [15886754888307641632](https://jules.google.com/task/15886754888307641632) started by @abhimehro*