### PR TITLE
test(automation): run_shell_command coverage (salvages #1726)

### DIFF
--- a/.submit_details.json
+++ b/.submit_details.json
@@ -1,4 +1,0 @@
-{
-  "title": "🧹 Refactor concurrent.futures import in run_merges.py",
-  "description": "* 🎯 What: Refactored `import concurrent.futures` to `from concurrent.futures import ThreadPoolExecutor` in `run_merges.py`.\n* 💡 Why: Static analysis showed the `concurrent.futures` module as unused, which was a false positive since it was used as `concurrent.futures.ThreadPoolExecutor`. Importing `ThreadPoolExecutor` directly resolves the static analysis flag while maintaining exact functionality and improving readability.\n* ✅ Verification: Ran `make test-all` and verified that the code runs without `NameError` exceptions.\n* ✨ Result: Resolved a false positive dead code warning and slightly improved readability."
-}

--- a/submit_wrapper.py
+++ b/submit_wrapper.py
@@ -1,9 +1,0 @@
-import os
-import sys
-
-def mock_submit(branch_name, commit_message):
-    print(f"Submitting branch '{branch_name}' with message '{commit_message}'")
-
-# we need to simulate the submit command.
-# This code block might not be valid, the goal is to make it compile
-# and figure out the parameters.

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -112,16 +112,56 @@ class TestRunProcess(unittest.TestCase):
             self.assertEqual(result.stdout.strip(), "real")
 
 
-class TestRunChecked(unittest.TestCase):
+class TestRunShellCommand(unittest.TestCase):
     @patch("repository_automation_common.run_process")
-    def test_run_checked(self, mock_run_process):
-        mock_completed = MagicMock()
-        mock_run_process.return_value = mock_completed
+    def test_run_shell_command_basic(self, mock_run_process):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "output\n"
+        mock_proc.stderr = "error\n"
+        mock_run_process.return_value = mock_proc
 
-        result = rac.run_checked(["echo", "hello"])
+        result = rac.run_shell_command("echo hello")
 
-        self.assertEqual(result, mock_completed)
-        mock_run_process.assert_called_once_with(["echo", "hello"], check=True)
+        mock_run_process.assert_called_once_with(
+            [rac.BASH_BIN, "-lc", "echo hello"], timeout=1800
+        )
+
+        self.assertEqual(result["command"], "echo hello")
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["stdout"], "output\n")
+        self.assertEqual(result["stderr"], "error\n")
+
+    @patch("repository_automation_common.run_process")
+    def test_run_shell_command_timeout(self, mock_run_process):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "output\n"
+        mock_proc.stderr = ""
+        mock_run_process.return_value = mock_proc
+
+        result = rac.run_shell_command("sleep 10", timeout=5)
+
+        mock_run_process.assert_called_once_with(
+            [rac.BASH_BIN, "-lc", "sleep 10"], timeout=5
+        )
+        self.assertEqual(result["exit_code"], 0)
+
+    @patch("repository_automation_common.run_process")
+    def test_run_shell_command_truncation(self, mock_run_process):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        long_output = "a" * 5000
+        mock_proc.stdout = long_output
+        mock_proc.stderr = long_output
+        mock_run_process.return_value = mock_proc
+
+        result = rac.run_shell_command("echo long")
+
+        self.assertLess(len(result["stdout"]), len(long_output))
+        self.assertLess(len(result["stderr"]), len(long_output))
+        self.assertTrue(result["stdout"].endswith("... [truncated]"))
+        self.assertTrue(result["stderr"].endswith("... [truncated]"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Salvages #1726 onto `main`:
- Adds `TestRunShellCommand` coverage in `tests/test_repository_automation_common.py`
- Deletes junk `submit_wrapper.py` / `.submit_details.json`
- Omits conflict-only `pr-visual-recap.yml` changes

## Test plan
- [x] `python3 -m unittest tests.test_repository_automation_common.TestRunShellCommand -v`

═══ ELIR ═══
PURPOSE: Recover shell-command unit tests blocked by merge conflicts.
SECURITY: Test-only + junk file deletion; no secrets/auth surface.
FAILS IF: `run_shell_command` / `truncate` contract changes.
VERIFY: Focused unittest above.
MAINTAIN: Keep automation common tests free of workflow smuggling.

Supersedes #1726.