### PR TITLE
🧪 Add tests for run_weekly_retrospective

### DIFF
--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -25,6 +25,7 @@ from repository_automation_tasks import (  # noqa: E402
     run_command_set,
     run_quality_assurance,
     run_safe_adjustment_commands,
+    run_weekly_retrospective,
 )
 
 
@@ -278,6 +279,105 @@ class TestRunCommandSet(unittest.TestCase):
         self.assertIn("## Human review required", data["body"])
         self.assertIn("`setup1` failed and is not marked optional.", data["body"])
         self.assertNotIn("## Optional command warnings", data["body"])
+
+
+@patch("repository_automation_tasks.write_result")
+@patch("repository_automation_tasks.append_publication_result")
+@patch("repository_automation_tasks.weekly_report_lines")
+@patch("repository_automation_tasks.run_safe_adjustment_commands")
+@patch("repository_automation_tasks.ensure_gh_token")
+@patch("repository_automation_tasks.weekly_markers")
+@patch("repository_automation_tasks.recent_daily_runs")
+class TestRunWeeklyRetrospective(unittest.TestCase):
+    def test_run_weekly_retrospective_success(
+        self,
+        mock_recent_daily_runs,
+        mock_weekly_markers,
+        mock_ensure_gh_token,
+        mock_run_safe_adjustment_commands,
+        mock_weekly_report_lines,
+        mock_append_publication_result,
+        mock_write_result
+    ):
+        mock_recent_daily_runs.return_value = ["run1", "run2"]
+        mock_weekly_markers.return_value = ["marker1"]
+        mock_ensure_gh_token.return_value = True
+        mock_run_safe_adjustment_commands.return_value = ([{"name": "safe_cmd", "exit_code": 0}], "http://safe_pr")
+        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+        mock_append_publication_result.return_value = ("appended_body", "http://issue", False)
+        mock_write_result.return_value = {"status": "success"}
+
+        config = {
+            "weekly_retrospective": {"labels": ["weekly"]},
+            "reporting": {"daily_issue_prefix": "[test] Daily", "weekly_issue_prefix": "[test] Weekly"}
+        }
+
+        result = run_weekly_retrospective(config)
+
+        mock_recent_daily_runs.assert_called_once()
+        mock_weekly_markers.assert_called_once_with("[test] Daily")
+        mock_ensure_gh_token.assert_called_once()
+        mock_run_safe_adjustment_commands.assert_called_once_with({"labels": ["weekly"]})
+        mock_weekly_report_lines.assert_called_once_with(config, ["run1", "run2"], ["marker1"], [{"name": "safe_cmd", "exit_code": 0}], "http://safe_pr")
+        mock_write_result.assert_called_once()
+
+        self.assertEqual(result, {"status": "success"})
+
+    def test_run_weekly_retrospective_no_gh_token(
+        self,
+        mock_recent_daily_runs,
+        mock_weekly_markers,
+        mock_ensure_gh_token,
+        mock_run_safe_adjustment_commands,
+        mock_weekly_report_lines,
+        mock_append_publication_result,
+        mock_write_result
+    ):
+        mock_recent_daily_runs.return_value = ["run1", "run2"]
+        mock_weekly_markers.return_value = ["marker1"]
+        mock_ensure_gh_token.return_value = False
+        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+        mock_append_publication_result.return_value = ("appended_body", "http://issue", False)
+        mock_write_result.return_value = {"status": "success"}
+
+        config = {}
+        result = run_weekly_retrospective(config)
+
+        mock_run_safe_adjustment_commands.assert_not_called()
+        mock_weekly_report_lines.assert_called_once_with(config, ["run1", "run2"], ["marker1"], [], "")
+        self.assertEqual(result, {"status": "success"})
+
+    def test_run_weekly_retrospective_publication_error(
+        self,
+        mock_recent_daily_runs,
+        mock_weekly_markers,
+        mock_ensure_gh_token,
+        mock_run_safe_adjustment_commands,
+        mock_weekly_report_lines,
+        mock_append_publication_result,
+        mock_write_result
+    ):
+        mock_recent_daily_runs.return_value = ["run1", "run2"]
+        mock_weekly_markers.return_value = ["marker1"]
+        mock_ensure_gh_token.return_value = True
+        mock_run_safe_adjustment_commands.return_value = ([], "")
+        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+        # error returned by append_publication_result is True
+        mock_append_publication_result.return_value = ("appended_body", "http://issue", True)
+        mock_write_result.return_value = {"status": "failure"}
+
+        config = {}
+        result = run_weekly_retrospective(config)
+
+        # check that write_result is called with status "failure" because error=True
+        mock_write_result.assert_called_once_with(
+            "weekly-retrospective",
+            ("failure", "Reviewed 2 daily workflow runs from the last 7 days."),
+            "appended_body",
+            {"runs": ["run1", "run2"], "issue_url": "http://issue", "safe_pr_url": ""}
+        )
+        self.assertEqual(result, {"status": "failure"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -281,31 +281,38 @@ class TestRunCommandSet(unittest.TestCase):
         self.assertNotIn("## Optional command warnings", data["body"])
 
 
-@patch("repository_automation_tasks.write_result")
-@patch("repository_automation_tasks.append_publication_result")
-@patch("repository_automation_tasks.weekly_report_lines")
-@patch("repository_automation_tasks.run_safe_adjustment_commands")
-@patch("repository_automation_tasks.ensure_gh_token")
-@patch("repository_automation_tasks.weekly_markers")
-@patch("repository_automation_tasks.recent_daily_runs")
 class TestRunWeeklyRetrospective(unittest.TestCase):
-    def test_run_weekly_retrospective_success(
-        self,
-        mock_recent_daily_runs,
-        mock_weekly_markers,
-        mock_ensure_gh_token,
-        mock_run_safe_adjustment_commands,
-        mock_weekly_report_lines,
-        mock_append_publication_result,
-        mock_write_result
-    ):
-        mock_recent_daily_runs.return_value = ["run1", "run2"]
-        mock_weekly_markers.return_value = ["marker1"]
-        mock_ensure_gh_token.return_value = True
-        mock_run_safe_adjustment_commands.return_value = ([{"name": "safe_cmd", "exit_code": 0}], "http://safe_pr")
-        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
-        mock_append_publication_result.return_value = ("appended_body", "http://issue", False)
-        mock_write_result.return_value = {"status": "success"}
+    def setUp(self):
+        self.mock_recent_daily_runs = patch("repository_automation_tasks.recent_daily_runs").start()
+        self.mock_weekly_markers = patch("repository_automation_tasks.weekly_markers").start()
+        self.mock_ensure_gh_token = patch("repository_automation_tasks.ensure_gh_token").start()
+        self.mock_run_safe_adjustment_commands = patch(
+            "repository_automation_tasks.run_safe_adjustment_commands"
+        ).start()
+        self.mock_weekly_report_lines = patch(
+            "repository_automation_tasks.weekly_report_lines"
+        ).start()
+        self.mock_append_publication_result = patch(
+            "repository_automation_tasks.append_publication_result"
+        ).start()
+        self.mock_write_result = patch("repository_automation_tasks.write_result").start()
+        self.addCleanup(patch.stopall)
+
+    def test_run_weekly_retrospective_success(self):
+        self.mock_recent_daily_runs.return_value = ["run1", "run2"]
+        self.mock_weekly_markers.return_value = ["marker1"]
+        self.mock_ensure_gh_token.return_value = True
+        self.mock_run_safe_adjustment_commands.return_value = (
+            [{"name": "safe_cmd", "exit_code": 0}],
+            "http://safe_pr",
+        )
+        self.mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+        self.mock_append_publication_result.return_value = (
+            "appended_body",
+            "http://issue",
+            False,
+        )
+        self.mock_write_result.return_value = {"status": "success"}
 
         config = {
             "weekly_retrospective": {"labels": ["weekly"]},
@@ -314,63 +321,61 @@ class TestRunWeeklyRetrospective(unittest.TestCase):
 
         result = run_weekly_retrospective(config)
 
-        mock_recent_daily_runs.assert_called_once()
-        mock_weekly_markers.assert_called_once_with("[test] Daily")
-        mock_ensure_gh_token.assert_called_once()
-        mock_run_safe_adjustment_commands.assert_called_once_with({"labels": ["weekly"]})
-        mock_weekly_report_lines.assert_called_once_with(config, ["run1", "run2"], ["marker1"], [{"name": "safe_cmd", "exit_code": 0}], "http://safe_pr")
-        mock_write_result.assert_called_once()
+        self.mock_recent_daily_runs.assert_called_once()
+        self.mock_weekly_markers.assert_called_once_with("[test] Daily")
+        self.mock_ensure_gh_token.assert_called_once()
+        self.mock_run_safe_adjustment_commands.assert_called_once_with({"labels": ["weekly"]})
+        self.mock_weekly_report_lines.assert_called_once_with(
+            config,
+            ["run1", "run2"],
+            ["marker1"],
+            [{"name": "safe_cmd", "exit_code": 0}],
+            "http://safe_pr",
+        )
+        self.mock_write_result.assert_called_once()
 
         self.assertEqual(result, {"status": "success"})
 
-    def test_run_weekly_retrospective_no_gh_token(
-        self,
-        mock_recent_daily_runs,
-        mock_weekly_markers,
-        mock_ensure_gh_token,
-        mock_run_safe_adjustment_commands,
-        mock_weekly_report_lines,
-        mock_append_publication_result,
-        mock_write_result
-    ):
-        mock_recent_daily_runs.return_value = ["run1", "run2"]
-        mock_weekly_markers.return_value = ["marker1"]
-        mock_ensure_gh_token.return_value = False
-        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
-        mock_append_publication_result.return_value = ("appended_body", "http://issue", False)
-        mock_write_result.return_value = {"status": "success"}
+    def test_run_weekly_retrospective_no_gh_token(self):
+        self.mock_recent_daily_runs.return_value = ["run1", "run2"]
+        self.mock_weekly_markers.return_value = ["marker1"]
+        self.mock_ensure_gh_token.return_value = False
+        self.mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+        self.mock_append_publication_result.return_value = (
+            "appended_body",
+            "http://issue",
+            False,
+        )
+        self.mock_write_result.return_value = {"status": "success"}
 
         config = {}
         result = run_weekly_retrospective(config)
 
-        mock_run_safe_adjustment_commands.assert_not_called()
-        mock_weekly_report_lines.assert_called_once_with(config, ["run1", "run2"], ["marker1"], [], "")
+        self.mock_run_safe_adjustment_commands.assert_not_called()
+        self.mock_weekly_report_lines.assert_called_once_with(
+            config, ["run1", "run2"], ["marker1"], [], ""
+        )
         self.assertEqual(result, {"status": "success"})
 
-    def test_run_weekly_retrospective_publication_error(
-        self,
-        mock_recent_daily_runs,
-        mock_weekly_markers,
-        mock_ensure_gh_token,
-        mock_run_safe_adjustment_commands,
-        mock_weekly_report_lines,
-        mock_append_publication_result,
-        mock_write_result
-    ):
-        mock_recent_daily_runs.return_value = ["run1", "run2"]
-        mock_weekly_markers.return_value = ["marker1"]
-        mock_ensure_gh_token.return_value = True
-        mock_run_safe_adjustment_commands.return_value = ([], "")
-        mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
+    def test_run_weekly_retrospective_publication_error(self):
+        self.mock_recent_daily_runs.return_value = ["run1", "run2"]
+        self.mock_weekly_markers.return_value = ["marker1"]
+        self.mock_ensure_gh_token.return_value = True
+        self.mock_run_safe_adjustment_commands.return_value = ([], "")
+        self.mock_weekly_report_lines.return_value = ("success", ["line1", "line2"])
         # error returned by append_publication_result is True
-        mock_append_publication_result.return_value = ("appended_body", "http://issue", True)
-        mock_write_result.return_value = {"status": "failure"}
+        self.mock_append_publication_result.return_value = (
+            "appended_body",
+            "http://issue",
+            True,
+        )
+        self.mock_write_result.return_value = {"status": "failure"}
 
         config = {}
         result = run_weekly_retrospective(config)
 
         # check that write_result is called with status "failure" because error=True
-        mock_write_result.assert_called_once_with(
+        self.mock_write_result.assert_called_once_with(
             "weekly-retrospective",
             ("failure", "Reviewed 2 daily workflow runs from the last 7 days."),
             "appended_body",


### PR DESCRIPTION
* 🎯 What: Added missing test coverage for `run_weekly_retrospective` in `repository_automation_tasks.py`.
* 📊 Coverage: Covered the happy path execution, the scenario where writes/GH tokens are unavailable (skipping safe commands), and the error case where appending the publication result fails.
* ✨ Result: Improved reliability by safely testing the high-level retrospective runner without hitting real network APIs.

---
*PR created automatically by Jules for task [7148654817244040870](https://jules.google.com/task/7148654817244040870) started by @abhimehro*