### PR TITLE
⚡ Bolt: Compile regex globally to avoid recompilation in loop

### DIFF
--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -572,6 +572,10 @@ def html_ul(items: Iterable[str]) -> str:
     return f"<ul>{''.join(item_list)}</ul>"
 
 
+_EMOJI_HEADING_PATTERN = re.compile(
+    r"^([\U0001F000-\U0001FAFF\U00002600-\U000027BF\u2600-\u27BF]+)\s+(.*)$"
+)
+
 def _render_heading(level: int, title: str, id_attr: str = "") -> str:
     safe_title = sanitize_text(title)
     id_str = f' id="{id_attr}"' if id_attr else ""
@@ -579,10 +583,7 @@ def _render_heading(level: int, title: str, id_attr: str = "") -> str:
     # Safely target emojis specifically by checking unicode ranges where emojis reside
     # rather than all non-ASCII characters. This includes Emoticons, Misc Symbols,
     # Dingbats, and the large Supplementary Multilingual Plane blocks.
-    emoji_pattern = re.compile(
-        r"^([\U0001F000-\U0001FAFF\U00002600-\U000027BF\u2600-\u27BF]+)\s+(.*)$"
-    )
-    match = emoji_pattern.match(safe_title)
+    match = _EMOJI_HEADING_PATTERN.match(safe_title)
     if match:
         icon = match.group(1)
         clean_title = match.group(2)


### PR DESCRIPTION
* 💡 What: Hoisted `re.compile` outside of `_render_heading` to a module-level constant.
* 🎯 Why: Compiling the regex inside `_render_heading` causes it to be recompiled every time a heading is generated, which is unnecessary overhead. Hoisting it to the module level compiles it once at startup.
* 📊 Impact: Eliminates repeated regex compilation overhead for heading generations, slightly improving execution speed.
* 🔬 Measurement: Verified by observing AST execution path; the regex is compiled once globally.

---
*PR created automatically by Jules for task [15243549562013999986](https://jules.google.com/task/15243549562013999986) started by @abhimehro*