### PR TITLE
🎨 Palette: Improve screen reader accessibility for data tables

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -338,3 +338,7 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## $(date +%Y-%m-%d) - Preserve list semantics for groups
 **Learning:** When grouping multiple related UI elements (such as a grid of metric cards), replacing the unordered list container (`<ul>`) with a generic `<div>` degrades accessibility by preventing screen readers from announcing the group context and item count.
 **Action:** Always use `<ul>` and `<li>` to group related repeating UI elements. Do not flatten them into generic `<div>` tags in the name of simplicity.
+
+## 2026-07-22 - Accessible Data Tables
+**Learning:** When creating data tables for performance reports, screen readers struggle to associate data cells with their row identifiers if they are marked as simple `<td>` elements.
+**Action:** Always use `<th scope="row">` for the first column in data-heavy tables to ensure proper row-level header associations for screen reader users.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -544,9 +544,9 @@ EOF
 	[[ $disk_usage -gt 90 ]] && disk_status="critical"
 
 	cat >>"$report_file" <<EOF
-            <tr><td>CPU Load</td><td>$cpu_load</td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
-            <tr><td>Memory Free Pages</td><td>$memory_usage</td><td class="good">GOOD</td></tr>
-            <tr><td>Disk Usage</td><td>${disk_usage}%</td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">CPU Load</th><td>$cpu_load</td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">Memory Free Pages</th><td>$memory_usage</td><td class="good">GOOD</td></tr>
+            <tr><th scope="row">Disk Usage</th><td>${disk_usage}%</td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
         </table>
     </section>
     


### PR DESCRIPTION
* 💡 What: Changed the first column in the Performance Metrics data table to use `<th scope="row">` instead of a plain `<td>` element.
* 🎯 Why: This helps screen readers correctly associate the row data (Value and Status) with their respective row identifier (Metric), making the table significantly easier to navigate for visually impaired users.
* 📸 Before/After: Visual presentation remains identical, underlying HTML semantics improved.
* ♿ Accessibility: Improved row-level screen reader associations for data tables by explicitly defining row scopes.

---
*PR created automatically by Jules for task [7237575025386634810](https://jules.google.com/task/7237575025386634810) started by @abhimehro*