### PR TITLE
fix(ssrf): route outbound HTTP through safe_http and harden URL validation

### DIFF
--- a/.agents/skills/save-to-spotify/references/cover-image.md
+++ b/.agents/skills/save-to-spotify/references/cover-image.md
@@ -69,6 +69,9 @@ available, cannot fail.
 **CDN endpoint:**
 `https://save-to-spotify.spotifycdn.com/assets/uts-{01..20}.png`
 
+Only download cover artwork from approved Spotify CDN hosts such as `i.scdn.co`,
+`mosaic.scdn.co`, and `spotifycdn.com`.
+
 ## Typography
 
 **Mandatory** on every cover (unless user opted out in Path 1). Always
@@ -118,7 +121,15 @@ Constants and thresholds are authoritative — see code below for exact values.
 
 ```python
 from PIL import Image, ImageDraw, ImageFont
-import os, hashlib, unicodedata, urllib.request
+import os, hashlib, unicodedata, sys
+from pathlib import Path
+
+# Make the shared safe_http helper importable from any script location.
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
 
 CANVAS = 1400
 MARGIN = 64
@@ -146,7 +157,14 @@ def load_font(size, title=""):
     fname, url = FONTS[detect_script(title)]
     path = os.path.join(FONT_CACHE, fname)
     if not os.path.exists(path):
-        urllib.request.urlretrieve(url, path)
+        # Only download fonts from approved hosts (raw.githubusercontent.com for the OFL mirrors used here).
+        safe_download(
+            url,
+            path,
+            allowed_hosts={"raw.githubusercontent.com"},
+            max_bytes=5 * 1024 * 1024,
+            timeout=30,
+        )
     return ImageFont.truetype(path, size)
 
 def measure_line(font, text):

--- a/.agents/skills/save-to-spotify/references/spotify-api.md
+++ b/.agents/skills/save-to-spotify/references/spotify-api.md
@@ -89,10 +89,21 @@ Minimal dependency-free Python wrapper:
 ```python
 import json
 import subprocess
+import sys
+from pathlib import Path
 from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+
+# Make the shared safe_http helper importable from any script location.
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_request
 
 API = "https://api.spotify.com/v1"
+
+# Allowed Spotify Web API and CDN hosts. Update if Spotify changes endpoints.
+SPOTIFY_ALLOWED_HOSTS = {"api.spotify.com", "i.scdn.co", "mosaic.scdn.co", "spotifycdn.com"}
 
 def spotify_token():
     return subprocess.run(
@@ -104,9 +115,14 @@ def spotify_token():
 
 def spotify_get(path, params):
     url = f"{API}{path}?{urlencode(params)}"
-    req = Request(url, headers={"Authorization": f"Bearer {spotify_token()}"})
-    with urlopen(req, timeout=20) as resp:
-        return json.load(resp)
+    resp = safe_request(
+        "GET",
+        url,
+        allowed_hosts=SPOTIFY_ALLOWED_HOSTS,
+        headers={"Authorization": f"Bearer {spotify_token()}"},
+        timeout=20,
+    )
+    return resp.json()
 
 def spotify_search(query, entity_type, limit=5):
     data = spotify_get("/search", {"q": query, "type": entity_type, "limit": limit})

--- a/.agents/skills/save-to-spotify/references/timeline.md
+++ b/.agents/skills/save-to-spotify/references/timeline.md
@@ -214,8 +214,22 @@ response = client.images.generate(
     quality="standard",
     n=1,
 )
-import urllib.request
-urllib.request.urlretrieve(response.data[0].url, "img.png")
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
+
+safe_download(
+    response.data[0].url,
+    "img.png",
+    allowed_hosts={"oaidalleapiprodscus.blob.core.windows.net"},
+    max_bytes=5 * 1024 * 1024,
+    timeout=60,
+)
 ```
 
 ### Stable Diffusion (local)
@@ -244,7 +258,14 @@ match what the timeline builder expects: `img_<chapter_index>_<slot>.jpg` (slots
 
 ```python
 from openai import OpenAI
-import urllib.request, subprocess, string
+import subprocess, string, sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
 
 client = OpenAI()
 
@@ -266,7 +287,13 @@ for idx, (_, prompts) in enumerate(chapter_images):
         resp = client.images.generate(model="dall-e-3", prompt=prompt,
                                       size="1024x1024", quality="standard", n=1)
         tmp = f"/tmp/raw_{idx}_{slot_letter}.png"
-        urllib.request.urlretrieve(resp.data[0].url, tmp)
+        safe_download(
+            resp.data[0].url,
+            tmp,
+            allowed_hosts={"oaidalleapiprodscus.blob.core.windows.net"},
+            max_bytes=5 * 1024 * 1024,
+            timeout=60,
+        )
         out = f"img_{idx:02d}_{slot_letter}.jpg"
         # Downsize + re-encode to guarantee <= 1 MB, <= 4096x4096, .jpg
         subprocess.check_call([

--- a/.claude/skills/save-to-spotify/references/cover-image.md
+++ b/.claude/skills/save-to-spotify/references/cover-image.md
@@ -69,6 +69,9 @@ available, cannot fail.
 **CDN endpoint:**
 `https://save-to-spotify.spotifycdn.com/assets/uts-{01..20}.png`
 
+Only download cover artwork from approved Spotify CDN hosts such as `i.scdn.co`,
+`mosaic.scdn.co`, and `spotifycdn.com`.
+
 ## Typography
 
 **Mandatory** on every cover (unless user opted out in Path 1). Always
@@ -118,7 +121,15 @@ Constants and thresholds are authoritative — see code below for exact values.
 
 ```python
 from PIL import Image, ImageDraw, ImageFont
-import os, hashlib, unicodedata, urllib.request
+import os, hashlib, unicodedata, sys
+from pathlib import Path
+
+# Make the shared safe_http helper importable from any script location.
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
 
 CANVAS = 1400
 MARGIN = 64
@@ -146,7 +157,14 @@ def load_font(size, title=""):
     fname, url = FONTS[detect_script(title)]
     path = os.path.join(FONT_CACHE, fname)
     if not os.path.exists(path):
-        urllib.request.urlretrieve(url, path)
+        # Only download fonts from approved hosts (raw.githubusercontent.com for the OFL mirrors used here).
+        safe_download(
+            url,
+            path,
+            allowed_hosts={"raw.githubusercontent.com"},
+            max_bytes=5 * 1024 * 1024,
+            timeout=30,
+        )
     return ImageFont.truetype(path, size)
 
 def measure_line(font, text):

--- a/.claude/skills/save-to-spotify/references/spotify-api.md
+++ b/.claude/skills/save-to-spotify/references/spotify-api.md
@@ -89,10 +89,21 @@ Minimal dependency-free Python wrapper:
 ```python
 import json
 import subprocess
+import sys
+from pathlib import Path
 from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+
+# Make the shared safe_http helper importable from any script location.
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_request
 
 API = "https://api.spotify.com/v1"
+
+# Allowed Spotify Web API and CDN hosts. Update if Spotify changes endpoints.
+SPOTIFY_ALLOWED_HOSTS = {"api.spotify.com", "i.scdn.co", "mosaic.scdn.co", "spotifycdn.com"}
 
 def spotify_token():
     return subprocess.run(
@@ -104,9 +115,14 @@ def spotify_token():
 
 def spotify_get(path, params):
     url = f"{API}{path}?{urlencode(params)}"
-    req = Request(url, headers={"Authorization": f"Bearer {spotify_token()}"})
-    with urlopen(req, timeout=20) as resp:
-        return json.load(resp)
+    resp = safe_request(
+        "GET",
+        url,
+        allowed_hosts=SPOTIFY_ALLOWED_HOSTS,
+        headers={"Authorization": f"Bearer {spotify_token()}"},
+        timeout=20,
+    )
+    return resp.json()
 
 def spotify_search(query, entity_type, limit=5):
     data = spotify_get("/search", {"q": query, "type": entity_type, "limit": limit})

--- a/.claude/skills/save-to-spotify/references/timeline.md
+++ b/.claude/skills/save-to-spotify/references/timeline.md
@@ -214,8 +214,22 @@ response = client.images.generate(
     quality="standard",
     n=1,
 )
-import urllib.request
-urllib.request.urlretrieve(response.data[0].url, "img.png")
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
+
+safe_download(
+    response.data[0].url,
+    "img.png",
+    allowed_hosts={"oaidalleapiprodscus.blob.core.windows.net"},
+    max_bytes=5 * 1024 * 1024,
+    timeout=60,
+)
 ```
 
 ### Stable Diffusion (local)
@@ -244,7 +258,14 @@ match what the timeline builder expects: `img_<chapter_index>_<slot>.jpg` (slots
 
 ```python
 from openai import OpenAI
-import urllib.request, subprocess, string
+import subprocess, string, sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from lib.safe_http import safe_download
 
 client = OpenAI()
 
@@ -266,7 +287,13 @@ for idx, (_, prompts) in enumerate(chapter_images):
         resp = client.images.generate(model="dall-e-3", prompt=prompt,
                                       size="1024x1024", quality="standard", n=1)
         tmp = f"/tmp/raw_{idx}_{slot_letter}.png"
-        urllib.request.urlretrieve(resp.data[0].url, tmp)
+        safe_download(
+            resp.data[0].url,
+            tmp,
+            allowed_hosts={"oaidalleapiprodscus.blob.core.windows.net"},
+            max_bytes=5 * 1024 * 1024,
+            timeout=60,
+        )
         out = f"img_{idx:02d}_{slot_letter}.jpg"
         # Downsize + re-encode to guarantee <= 1 MB, <= 4096x4096, .jpg
         subprocess.check_call([

--- a/.github/gitleaks.toml
+++ b/.github/gitleaks.toml
@@ -175,6 +175,11 @@ tags = ["env", "environment", "secret"]
 
 # Exclude patterns - files that are known to contain test/fake secrets
 [allowlist]
+# Suppress false positive in lib/safe_http.py docstring that contained the
+# word "password" followed by prose ("components"). The commit was part of
+# PR #1766 and has since been corrected; this suppresses the historical FP.
+commits = ["ab406fd5d21d059451b7aa3dcfd01a0eb7fd11eb"]
+
 # Suppress GitHub Actions built-in context references that are not real secrets.
 # The personal-config-generic-secret rule matches "secret" as a substring, which
 # causes false positives for:
@@ -183,42 +188,42 @@ tags = ["env", "environment", "secret"]
 #     (job-name fragments inside ${{ needs.*.result }} expressions)
 # These regexes are matched against the captured "secret" value by gitleaks.
 regexes = [
-    # GitHub Actions secrets context: secrets.GITHUB_TOKEN, secrets.MY_TOKEN, etc.
-    '''^secrets\.[A-Za-z0-9_]+$''',
-    # GitHub Actions needs-context results: needs.<job>.result fragments
-    '''^secrets\.result$''',
-    # Prose stopwords after "secret|password|…" (?P<secret> value). Real
-    # credentials are never a single English stopword like these.
-    '''(?i)^(presence|scanning|false-positive|allowlist|detection|validation|management|injection|exfiltration)$''',
+  # GitHub Actions secrets context: secrets.GITHUB_TOKEN, secrets.MY_TOKEN, etc.
+  '''^secrets\.[A-Za-z0-9_]+$''',
+  # GitHub Actions needs-context results: needs.<job>.result fragments
+  '''^secrets\.result$''',
+  # Prose stopwords after "secret|password|…" (?P<secret> value). Real
+  # credentials are never a single English stopword like these.
+  '''(?i)^(presence|scanning|false-positive|allowlist|detection|validation|management|injection|exfiltration)$''',
 ]
 paths = [
-    '''(?i)test''',
-    '''(?i)mock''',
-    '''(?i)example''',
-    '''(?i)sample''',
-    '''(?i)fixture''',
-    '''(?i)template''',
-    '''(?i)dummy''',
-    '''(?i)placeholder''',
-    '''(?i)test_''',
-    '''_test\.''',
-    '''(?i)\.(example|sample|template|dist|bak|backup|old|orig)$''',
-    '''(?i)README''',
-    '''(?i)CHANGELOG''',
-    '''(?i)LICENSE''',
-    '''(?i)CODE_OF_CONDUCT''',
-    '''(?i)CONTRIBUTING''',
-    # ABHI-1321 / PR #1670 — NARROW path allowlist (not all of tasks/).
-    # Rationale: personal-config-generic-secret false-positive on prose
-    # "secret scanning" (keyword + whitespace + 8+ alnum) in the session
-    # journal. Do not expand to tasks/** — other journals may discuss real
-    # credential handling and must stay scanned.
-    # Verified: PR-range gitleaks detect is clean; full-history dispatch may
-    # still flag unrelated pre-existing FPs elsewhere in the tree.
-    '''(?i)^tasks/todo\.md$''',
-    '''(?i)validate_repo_structure\.sh$''',
-    '''(?i)scripts/repair-controld-keepalive\.sh$''',
-    '''(?i)scripts/lib/.*\.sh$''',
+  '''(?i)test''',
+  '''(?i)mock''',
+  '''(?i)example''',
+  '''(?i)sample''',
+  '''(?i)fixture''',
+  '''(?i)template''',
+  '''(?i)dummy''',
+  '''(?i)placeholder''',
+  '''(?i)test_''',
+  '''_test\.''',
+  '''(?i)\.(example|sample|template|dist|bak|backup|old|orig)$''',
+  '''(?i)README''',
+  '''(?i)CHANGELOG''',
+  '''(?i)LICENSE''',
+  '''(?i)CODE_OF_CONDUCT''',
+  '''(?i)CONTRIBUTING''',
+  # ABHI-1321 / PR #1670 — NARROW path allowlist (not all of tasks/).
+  # Rationale: personal-config-generic-secret false-positive on prose
+  # "secret scanning" (keyword + whitespace + 8+ alnum) in the session
+  # journal. Do not expand to tasks/** — other journals may discuss real
+  # credential handling and must stay scanned.
+  # Verified: PR-range gitleaks detect is clean; full-history dispatch may
+  # still flag unrelated pre-existing FPs elsewhere in the tree.
+  '''(?i)^tasks/todo\.md$''',
+  '''(?i)validate_repo_structure\.sh$''',
+  '''(?i)scripts/repair-controld-keepalive\.sh$''',
+  '''(?i)scripts/lib/.*\.sh$''',
 ]
 
 # Exclude specific test patterns
@@ -226,44 +231,40 @@ paths = [
 id = "test-patterns"
 regex = '''(?i)(test|mock|example|sample|dummy|placeholder|fake|stub)'''
 paths = [
-    '''(?i)tests/''',
-    '''(?i)test/''',
-    '''(?i)mock/''',
-    '''(?i)fixtures/''',
+  '''(?i)tests/''',
+  '''(?i)test/''',
+  '''(?i)mock/''',
+  '''(?i)fixtures/''',
 ]
 
 # Exclude documentation files
 [[allowlist.rules]]
 id = "documentation"
 regex = '''(?i)'''
-paths = [
-    '''(?i)docs/''',
-    '''(?i)doc/''',
-    '''(?i)\.(md|markdown|txt|rst)$''',
-]
+paths = ['''(?i)docs/''', '''(?i)doc/''', '''(?i)\.(md|markdown|txt|rst)$''']
 
 # Exclude configuration templates
 [[allowlist.rules]]
 id = "templates"
 regex = '''(?i)(template|example|sample)'''
 paths = [
-    '''(?i)configs/.*\.(template|example|sample|dist)$''',
-    '''(?i)templates/''',
-    '''(?i)examples/''',
+  '''(?i)configs/.*\.(template|example|sample|dist)$''',
+  '''(?i)templates/''',
+  '''(?i)examples/''',
 ]
 
 # Exclude known safe files
 [[allowlist.rules]]
 id = "safe-files"
 paths = [
-    '''(?i)\.(gitignore|gitattributes|gitmodules)$''',
-    '''(?i)Makefile$''',
-    '''(?i)Dockerfile$''',
-    '''(?i)docker-compose\.yml$''',
-    '''(?i)package\.json$''',
-    '''(?i)requirements\.txt$''',
-    '''(?i)setup\.py$''',
-    '''(?i)pyproject\.toml$''',
+  '''(?i)\.(gitignore|gitattributes|gitmodules)$''',
+  '''(?i)Makefile$''',
+  '''(?i)Dockerfile$''',
+  '''(?i)docker-compose\.yml$''',
+  '''(?i)package\.json$''',
+  '''(?i)requirements\.txt$''',
+  '''(?i)setup\.py$''',
+  '''(?i)pyproject\.toml$''',
 ]
 [gitleaks]
 # Enable verbose logging
@@ -287,6 +288,6 @@ configPath = ".github/gitleaks.toml"
 id = "security-scripts"
 regex = '''(?i)(pattern|regex|detect|scan|validate|check)'''
 paths = [
-    '''(?i)scripts/validate_repo_structure\.sh$''',
-    '''(?i)scripts/lib/.*\.sh$''',
+  '''(?i)scripts/validate_repo_structure\.sh$''',
+  '''(?i)scripts/lib/.*\.sh$''',
 ]

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,5 +1,12 @@
 # Generic, formatter-friendly config.
-select = ["B", "D3", "D4", "E", "F"]
+select = ["B", "D3", "D4", "E", "F", "S310"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.
 ignore = ["E501"]
+
+[per-file-ignores]
+# urllib.urlopen is intentionally wrapped inside safe_http; direct use elsewhere is forbidden.
+"lib/safe_http.py" = ["S310"]
+# Scripts add the repo root to sys.path before importing the shared lib helper.
+"scripts/morning-brief/morning-brief.py" = ["E402"]
+"media-streaming/scripts/bootstrap-jellyfin-local.py" = ["E402"]

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Python helpers for the personal-config repository."""

--- a/lib/safe_http.py
+++ b/lib/safe_http.py
@@ -1,0 +1,696 @@
+"""SSRF-safe HTTP helpers for personal-config.
+
+Provides URL validation, safe wrappers around ``requests`` and
+``urllib.request``, redirect validation, and download size limits.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import re
+import shutil
+import socket
+import ssl
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, BinaryIO
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger("safe_http")
+
+MAX_REDIRECTS = 3
+DEFAULT_TIMEOUT = (5, 20)  # (connect, read) seconds
+DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# Tailscale CGNAT range is not considered private by ``ipaddress`` but is not
+# globally routable, so we treat it separately.
+_CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
+
+# Headers that should never be forwarded across hosts on a redirect.
+_AUTH_HEADERS = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "x-emby-token",
+        "x-mediabrowser-token",
+    }
+)
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL fails SSRF validation."""
+
+
+class UnsafeRedirectError(UnsafeURLError):
+    """Raised when a redirect target fails SSRF validation."""
+
+
+class TooManyRedirectsError(UnsafeURLError):
+    """Raised when the redirect hop limit is exceeded."""
+
+
+@dataclass(frozen=True)
+class SafeResponse:
+    """A small, read-once response wrapper for ``urllib`` requests."""
+
+    status: int
+    url: str
+    headers: dict[str, str]
+    body: bytes
+
+    def getcode(self) -> int:
+        """Compatibility alias for urllib-style callers."""
+        return self.status
+
+    def read(self, size: int = -1) -> bytes:
+        """Return the already-read body."""
+        if size < 0 or size >= len(self.body):
+            return self.body
+        return self.body[:size]
+
+    def geturl(self) -> str:
+        """Return the final URL after any redirects."""
+        return self.url
+
+
+def _normalize_host(host: str) -> str:
+    """Lower-case and IDNA-encode a hostname, rejecting obvious homoglyphs."""
+    if not host:
+        raise UnsafeURLError("URL host is required")
+
+    # Reject non-ASCII hostnames by default. If a legitimate IDN is ever
+    # needed, convert via idna first and keep the Punycode form in allowlists.
+    if not host.isascii():
+        raise UnsafeURLError(f"Non-ASCII hostnames are not allowed: {host!r}")
+
+    try:
+        host = host.lower().rstrip(".")
+    except Exception as exc:
+        raise UnsafeURLError(f"Invalid hostname: {host!r}") from exc
+
+    if re.search(r"\s", host):
+        raise UnsafeURLError(f"Invalid hostname: {host!r}")
+
+    return host
+
+
+def _host_key(host: str) -> str | None:
+    """Return the normalized hostname from an allowlist entry that may include a port."""
+    if not host:
+        return None
+    # urlsplit requires a netloc; prepend // for bare host[:port] entries.
+    if "://" not in host:
+        host = "//" + host
+    try:
+        parsed = urllib.parse.urlsplit(host)
+        hostname = parsed.hostname
+    except ValueError:
+        hostname = None
+    if hostname:
+        return hostname.lower().rstrip(".")
+    return host.lower().lstrip("/").rstrip(".")
+
+
+def _is_allowed_host(host: str, allowed_hosts: Iterable[str] | None) -> bool:
+    """Check whether ``host`` is in the allowlist (exact or subdomain match)."""
+    if allowed_hosts is None:
+        return True
+
+    allowed = frozenset(_host_key(h) for h in allowed_hosts if _host_key(h))
+    if not allowed:
+        return True
+
+    if host in allowed:
+        return True
+
+    for a in allowed:
+        if host.endswith(f".{a}"):
+            return True
+
+    return False
+
+
+def _resolve_ips(
+    host: str, port: int
+) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve ``host`` and return the set of IP addresses."""
+    try:
+        addr_info = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, OSError, ValueError) as exc:
+        raise UnsafeURLError(f"Could not resolve {host!r}: {exc}") from exc
+
+    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+    for res in addr_info:
+        ip_str = res[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        # Treat IPv4-mapped IPv6 as IPv4 for policy checks.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        ips.add(ip)
+
+    if not ips:
+        raise UnsafeURLError(f"No IP addresses resolved for {host!r}")
+
+    return ips
+
+
+def _check_ip_safety(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    *,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+) -> None:
+    """Raise ``UnsafeURLError`` if ``ip`` is not permitted."""
+    if ip.is_loopback:
+        if allow_loopback:
+            return
+        raise UnsafeURLError(f"Loopback address is not allowed: {ip}")
+
+    if ip.is_global:
+        return
+
+    if ip.is_link_local:
+        if allow_link_local:
+            return
+        raise UnsafeURLError(f"Link-local address is not allowed: {ip}")
+
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:
+        if allow_cgnat:
+            return
+        raise UnsafeURLError(f"CGNAT address is not allowed: {ip}")
+
+    if ip.is_private:
+        if allow_private:
+            return
+        raise UnsafeURLError(f"Private address is not allowed: {ip}")
+
+    # Multicast, reserved, unspecified, etc.
+    raise UnsafeURLError(f"Non-public address is not allowed: {ip}")
+
+
+def validate_url(
+    url: str,
+    *,
+    allowed_hosts: Iterable[str] | None = None,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+    resolve: bool = True,
+    require_https: bool = False,
+) -> tuple[str, int, set[ipaddress.IPv4Address | ipaddress.IPv6Address]]:
+    """Validate a URL for SSRF safety.
+
+    Returns the normalized hostname, port, and resolved IP set.
+    Raises ``UnsafeURLError`` on any problem.
+    """
+    if not url or not isinstance(url, str):
+        raise UnsafeURLError("URL must be a non-empty string")
+
+    parts = urllib.parse.urlsplit(url)
+    scheme = (parts.scheme or "").lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise UnsafeURLError(f"Unsupported URL scheme: {parts.scheme!r}")
+
+    if require_https and scheme != "https":
+        raise UnsafeURLError("HTTPS is required for this URL")
+
+    if parts.username is not None or parts.password is not None:
+        raise UnsafeURLError("URL userinfo is not allowed")
+
+    host = _normalize_host(parts.hostname or "")
+    if not _is_allowed_host(host, allowed_hosts):
+        raise UnsafeURLError(f"Host is not allowlisted: {host}")
+
+    port = parts.port or (443 if scheme == "https" else 80)
+
+    if not resolve:
+        return host, port, set()
+
+    ips = _resolve_ips(host, port)
+    for ip in ips:
+        _check_ip_safety(
+            ip,
+            allow_loopback=allow_loopback,
+            allow_private=allow_private,
+            allow_link_local=allow_link_local,
+            allow_cgnat=allow_cgnat,
+        )
+
+    return host, port, ips
+
+
+def _strip_auth_headers(
+    headers: Mapping[str, str], old_host: str, new_host: str
+) -> dict[str, str]:
+    """Remove sensitive headers when a redirect crosses hosts."""
+    old = old_host.lower()
+    new = new_host.lower()
+    if old == new:
+        return dict(headers)
+
+    cleaned: dict[str, str] = {}
+    for key, value in headers.items():
+        if key.lower() in _AUTH_HEADERS:
+            logger.debug("Dropping %s header on cross-host redirect", key)
+            continue
+        cleaned[key] = value
+
+    return cleaned
+
+
+def _build_requests_session(
+    total_retries: int = 3,
+    backoff_factor: float = 1.0,
+) -> requests.Session:
+    """Create a ``requests`` session that ignores proxy env vars by default."""
+    session = requests.Session()
+    session.trust_env = False
+    if total_retries > 0:
+        retry = Retry(
+            total=total_retries,
+            connect=total_retries,
+            read=total_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=frozenset(
+                ["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS"]
+            ),
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+    return session
+
+
+def safe_request(
+    method: str,
+    url: str,
+    *,
+    session: requests.Session | None = None,
+    allowed_hosts: Iterable[str] | None = None,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+    require_https: bool = False,
+    max_redirects: int = MAX_REDIRECTS,
+    strip_auth_on_redirect: bool = True,
+    **kwargs: Any,
+) -> requests.Response:
+    """Make an SSRF-safe ``requests`` call with manually validated redirects.
+
+    Proxy environment variables are ignored. ``timeout`` defaults to
+    ``DEFAULT_TIMEOUT``.
+    """
+    if session is None:
+        session = _build_requests_session()
+    else:
+        session.trust_env = False
+
+    if "timeout" not in kwargs:
+        kwargs["timeout"] = DEFAULT_TIMEOUT
+
+    method = method.upper()
+    short_method = method.lower()
+    use_shortcut = short_method in {
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete",
+        "head",
+        "options",
+    }
+    validate_url(
+        url,
+        allowed_hosts=allowed_hosts,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+        require_https=require_https,
+    )
+
+    current_url = url
+    headers = dict(kwargs.pop("headers", {}) or {})
+
+    for hop in range(max_redirects + 1):
+        if use_shortcut:
+            session_method = getattr(session, short_method, session.request)
+        else:
+            session_method = session.request
+
+        if session_method is session.request:
+            response = session_method(
+                method,
+                current_url,
+                headers=headers,
+                allow_redirects=False,
+                **kwargs,
+            )
+        else:
+            response = session_method(
+                current_url,
+                headers=headers,
+                allow_redirects=False,
+                **kwargs,
+            )
+
+        # Real responses have int status_code; mocked or unusual responses are
+        # returned as-is so callers can raise_for_status / parse themselves.
+        status_code = response.status_code
+        if not isinstance(status_code, int):
+            return response
+        if not (300 <= status_code < 400):
+            return response
+
+        if hop == max_redirects:
+            raise TooManyRedirectsError(
+                f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
+            )
+
+        location = response.headers.get("Location") or response.headers.get("location")
+        if not location:
+            raise UnsafeRedirectError("Redirect response missing Location header")
+
+        new_url = urllib.parse.urljoin(current_url, location)
+        old_host = urllib.parse.urlsplit(current_url).hostname or ""
+        new_host = urllib.parse.urlsplit(new_url).hostname or ""
+
+        validate_url(
+            new_url,
+            allowed_hosts=allowed_hosts,
+            allow_loopback=allow_loopback,
+            allow_private=allow_private,
+            allow_link_local=allow_link_local,
+            allow_cgnat=allow_cgnat,
+            require_https=require_https,
+        )
+
+        if strip_auth_on_redirect and old_host.lower() != new_host.lower():
+            headers = _strip_auth_headers(headers, old_host, new_host)
+            # POST data should not be replayed to a different host on a redirect.
+            kwargs.pop("data", None)
+            kwargs.pop("json", None)
+
+        current_url = new_url
+
+    raise TooManyRedirectsError(
+        f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
+    )
+
+
+class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that validates every hop and strips cross-host auth."""
+
+    def __init__(
+        self,
+        *,
+        allowed_hosts: Iterable[str] | None = None,
+        allow_loopback: bool = False,
+        allow_private: bool = False,
+        allow_link_local: bool = False,
+        allow_cgnat: bool = False,
+        require_https: bool = False,
+        max_redirects: int = MAX_REDIRECTS,
+    ):
+        self._allowed_hosts = allowed_hosts
+        self._allow_loopback = allow_loopback
+        self._allow_private = allow_private
+        self._allow_link_local = allow_link_local
+        self._allow_cgnat = allow_cgnat
+        self._require_https = require_https
+        self.max_redirections = max_redirects
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Reject non-HTTP(S) schemes before the default handler re-encodes them.
+        parsed = urllib.parse.urlsplit(newurl)
+        if parsed.scheme and parsed.scheme.lower() not in ALLOWED_SCHEMES:
+            raise urllib.error.HTTPError(
+                newurl,
+                code,
+                f"Redirect to unsupported scheme: {parsed.scheme!r}",
+                headers,
+                fp,
+            )
+
+        validate_url(
+            newurl,
+            allowed_hosts=self._allowed_hosts,
+            allow_loopback=self._allow_loopback,
+            allow_private=self._allow_private,
+            allow_link_local=self._allow_link_local,
+            allow_cgnat=self._allow_cgnat,
+            require_https=self._require_https,
+        )
+
+        old_host = urllib.parse.urlsplit(req.full_url).hostname or ""
+        new_host = parsed.hostname or ""
+        new_headers = {
+            k: v
+            for k, v in req.headers.items()
+            if k.lower() not in _AUTH_HEADERS or old_host.lower() == new_host.lower()
+        }
+
+        # Remove content headers on method-changing redirects; otherwise preserve
+        # the original request body so POST data can follow 307/308 safely.
+        method = req.get_method()
+        data = req.data if method in ("POST", "PUT", "PATCH") else None
+        return urllib.request.Request(
+            newurl,
+            data=data,
+            headers=new_headers,
+            method=method,
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+        )
+
+
+def safe_urlopen(
+    url: str,
+    *,
+    data: bytes | None = None,
+    headers: Mapping[str, str] | None = None,
+    method: str | None = None,
+    timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
+    allowed_hosts: Iterable[str] | None = None,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+    require_https: bool = False,
+    max_redirects: int = MAX_REDIRECTS,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    context: ssl.SSLContext | None = None,
+) -> SafeResponse:
+    """Open ``url`` safely with ``urllib`` and return a read-once response.
+
+    Redirects are validated hop-by-hop, auth headers are stripped on
+    cross-host hops, and the response body is bounded by ``max_bytes``.
+    """
+    # urllib.request only accepts a single numeric timeout; collapse
+    # (connect, read) tuples into a total ceiling.
+    if isinstance(timeout, tuple):
+        timeout = timeout[0] + timeout[1]
+
+    validate_url(
+        url,
+        allowed_hosts=allowed_hosts,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+        require_https=require_https,
+    )
+
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers=dict(headers or {}),
+        method=method,
+    )
+
+    redirect_handler = _ValidatingRedirectHandler(
+        allowed_hosts=allowed_hosts,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+        require_https=require_https,
+        max_redirects=max_redirects,
+    )
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        urllib.request.HTTPHandler,
+        urllib.request.HTTPSHandler(context=context),
+        redirect_handler,
+        urllib.request.HTTPErrorProcessor,
+    )
+
+    try:
+        with opener.open(req, timeout=timeout) as resp:  # nosec B310
+            body = resp.read(max_bytes + 1)
+    except urllib.error.HTTPError as exc:
+        # Re-raise as UnsafeURLError only for validation-triggered errors.
+        if isinstance(exc, UnsafeURLError):
+            raise
+        raise
+
+    if len(body) > max_bytes:
+        raise UnsafeURLError(f"Response exceeds maximum size of {max_bytes} bytes")
+
+    return SafeResponse(
+        status=getattr(resp, "code", resp.getcode()),
+        url=resp.geturl(),
+        headers=dict(resp.headers or {}),
+        body=body,
+    )
+
+
+def safe_download(
+    url: str,
+    destination: str | BinaryIO,
+    *,
+    timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    allowed_hosts: Iterable[str] | None = None,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+    require_https: bool = False,
+    expected_types: Iterable[str] | None = None,
+    **kwargs: Any,
+) -> None:
+    """Stream a remote resource to ``destination`` with size and host checks."""
+    validate_url(
+        url,
+        allowed_hosts=allowed_hosts,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+        require_https=require_https,
+    )
+
+    resp = safe_urlopen(
+        url,
+        timeout=timeout,
+        allowed_hosts=allowed_hosts,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+        require_https=require_https,
+        max_redirects=kwargs.pop("max_redirects", MAX_REDIRECTS),
+        max_bytes=max_bytes,
+    )
+
+    if expected_types:
+        content_type = resp.headers.get("Content-Type", "").lower()
+        if not any(t in content_type for t in expected_types):
+            raise UnsafeURLError(
+                f"Unexpected Content-Type for {url!r}: {content_type!r}"
+            )
+
+    if "Content-Length" in resp.headers:
+        try:
+            length = int(resp.headers["Content-Length"])
+        except ValueError:
+            length = None
+        if length is not None and length > max_bytes:
+            raise UnsafeURLError(f"Content-Length {length} exceeds maximum {max_bytes}")
+
+    if isinstance(destination, str):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(resp.body)
+            tmp_path = tmp.name
+        shutil.move(tmp_path, destination)
+    else:
+        destination.write(resp.body)
+
+
+def build_safe_session(
+    total_retries: int = 3,
+    backoff_factor: float = 1.0,
+) -> requests.Session:
+    """Build a ``requests`` session that ignores proxy env vars.
+
+    Callers should still route requests through ``safe_request`` or pass
+    the same validation parameters to ensure URL validation and redirect
+    handling are applied.
+    """
+    return _build_requests_session(
+        total_retries=total_retries,
+        backoff_factor=backoff_factor,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Validate a URL for SSRF safety")
+    parser.add_argument("--check-url", required=True, help="URL to validate")
+    parser.add_argument(
+        "--allowed-hosts",
+        default="",
+        help="Comma-separated list of allowed hosts",
+    )
+    parser.add_argument(
+        "--allow-loopback",
+        action="store_true",
+        help="Allow loopback addresses",
+    )
+    parser.add_argument(
+        "--allow-private",
+        action="store_true",
+        help="Allow RFC1918 private addresses",
+    )
+    parser.add_argument(
+        "--allow-link-local",
+        action="store_true",
+        help="Allow link-local addresses (including mDNS .local)",
+    )
+    parser.add_argument(
+        "--allow-cgnat",
+        action="store_true",
+        help="Allow 100.64.0.0/10 CGNAT (Tailscale) addresses",
+    )
+    parser.add_argument(
+        "--require-https",
+        action="store_true",
+        help="Require HTTPS scheme",
+    )
+
+    args = parser.parse_args()
+    allowed_hosts = [h.strip() for h in args.allowed_hosts.split(",") if h.strip()]
+    try:
+        validate_url(
+            args.check_url,
+            allowed_hosts=allowed_hosts or None,
+            allow_loopback=args.allow_loopback,
+            allow_private=args.allow_private,
+            allow_link_local=args.allow_link_local,
+            allow_cgnat=args.allow_cgnat,
+            require_https=args.require_https,
+        )
+    except UnsafeURLError as exc:
+        print(f"Unsafe URL: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print("OK")

--- a/lib/safe_http.py
+++ b/lib/safe_http.py
@@ -45,6 +45,12 @@ _AUTH_HEADERS = frozenset(
     }
 )
 
+# HTTP methods that can use the convenience methods on ``requests.Session``.
+_SHORT_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
+
+# HTTP methods that may carry a request body.
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
 
 class UnsafeURLError(ValueError):
     """Raised when a URL fails SSRF validation."""
@@ -86,33 +92,20 @@ def _normalize_host(host: str) -> str:
     """Lower-case and IDNA-encode a hostname, rejecting obvious homoglyphs."""
     if not host:
         raise UnsafeURLError("URL host is required")
-
-    # Reject non-ASCII hostnames by default. If a legitimate IDN is ever
-    # needed, convert via idna first and keep the Punycode form in allowlists.
     if not host.isascii():
         raise UnsafeURLError(f"Non-ASCII hostnames are not allowed: {host!r}")
-
-    try:
-        host = host.lower().rstrip(".")
-    except Exception as exc:
-        raise UnsafeURLError(f"Invalid hostname: {host!r}") from exc
-
     if re.search(r"\s", host):
         raise UnsafeURLError(f"Invalid hostname: {host!r}")
-
-    return host
+    return host.lower().rstrip(".")
 
 
 def _host_key(host: str) -> str | None:
     """Return the normalized hostname from an allowlist entry that may include a port."""
     if not host:
         return None
-    # urlsplit requires a netloc; prepend // for bare host[:port] entries.
-    if "://" not in host:
-        host = "//" + host
+    netloc = host if "://" in host else "//" + host
     try:
-        parsed = urllib.parse.urlsplit(host)
-        hostname = parsed.hostname
+        hostname = urllib.parse.urlsplit(netloc).hostname
     except ValueError:
         hostname = None
     if hostname:
@@ -124,19 +117,36 @@ def _is_allowed_host(host: str, allowed_hosts: Iterable[str] | None) -> bool:
     """Check whether ``host`` is in the allowlist (exact or subdomain match)."""
     if allowed_hosts is None:
         return True
-
-    allowed = frozenset(_host_key(h) for h in allowed_hosts if _host_key(h))
-    if not allowed:
+    allowed = {_host_key(h) for h in allowed_hosts if _host_key(h)}
+    if not allowed or host in allowed:
         return True
+    return any(host.endswith(f".{a}") for a in allowed)
 
-    if host in allowed:
-        return True
 
-    for a in allowed:
-        if host.endswith(f".{a}"):
-            return True
+def _parse_addr_info(
+    addr_info: list,
+) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Convert the result of ``getaddrinfo`` into a set of IP addresses."""
+    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+    for res in addr_info:
+        ip = _parse_addr_entry(res)
+        if ip is not None:
+            ips.add(ip)
+    return ips
 
-    return False
+
+def _parse_addr_entry(
+    res: tuple,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse a single ``getaddrinfo`` result tuple into an IP address."""
+    ip_str = res[4][0]
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip
 
 
 def _resolve_ips(
@@ -147,23 +157,29 @@ def _resolve_ips(
         addr_info = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
     except (socket.gaierror, OSError, ValueError) as exc:
         raise UnsafeURLError(f"Could not resolve {host!r}: {exc}") from exc
-
-    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
-    for res in addr_info:
-        ip_str = res[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
-        # Treat IPv4-mapped IPv6 as IPv4 for policy checks.
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
-            ip = ip.ipv4_mapped
-        ips.add(ip)
-
+    ips = _parse_addr_info(addr_info)
     if not ips:
         raise UnsafeURLError(f"No IP addresses resolved for {host!r}")
-
     return ips
+
+
+def _is_cgnat(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if ``ip`` is in the Tailscale CGNAT range."""
+    return isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK
+
+
+def _maybe_allow(
+    is_category: bool,
+    allowed: bool,
+    label: str,
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True if an IP category is allowed, raise if it is not."""
+    if not is_category:
+        return False
+    if allowed:
+        return True
+    raise UnsafeURLError(f"{label} is not allowed: {ip}")
 
 
 def _check_ip_safety(
@@ -175,31 +191,74 @@ def _check_ip_safety(
     allow_cgnat: bool = False,
 ) -> None:
     """Raise ``UnsafeURLError`` if ``ip`` is not permitted."""
-    if ip.is_loopback:
-        if allow_loopback:
-            return
-        raise UnsafeURLError(f"Loopback address is not allowed: {ip}")
-
     if ip.is_global:
         return
-
-    if ip.is_link_local:
-        if allow_link_local:
-            return
-        raise UnsafeURLError(f"Link-local address is not allowed: {ip}")
-
-    if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:
-        if allow_cgnat:
-            return
-        raise UnsafeURLError(f"CGNAT address is not allowed: {ip}")
-
-    if ip.is_private:
-        if allow_private:
-            return
-        raise UnsafeURLError(f"Private address is not allowed: {ip}")
-
-    # Multicast, reserved, unspecified, etc.
+    if _maybe_allow(ip.is_loopback, allow_loopback, "Loopback address", ip):
+        return
+    if _maybe_allow(ip.is_link_local, allow_link_local, "Link-local address", ip):
+        return
+    if _maybe_allow(ip.is_private, allow_private, "Private address", ip):
+        return
+    if _is_cgnat(ip) and _maybe_allow(True, allow_cgnat, "CGNAT address", ip):
+        return
     raise UnsafeURLError(f"Non-public address is not allowed: {ip}")
+
+
+def _check_ip_set(
+    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    *,
+    allow_loopback: bool = False,
+    allow_private: bool = False,
+    allow_link_local: bool = False,
+    allow_cgnat: bool = False,
+) -> None:
+    """Validate every resolved IP against the safety policy."""
+    for ip in ips:
+        _check_ip_safety(
+            ip,
+            allow_loopback=allow_loopback,
+            allow_private=allow_private,
+            allow_link_local=allow_link_local,
+            allow_cgnat=allow_cgnat,
+        )
+
+
+def _validate_url_string(url: Any) -> urllib.parse.SplitResult:
+    """Ensure ``url`` is a non-empty string and parse it."""
+    if not url or not isinstance(url, str):
+        raise UnsafeURLError("URL must be a non-empty string")
+    return urllib.parse.urlsplit(url)
+
+
+def _validate_scheme(scheme: str, require_https: bool) -> str:
+    """Validate and normalize the URL scheme."""
+    scheme = scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise UnsafeURLError(f"Unsupported URL scheme: {scheme!r}")
+    if require_https and scheme != "https":
+        raise UnsafeURLError("HTTPS is required for this URL")
+    return scheme
+
+
+def _validate_userinfo(parts: urllib.parse.SplitResult) -> None:
+    """Reject URLs that contain username or password components."""
+    if parts.username is not None or parts.password is not None:
+        raise UnsafeURLError("URL userinfo is not allowed")
+
+
+def _resolve_port(scheme: str, explicit_port: int | None) -> int:
+    """Return the port, using scheme defaults when omitted."""
+    if explicit_port is not None:
+        return explicit_port
+    return 443 if scheme == "https" else 80
+
+
+def _validate_host(host: str, allowed_hosts: Iterable[str] | None) -> str:
+    """Normalize and allowlist-check a hostname."""
+    host = _normalize_host(host)
+    if not _is_allowed_host(host, allowed_hosts):
+        raise UnsafeURLError(f"Host is not allowlisted: {host}")
+    return host
 
 
 def validate_url(
@@ -218,39 +277,21 @@ def validate_url(
     Returns the normalized hostname, port, and resolved IP set.
     Raises ``UnsafeURLError`` on any problem.
     """
-    if not url or not isinstance(url, str):
-        raise UnsafeURLError("URL must be a non-empty string")
-
-    parts = urllib.parse.urlsplit(url)
-    scheme = (parts.scheme or "").lower()
-    if scheme not in ALLOWED_SCHEMES:
-        raise UnsafeURLError(f"Unsupported URL scheme: {parts.scheme!r}")
-
-    if require_https and scheme != "https":
-        raise UnsafeURLError("HTTPS is required for this URL")
-
-    if parts.username is not None or parts.password is not None:
-        raise UnsafeURLError("URL userinfo is not allowed")
-
-    host = _normalize_host(parts.hostname or "")
-    if not _is_allowed_host(host, allowed_hosts):
-        raise UnsafeURLError(f"Host is not allowlisted: {host}")
-
-    port = parts.port or (443 if scheme == "https" else 80)
-
+    parts = _validate_url_string(url)
+    scheme = _validate_scheme(parts.scheme or "", require_https)
+    _validate_userinfo(parts)
+    host = _validate_host(parts.hostname or "", allowed_hosts)
+    port = _resolve_port(scheme, parts.port)
     if not resolve:
         return host, port, set()
-
     ips = _resolve_ips(host, port)
-    for ip in ips:
-        _check_ip_safety(
-            ip,
-            allow_loopback=allow_loopback,
-            allow_private=allow_private,
-            allow_link_local=allow_link_local,
-            allow_cgnat=allow_cgnat,
-        )
-
+    _check_ip_set(
+        ips,
+        allow_loopback=allow_loopback,
+        allow_private=allow_private,
+        allow_link_local=allow_link_local,
+        allow_cgnat=allow_cgnat,
+    )
     return host, port, ips
 
 
@@ -258,18 +299,14 @@ def _strip_auth_headers(
     headers: Mapping[str, str], old_host: str, new_host: str
 ) -> dict[str, str]:
     """Remove sensitive headers when a redirect crosses hosts."""
-    old = old_host.lower()
-    new = new_host.lower()
-    if old == new:
+    if old_host.lower() == new_host.lower():
         return dict(headers)
-
     cleaned: dict[str, str] = {}
     for key, value in headers.items():
         if key.lower() in _AUTH_HEADERS:
             logger.debug("Dropping %s header on cross-host redirect", key)
             continue
         cleaned[key] = value
-
     return cleaned
 
 
@@ -280,21 +317,92 @@ def _build_requests_session(
     """Create a ``requests`` session that ignores proxy env vars by default."""
     session = requests.Session()
     session.trust_env = False
-    if total_retries > 0:
-        retry = Retry(
-            total=total_retries,
-            connect=total_retries,
-            read=total_retries,
-            backoff_factor=backoff_factor,
-            status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=frozenset(
-                ["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS"]
-            ),
-        )
-        adapter = HTTPAdapter(max_retries=retry)
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
+    if total_retries <= 0:
+        return session
+    retry = Retry(
+        total=total_retries,
+        connect=total_retries,
+        read=total_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset(["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS"]),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
     return session
+
+
+def _method_shortcut(method: str) -> str | None:
+    """Return the lowercase method name if it maps to a Session helper."""
+    short = method.lower()
+    return short if short in _SHORT_METHODS else None
+
+
+def _send_request(
+    session: requests.Session,
+    method: str,
+    short: str | None,
+    url: str,
+    headers: dict[str, str],
+    **kwargs: Any,
+) -> requests.Response:
+    """Send a single request without following redirects."""
+    if short is None:
+        return session.request(
+            method, url, headers=headers, allow_redirects=False, **kwargs
+        )
+    return getattr(session, short)(
+        url, headers=headers, allow_redirects=False, **kwargs
+    )
+
+
+def _is_redirect_response(response: requests.Response) -> bool:
+    """Return True if the response is an HTTP redirect and status is numeric."""
+    status = response.status_code
+    return isinstance(status, int) and 300 <= status < 400
+
+
+def _extract_redirect_url(current_url: str, response: requests.Response) -> str:
+    """Resolve the Location header into an absolute URL."""
+    location = response.headers.get("Location") or response.headers.get("location")
+    if not location:
+        raise UnsafeRedirectError("Redirect response missing Location header")
+    return urllib.parse.urljoin(current_url, location)
+
+
+def _prepare_redirect(
+    current_url: str,
+    new_url: str,
+    headers: dict[str, str],
+    kwargs: dict[str, Any],
+    strip_auth: bool,
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Validate a redirect target and strip auth/body if the host changes."""
+    old_host = urllib.parse.urlsplit(current_url).hostname or ""
+    new_host = urllib.parse.urlsplit(new_url).hostname or ""
+    if strip_auth and old_host.lower() != new_host.lower():
+        headers = _strip_auth_headers(headers, old_host, new_host)
+        kwargs.pop("data", None)
+        kwargs.pop("json", None)
+    return new_url, headers, kwargs
+
+
+def _safety_flags(
+    allow_loopback: bool,
+    allow_private: bool,
+    allow_link_local: bool,
+    allow_cgnat: bool,
+    require_https: bool,
+) -> dict[str, bool]:
+    """Bundle the safety policy flags into a dict for ``validate_url``."""
+    return {
+        "allow_loopback": allow_loopback,
+        "allow_private": allow_private,
+        "allow_link_local": allow_link_local,
+        "allow_cgnat": allow_cgnat,
+        "require_https": require_https,
+    }
 
 
 def safe_request(
@@ -326,89 +434,29 @@ def safe_request(
         kwargs["timeout"] = DEFAULT_TIMEOUT
 
     method = method.upper()
-    short_method = method.lower()
-    use_shortcut = short_method in {
-        "get",
-        "post",
-        "put",
-        "patch",
-        "delete",
-        "head",
-        "options",
-    }
-    validate_url(
-        url,
-        allowed_hosts=allowed_hosts,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-        require_https=require_https,
+    short = _method_shortcut(method)
+    flags = _safety_flags(
+        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
     )
+    validate_url(url, allowed_hosts=allowed_hosts, **flags)
 
     current_url = url
     headers = dict(kwargs.pop("headers", {}) or {})
 
     for hop in range(max_redirects + 1):
-        if use_shortcut:
-            session_method = getattr(session, short_method, session.request)
-        else:
-            session_method = session.request
-
-        if session_method is session.request:
-            response = session_method(
-                method,
-                current_url,
-                headers=headers,
-                allow_redirects=False,
-                **kwargs,
-            )
-        else:
-            response = session_method(
-                current_url,
-                headers=headers,
-                allow_redirects=False,
-                **kwargs,
-            )
-
-        # Real responses have int status_code; mocked or unusual responses are
-        # returned as-is so callers can raise_for_status / parse themselves.
-        status_code = response.status_code
-        if not isinstance(status_code, int):
+        response = _send_request(session, method, short, current_url, headers, **kwargs)
+        if not _is_redirect_response(response):
             return response
-        if not (300 <= status_code < 400):
-            return response
-
         if hop == max_redirects:
             raise TooManyRedirectsError(
                 f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
             )
 
-        location = response.headers.get("Location") or response.headers.get("location")
-        if not location:
-            raise UnsafeRedirectError("Redirect response missing Location header")
-
-        new_url = urllib.parse.urljoin(current_url, location)
-        old_host = urllib.parse.urlsplit(current_url).hostname or ""
-        new_host = urllib.parse.urlsplit(new_url).hostname or ""
-
-        validate_url(
-            new_url,
-            allowed_hosts=allowed_hosts,
-            allow_loopback=allow_loopback,
-            allow_private=allow_private,
-            allow_link_local=allow_link_local,
-            allow_cgnat=allow_cgnat,
-            require_https=require_https,
+        new_url = _extract_redirect_url(current_url, response)
+        validate_url(new_url, allowed_hosts=allowed_hosts, **flags)
+        current_url, headers, kwargs = _prepare_redirect(
+            current_url, new_url, headers, kwargs, strip_auth_on_redirect
         )
-
-        if strip_auth_on_redirect and old_host.lower() != new_host.lower():
-            headers = _strip_auth_headers(headers, old_host, new_host)
-            # POST data should not be replayed to a different host on a redirect.
-            kwargs.pop("data", None)
-            kwargs.pop("json", None)
-
-        current_url = new_url
 
     raise TooManyRedirectsError(
         f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
@@ -430,15 +478,13 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
         max_redirects: int = MAX_REDIRECTS,
     ):
         self._allowed_hosts = allowed_hosts
-        self._allow_loopback = allow_loopback
-        self._allow_private = allow_private
-        self._allow_link_local = allow_link_local
-        self._allow_cgnat = allow_cgnat
-        self._require_https = require_https
+        self._flags = _safety_flags(
+            allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
+        )
         self.max_redirections = max_redirects
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
-        # Reject non-HTTP(S) schemes before the default handler re-encodes them.
+        """Validate the redirect and build a sanitized follow-up request."""
         parsed = urllib.parse.urlsplit(newurl)
         if parsed.scheme and parsed.scheme.lower() not in ALLOWED_SCHEMES:
             raise urllib.error.HTTPError(
@@ -449,28 +495,14 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
                 fp,
             )
 
-        validate_url(
-            newurl,
-            allowed_hosts=self._allowed_hosts,
-            allow_loopback=self._allow_loopback,
-            allow_private=self._allow_private,
-            allow_link_local=self._allow_link_local,
-            allow_cgnat=self._allow_cgnat,
-            require_https=self._require_https,
-        )
+        validate_url(newurl, allowed_hosts=self._allowed_hosts, **self._flags)
 
         old_host = urllib.parse.urlsplit(req.full_url).hostname or ""
         new_host = parsed.hostname or ""
-        new_headers = {
-            k: v
-            for k, v in req.headers.items()
-            if k.lower() not in _AUTH_HEADERS or old_host.lower() == new_host.lower()
-        }
+        new_headers = self._filter_headers(req.headers, old_host, new_host)
 
-        # Remove content headers on method-changing redirects; otherwise preserve
-        # the original request body so POST data can follow 307/308 safely.
         method = req.get_method()
-        data = req.data if method in ("POST", "PUT", "PATCH") else None
+        data = req.data if method in _BODY_METHODS else None
         return urllib.request.Request(
             newurl,
             data=data,
@@ -479,6 +511,62 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
             origin_req_host=req.origin_req_host,
             unverifiable=True,
         )
+
+    def _filter_headers(
+        self, headers: dict[str, str], old_host: str, new_host: str
+    ) -> dict[str, str]:
+        """Preserve auth headers only when the redirect stays on the same host."""
+        keep_auth = old_host.lower() == new_host.lower()
+        return {
+            k: v
+            for k, v in headers.items()
+            if k.lower() not in _AUTH_HEADERS or keep_auth
+        }
+
+
+def _collapse_timeout(timeout: float | tuple[float, float]) -> float:
+    """Collapse a (connect, read) tuple into a single numeric timeout."""
+    if isinstance(timeout, tuple):
+        return timeout[0] + timeout[1]
+    return timeout
+
+
+def _build_safe_opener(
+    redirect_handler: urllib.request.HTTPRedirectHandler,
+    context: ssl.SSLContext | None,
+) -> urllib.request.OpenerDirector:
+    """Assemble an opener that ignores proxies and uses the validating handler."""
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        urllib.request.HTTPHandler,
+        urllib.request.HTTPSHandler(context=context),
+        redirect_handler,
+        urllib.request.HTTPErrorProcessor,
+    )
+
+
+def _read_body(
+    opener: urllib.request.OpenerDirector,
+    req: urllib.request.Request,
+    timeout: float,
+    max_bytes: int,
+) -> tuple[Any, bytes]:
+    """Open the request and read up to ``max_bytes + 1`` bytes."""
+    with opener.open(req, timeout=timeout) as resp:  # nosec B310
+        body = resp.read(max_bytes + 1)
+    return resp, body
+
+
+def _make_safe_response(resp: Any, body: bytes, max_bytes: int) -> SafeResponse:
+    """Build a ``SafeResponse`` and enforce the size limit."""
+    if len(body) > max_bytes:
+        raise UnsafeURLError(f"Response exceeds maximum size of {max_bytes} bytes")
+    return SafeResponse(
+        status=getattr(resp, "code", resp.getcode()),
+        url=resp.geturl(),
+        headers=dict(resp.headers or {}),
+        body=body,
+    )
 
 
 def safe_urlopen(
@@ -503,20 +591,11 @@ def safe_urlopen(
     Redirects are validated hop-by-hop, auth headers are stripped on
     cross-host hops, and the response body is bounded by ``max_bytes``.
     """
-    # urllib.request only accepts a single numeric timeout; collapse
-    # (connect, read) tuples into a total ceiling.
-    if isinstance(timeout, tuple):
-        timeout = timeout[0] + timeout[1]
-
-    validate_url(
-        url,
-        allowed_hosts=allowed_hosts,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-        require_https=require_https,
+    timeout = _collapse_timeout(timeout)
+    flags = _safety_flags(
+        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
     )
+    validate_url(url, allowed_hosts=allowed_hosts, **flags)
 
     req = urllib.request.Request(
         url,
@@ -534,32 +613,49 @@ def safe_urlopen(
         require_https=require_https,
         max_redirects=max_redirects,
     )
-    opener = urllib.request.build_opener(
-        urllib.request.ProxyHandler({}),
-        urllib.request.HTTPHandler,
-        urllib.request.HTTPSHandler(context=context),
-        redirect_handler,
-        urllib.request.HTTPErrorProcessor,
-    )
+    opener = _build_safe_opener(redirect_handler, context)
 
     try:
-        with opener.open(req, timeout=timeout) as resp:  # nosec B310
-            body = resp.read(max_bytes + 1)
+        resp, body = _read_body(opener, req, timeout, max_bytes)
     except urllib.error.HTTPError as exc:
-        # Re-raise as UnsafeURLError only for validation-triggered errors.
         if isinstance(exc, UnsafeURLError):
             raise
         raise
 
-    if len(body) > max_bytes:
-        raise UnsafeURLError(f"Response exceeds maximum size of {max_bytes} bytes")
+    return _make_safe_response(resp, body, max_bytes)
 
-    return SafeResponse(
-        status=getattr(resp, "code", resp.getcode()),
-        url=resp.geturl(),
-        headers=dict(resp.headers or {}),
-        body=body,
-    )
+
+def _check_content_type(
+    headers: dict[str, str], expected_types: Iterable[str], url: str
+) -> None:
+    """Raise if the response Content-Type is not in the expected set."""
+    content_type = headers.get("Content-Type", "").lower()
+    if not any(t in content_type for t in expected_types):
+        raise UnsafeURLError(f"Unexpected Content-Type for {url!r}: {content_type!r}")
+
+
+def _check_content_length(headers: dict[str, str], max_bytes: int) -> None:
+    """Raise if the declared Content-Length exceeds the maximum."""
+    raw = headers.get("Content-Length")
+    if raw is None:
+        return
+    try:
+        length = int(raw)
+    except ValueError:
+        return
+    if length > max_bytes:
+        raise UnsafeURLError(f"Content-Length {length} exceeds maximum {max_bytes}")
+
+
+def _write_destination(destination: str | BinaryIO, body: bytes) -> None:
+    """Write the downloaded body to a path or file-like object."""
+    if isinstance(destination, str):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(body)
+            tmp_path = tmp.name
+        shutil.move(tmp_path, destination)
+    else:
+        destination.write(body)
 
 
 def safe_download(
@@ -578,15 +674,10 @@ def safe_download(
     **kwargs: Any,
 ) -> None:
     """Stream a remote resource to ``destination`` with size and host checks."""
-    validate_url(
-        url,
-        allowed_hosts=allowed_hosts,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-        require_https=require_https,
+    flags = _safety_flags(
+        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
     )
+    validate_url(url, allowed_hosts=allowed_hosts, **flags)
 
     resp = safe_urlopen(
         url,
@@ -602,27 +693,9 @@ def safe_download(
     )
 
     if expected_types:
-        content_type = resp.headers.get("Content-Type", "").lower()
-        if not any(t in content_type for t in expected_types):
-            raise UnsafeURLError(
-                f"Unexpected Content-Type for {url!r}: {content_type!r}"
-            )
-
-    if "Content-Length" in resp.headers:
-        try:
-            length = int(resp.headers["Content-Length"])
-        except ValueError:
-            length = None
-        if length is not None and length > max_bytes:
-            raise UnsafeURLError(f"Content-Length {length} exceeds maximum {max_bytes}")
-
-    if isinstance(destination, str):
-        with tempfile.NamedTemporaryFile(delete=False) as tmp:
-            tmp.write(resp.body)
-            tmp_path = tmp.name
-        shutil.move(tmp_path, destination)
-    else:
-        destination.write(resp.body)
+        _check_content_type(resp.headers, expected_types, url)
+    _check_content_length(resp.headers, max_bytes)
+    _write_destination(destination, resp.body)
 
 
 def build_safe_session(
@@ -680,15 +753,18 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     allowed_hosts = [h.strip() for h in args.allowed_hosts.split(",") if h.strip()]
+    flags = _safety_flags(
+        args.allow_loopback,
+        args.allow_private,
+        args.allow_link_local,
+        args.allow_cgnat,
+        args.require_https,
+    )
     try:
         validate_url(
             args.check_url,
             allowed_hosts=allowed_hosts or None,
-            allow_loopback=args.allow_loopback,
-            allow_private=args.allow_private,
-            allow_link_local=args.allow_link_local,
-            allow_cgnat=args.allow_cgnat,
-            require_https=args.require_https,
+            **flags,
         )
     except UnsafeURLError as exc:
         print(f"Unsafe URL: {exc}", file=sys.stderr)

--- a/lib/safe_http.py
+++ b/lib/safe_http.py
@@ -353,11 +353,11 @@ def _method_shortcut(method: str) -> str | None:
 def _send_one_request(
     session: requests.Session,
     method: str,
-    short: str | None,
     url: str,
     request_kwargs: dict[str, Any],
 ) -> requests.Response:
     """Send a single request without following redirects."""
+    short = _method_shortcut(method)
     if short is None:
         return session.request(method, url, allow_redirects=False, **request_kwargs)
     return getattr(session, short)(url, allow_redirects=False, **request_kwargs)
@@ -407,31 +407,6 @@ def _sanitize_redirect_kwargs(
         request_kwargs.pop("json", None)
 
 
-def _request_with_redirects(
-    session: requests.Session,
-    method: str,
-    short: str | None,
-    current_url: str,
-    request_kwargs: dict[str, Any],
-    options: dict[str, Any],
-    remaining: int,
-) -> requests.Response:
-    """Follow redirects manually while re-validating each hop."""
-    response = _send_one_request(session, method, short, current_url, request_kwargs)
-    if _is_redirect_response(response):
-        if remaining <= 0:
-            raise TooManyRedirectsError(
-                f"Maximum redirect hops ({options['max_redirects']}) exceeded starting from {current_url!r}"
-            )
-        new_url = _extract_redirect_url(current_url, response)
-        validate_url(new_url, **options)
-        _sanitize_redirect_kwargs(request_kwargs, current_url, new_url, options)
-        return _request_with_redirects(
-            session, method, short, new_url, request_kwargs, options, remaining - 1
-        )
-    return response
-
-
 def safe_request(
     method: str,
     url: str,
@@ -458,10 +433,23 @@ def safe_request(
         kwargs["headers"] = dict(kwargs["headers"])
 
     method = method.upper()
-    short = _method_shortcut(method)
     validate_url(url, **options)
-    return _request_with_redirects(
-        session, method, short, url, kwargs, options, options["max_redirects"]
+    original_url = url
+    current_url = url
+    max_redirects = options["max_redirects"]
+    for hop in range(max_redirects + 1):
+        response = _send_one_request(session, method, current_url, kwargs)
+        if not _is_redirect_response(response):
+            return response
+        if hop == max_redirects:
+            raise TooManyRedirectsError(
+                f"Maximum redirect hops ({max_redirects}) exceeded starting from {original_url!r}"
+            )
+        current_url = _extract_redirect_url(current_url, response)
+        validate_url(current_url, **options)
+        _sanitize_redirect_kwargs(kwargs, original_url, current_url, options)
+    raise TooManyRedirectsError(
+        f"Maximum redirect hops ({max_redirects}) exceeded starting from {original_url!r}"
     )
 
 
@@ -501,8 +489,13 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
         self._options = _extract_safety_options(safety_kwargs)
         self.max_redirections = self._options["max_redirects"]
 
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        """Validate the redirect and build a sanitized follow-up request."""
+    def redirect_request(self, *args):
+        """Validate the redirect and build a sanitized follow-up request.
+
+        ``*args`` is used because the parent-class signature has six positional
+        parameters (``req, fp, code, msg, headers, newurl``).
+        """
+        req, fp, code, msg, headers, newurl = args
         parsed = urllib.parse.urlsplit(newurl)
         if not _is_allowed_scheme(parsed.scheme):
             raise urllib.error.HTTPError(
@@ -580,19 +573,23 @@ def _make_safe_response(resp: Any, body: bytes, max_bytes: int) -> SafeResponse:
 def safe_urlopen(
     url: str,
     *,
-    data: bytes | None = None,
-    headers: Mapping[str, str] | None = None,
-    method: str | None = None,
     timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
     context: ssl.SSLContext | None = None,
-    **safety_kwargs: Any,
+    **kwargs: Any,
 ) -> SafeResponse:
     """Open ``url`` safely with ``urllib`` and return a read-once response.
 
     Redirects are validated hop-by-hop, auth headers are stripped on
     cross-host hops, and the response body is bounded by ``max_bytes``.
+
+    Request parameters may be passed as keyword arguments:
+    ``data``, ``headers``, ``method``. Remaining keyword arguments are
+    treated as safety options.
     """
-    options = _extract_safety_options(safety_kwargs)
+    data = kwargs.pop("data", None)
+    headers = kwargs.pop("headers", None)
+    method = kwargs.pop("method", None)
+    options = _extract_safety_options(kwargs)
     timeout = _collapse_timeout(timeout)
     validate_url(url, **options)
 
@@ -649,11 +646,11 @@ def safe_download(
     destination: str | BinaryIO,
     *,
     timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
-    expected_types: Iterable[str] | None = None,
-    **safety_kwargs: Any,
+    **kwargs: Any,
 ) -> None:
     """Stream a remote resource to ``destination`` with size and host checks."""
-    options = _extract_safety_options(safety_kwargs)
+    expected_types = kwargs.pop("expected_types", None)
+    options = _extract_safety_options(kwargs)
     resp = safe_urlopen(url, timeout=timeout, **options)
     max_bytes = options["max_bytes"]
     if expected_types:
@@ -676,23 +673,6 @@ def build_safe_session(
         total_retries=total_retries,
         backoff_factor=backoff_factor,
     )
-
-
-def _safety_flags(
-    allow_loopback: bool,
-    allow_private: bool,
-    allow_link_local: bool,
-    allow_cgnat: bool,
-    require_https: bool,
-) -> dict[str, bool]:
-    """Bundle the boolean safety flags for CLI callers."""
-    return {
-        "allow_loopback": allow_loopback,
-        "allow_private": allow_private,
-        "allow_link_local": allow_link_local,
-        "allow_cgnat": allow_cgnat,
-        "require_https": require_https,
-    }
 
 
 if __name__ == "__main__":
@@ -734,13 +714,13 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     allowed_hosts = [h.strip() for h in args.allowed_hosts.split(",") if h.strip()]
-    flags = _safety_flags(
-        args.allow_loopback,
-        args.allow_private,
-        args.allow_link_local,
-        args.allow_cgnat,
-        args.require_https,
-    )
+    flags = {
+        "allow_loopback": args.allow_loopback,
+        "allow_private": args.allow_private,
+        "allow_link_local": args.allow_link_local,
+        "allow_cgnat": args.allow_cgnat,
+        "require_https": args.require_https,
+    }
     try:
         validate_url(
             args.check_url,

--- a/lib/safe_http.py
+++ b/lib/safe_http.py
@@ -51,6 +51,20 @@ _SHORT_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "op
 # HTTP methods that may carry a request body.
 _BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
 
+# Safety options shared by the public helpers. Populated from ``**kwargs``.
+_SAFETY_DEFAULTS: dict[str, Any] = {
+    "allowed_hosts": None,
+    "allow_loopback": False,
+    "allow_private": False,
+    "allow_link_local": False,
+    "allow_cgnat": False,
+    "require_https": False,
+    "max_redirects": MAX_REDIRECTS,
+    "max_bytes": DEFAULT_MAX_BYTES,
+    "strip_auth_on_redirect": True,
+}
+_SAFETY_KEYS = frozenset(_SAFETY_DEFAULTS.keys())
+
 
 class UnsafeURLError(ValueError):
     """Raised when a URL fails SSRF validation."""
@@ -88,6 +102,11 @@ class SafeResponse:
         return self.url
 
 
+def _extract_safety_options(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Pop safety-related keys from ``kwargs`` and return them as a dict."""
+    return {key: kwargs.pop(key, _SAFETY_DEFAULTS[key]) for key in _SAFETY_KEYS}
+
+
 def _normalize_host(host: str) -> str:
     """Lower-case and IDNA-encode a hostname, rejecting obvious homoglyphs."""
     if not host:
@@ -101,26 +120,49 @@ def _normalize_host(host: str) -> str:
 
 def _host_key(host: str) -> str | None:
     """Return the normalized hostname from an allowlist entry that may include a port."""
-    if not host:
-        return None
-    netloc = host if "://" in host else "//" + host
-    try:
-        hostname = urllib.parse.urlsplit(netloc).hostname
-    except ValueError:
-        hostname = None
-    if hostname:
-        return hostname.lower().rstrip(".")
-    return host.lower().lstrip("/").rstrip(".")
+    if host:
+        if "://" in host:
+            netloc = host
+        else:
+            netloc = "//" + host
+        try:
+            hostname = urllib.parse.urlsplit(netloc).hostname
+        except ValueError:
+            hostname = None
+        if hostname:
+            return hostname.lower().rstrip(".")
+        return netloc.lower().lstrip("/").rstrip(".")
+    return None
+
+
+def _allowed_host_set(allowed_hosts: Iterable[str]) -> set[str]:
+    """Build a normalized set of allowlisted hostnames."""
+    allowed: set[str] = set()
+    for entry in allowed_hosts:
+        key = _host_key(entry)
+        if key:
+            allowed.add(key)
+    return allowed
+
+
+def _is_subdomain(host: str, allowed: set[str]) -> bool:
+    """Return True when ``host`` is a subdomain of an entry in ``allowed``."""
+    for entry in allowed:
+        if host.endswith(f".{entry}"):
+            return True
+    return False
 
 
 def _is_allowed_host(host: str, allowed_hosts: Iterable[str] | None) -> bool:
     """Check whether ``host`` is in the allowlist (exact or subdomain match)."""
     if allowed_hosts is None:
         return True
-    allowed = {_host_key(h) for h in allowed_hosts if _host_key(h)}
-    if not allowed or host in allowed:
-        return True
-    return any(host.endswith(f".{a}") for a in allowed)
+    allowed = _allowed_host_set(allowed_hosts)
+    if allowed:
+        if host in allowed:
+            return True
+        return _is_subdomain(host, allowed)
+    return True
 
 
 def _parse_addr_info(
@@ -130,7 +172,7 @@ def _parse_addr_info(
     ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
     for res in addr_info:
         ip = _parse_addr_entry(res)
-        if ip is not None:
+        if ip:
             ips.add(ip)
     return ips
 
@@ -158,9 +200,9 @@ def _resolve_ips(
     except (socket.gaierror, OSError, ValueError) as exc:
         raise UnsafeURLError(f"Could not resolve {host!r}: {exc}") from exc
     ips = _parse_addr_info(addr_info)
-    if not ips:
-        raise UnsafeURLError(f"No IP addresses resolved for {host!r}")
-    return ips
+    if ips:
+        return ips
+    raise UnsafeURLError(f"No IP addresses resolved for {host!r}")
 
 
 def _is_cgnat(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -168,80 +210,64 @@ def _is_cgnat(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK
 
 
-def _maybe_allow(
-    is_category: bool,
-    allowed: bool,
-    label: str,
+def _check_ip_category(
     ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
-) -> bool:
-    """Return True if an IP category is allowed, raise if it is not."""
-    if not is_category:
-        return False
-    if allowed:
-        return True
+    flag: str,
+    label: str,
+    options: dict[str, Any],
+) -> None:
+    """Raise ``UnsafeURLError`` if the flagged IP category is not allowed."""
+    if options.get(flag):
+        return
     raise UnsafeURLError(f"{label} is not allowed: {ip}")
 
 
 def _check_ip_safety(
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
-    *,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address, options: dict[str, Any]
 ) -> None:
     """Raise ``UnsafeURLError`` if ``ip`` is not permitted."""
     if ip.is_global:
         return
-    if _maybe_allow(ip.is_loopback, allow_loopback, "Loopback address", ip):
-        return
-    if _maybe_allow(ip.is_link_local, allow_link_local, "Link-local address", ip):
-        return
-    if _maybe_allow(ip.is_private, allow_private, "Private address", ip):
-        return
-    if _is_cgnat(ip) and _maybe_allow(True, allow_cgnat, "CGNAT address", ip):
-        return
+    checks = (
+        (ip.is_loopback, "allow_loopback", "Loopback address"),
+        (ip.is_link_local, "allow_link_local", "Link-local address"),
+        (ip.is_private, "allow_private", "Private address"),
+        (_is_cgnat(ip), "allow_cgnat", "CGNAT address"),
+    )
+    for is_category, flag, label in checks:
+        if is_category:
+            _check_ip_category(ip, flag, label, options)
+            return
     raise UnsafeURLError(f"Non-public address is not allowed: {ip}")
 
 
 def _check_ip_set(
-    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address],
-    *,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
+    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address], options: dict[str, Any]
 ) -> None:
     """Validate every resolved IP against the safety policy."""
     for ip in ips:
-        _check_ip_safety(
-            ip,
-            allow_loopback=allow_loopback,
-            allow_private=allow_private,
-            allow_link_local=allow_link_local,
-            allow_cgnat=allow_cgnat,
-        )
+        _check_ip_safety(ip, options)
 
 
 def _validate_url_string(url: Any) -> urllib.parse.SplitResult:
     """Ensure ``url`` is a non-empty string and parse it."""
-    if not url or not isinstance(url, str):
-        raise UnsafeURLError("URL must be a non-empty string")
-    return urllib.parse.urlsplit(url)
+    if url and isinstance(url, str):
+        return urllib.parse.urlsplit(url)
+    raise UnsafeURLError("URL must be a non-empty string")
 
 
-def _validate_scheme(scheme: str, require_https: bool) -> str:
+def _validate_scheme(scheme: str, options: dict[str, Any]) -> str:
     """Validate and normalize the URL scheme."""
     scheme = scheme.lower()
     if scheme not in ALLOWED_SCHEMES:
         raise UnsafeURLError(f"Unsupported URL scheme: {scheme!r}")
-    if require_https and scheme != "https":
+    if options.get("require_https") and scheme != "https":
         raise UnsafeURLError("HTTPS is required for this URL")
     return scheme
 
 
 def _validate_userinfo(parts: urllib.parse.SplitResult) -> None:
-    """Reject URLs that contain username or password components."""
+    """Reject URLs that contain embedded credentials."""
     if parts.username is not None or parts.password is not None:
         raise UnsafeURLError("URL userinfo is not allowed")
 
@@ -253,58 +279,43 @@ def _resolve_port(scheme: str, explicit_port: int | None) -> int:
     return 443 if scheme == "https" else 80
 
 
-def _validate_host(host: str, allowed_hosts: Iterable[str] | None) -> str:
+def _validate_host(host: str | None, allowed_hosts: Iterable[str] | None) -> str:
     """Normalize and allowlist-check a hostname."""
     host = _normalize_host(host)
-    if not _is_allowed_host(host, allowed_hosts):
-        raise UnsafeURLError(f"Host is not allowlisted: {host}")
-    return host
+    if _is_allowed_host(host, allowed_hosts):
+        return host
+    raise UnsafeURLError(f"Host is not allowlisted: {host}")
 
 
 def validate_url(
     url: str,
     *,
-    allowed_hosts: Iterable[str] | None = None,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
     resolve: bool = True,
-    require_https: bool = False,
+    **safety_kwargs: Any,
 ) -> tuple[str, int, set[ipaddress.IPv4Address | ipaddress.IPv6Address]]:
     """Validate a URL for SSRF safety.
 
     Returns the normalized hostname, port, and resolved IP set.
     Raises ``UnsafeURLError`` on any problem.
     """
+    options = _extract_safety_options(safety_kwargs)
     parts = _validate_url_string(url)
-    scheme = _validate_scheme(parts.scheme or "", require_https)
+    scheme = _validate_scheme(parts.scheme, options)
     _validate_userinfo(parts)
-    host = _validate_host(parts.hostname or "", allowed_hosts)
+    host = _validate_host(parts.hostname, options.get("allowed_hosts"))
     port = _resolve_port(scheme, parts.port)
-    if not resolve:
-        return host, port, set()
-    ips = _resolve_ips(host, port)
-    _check_ip_set(
-        ips,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-    )
-    return host, port, ips
+    if resolve:
+        ips = _resolve_ips(host, port)
+        _check_ip_set(ips, options)
+        return host, port, ips
+    return host, port, set()
 
 
-def _strip_auth_headers(
-    headers: Mapping[str, str], old_host: str, new_host: str
-) -> dict[str, str]:
-    """Remove sensitive headers when a redirect crosses hosts."""
-    if old_host.lower() == new_host.lower():
-        return dict(headers)
+def _strip_auth_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Remove sensitive headers from a header dict."""
     cleaned: dict[str, str] = {}
     for key, value in headers.items():
         if key.lower() in _AUTH_HEADERS:
-            logger.debug("Dropping %s header on cross-host redirect", key)
             continue
         cleaned[key] = value
     return cleaned
@@ -339,70 +350,86 @@ def _method_shortcut(method: str) -> str | None:
     return short if short in _SHORT_METHODS else None
 
 
-def _send_request(
+def _send_one_request(
     session: requests.Session,
     method: str,
     short: str | None,
     url: str,
-    headers: dict[str, str],
-    **kwargs: Any,
+    request_kwargs: dict[str, Any],
 ) -> requests.Response:
     """Send a single request without following redirects."""
     if short is None:
-        return session.request(
-            method, url, headers=headers, allow_redirects=False, **kwargs
-        )
-    return getattr(session, short)(
-        url, headers=headers, allow_redirects=False, **kwargs
-    )
+        return session.request(method, url, allow_redirects=False, **request_kwargs)
+    return getattr(session, short)(url, allow_redirects=False, **request_kwargs)
 
 
 def _is_redirect_response(response: requests.Response) -> bool:
     """Return True if the response is an HTTP redirect and status is numeric."""
     status = response.status_code
-    return isinstance(status, int) and 300 <= status < 400
+    if isinstance(status, int):
+        return 300 <= status < 400
+    return False
 
 
 def _extract_redirect_url(current_url: str, response: requests.Response) -> str:
     """Resolve the Location header into an absolute URL."""
-    location = response.headers.get("Location") or response.headers.get("location")
-    if not location:
-        raise UnsafeRedirectError("Redirect response missing Location header")
-    return urllib.parse.urljoin(current_url, location)
+    location = response.headers.get("Location")
+    if location is None:
+        location = response.headers.get("location")
+    if location:
+        return urllib.parse.urljoin(current_url, location)
+    raise UnsafeRedirectError("Redirect response missing Location header")
 
 
-def _prepare_redirect(
-    current_url: str,
+def _same_host(old_url: str, new_url: str) -> bool:
+    """Compare the hostnames of two URLs case-insensitively."""
+    old_host = urllib.parse.urlsplit(old_url).hostname
+    new_host = urllib.parse.urlsplit(new_url).hostname
+    if old_host is None:
+        old_host = ""
+    if new_host is None:
+        new_host = ""
+    return old_host.lower() == new_host.lower()
+
+
+def _sanitize_redirect_kwargs(
+    request_kwargs: dict[str, Any],
+    old_url: str,
     new_url: str,
-    headers: dict[str, str],
-    kwargs: dict[str, Any],
-    strip_auth: bool,
-) -> tuple[str, dict[str, str], dict[str, Any]]:
-    """Validate a redirect target and strip auth/body if the host changes."""
-    old_host = urllib.parse.urlsplit(current_url).hostname or ""
-    new_host = urllib.parse.urlsplit(new_url).hostname or ""
-    if strip_auth and old_host.lower() != new_host.lower():
-        headers = _strip_auth_headers(headers, old_host, new_host)
-        kwargs.pop("data", None)
-        kwargs.pop("json", None)
-    return new_url, headers, kwargs
+    options: dict[str, Any],
+) -> None:
+    """Strip auth headers and body when a redirect crosses hosts."""
+    if options.get("strip_auth_on_redirect", True):
+        if _same_host(old_url, new_url):
+            return
+        request_kwargs["headers"] = _strip_auth_headers(request_kwargs["headers"])
+        request_kwargs.pop("data", None)
+        request_kwargs.pop("json", None)
 
 
-def _safety_flags(
-    allow_loopback: bool,
-    allow_private: bool,
-    allow_link_local: bool,
-    allow_cgnat: bool,
-    require_https: bool,
-) -> dict[str, bool]:
-    """Bundle the safety policy flags into a dict for ``validate_url``."""
-    return {
-        "allow_loopback": allow_loopback,
-        "allow_private": allow_private,
-        "allow_link_local": allow_link_local,
-        "allow_cgnat": allow_cgnat,
-        "require_https": require_https,
-    }
+def _request_with_redirects(
+    session: requests.Session,
+    method: str,
+    short: str | None,
+    current_url: str,
+    request_kwargs: dict[str, Any],
+    options: dict[str, Any],
+    remaining: int,
+) -> requests.Response:
+    """Follow redirects manually while re-validating each hop."""
+    response = _send_one_request(session, method, short, current_url, request_kwargs)
+    if _is_redirect_response(response):
+        if remaining <= 0:
+            raise TooManyRedirectsError(
+                f"Maximum redirect hops ({options['max_redirects']}) exceeded starting from {current_url!r}"
+            )
+        new_url = _extract_redirect_url(current_url, response)
+        validate_url(new_url, **options)
+        _sanitize_redirect_kwargs(request_kwargs, current_url, new_url, options)
+        return _request_with_redirects(
+            session, method, short, new_url, request_kwargs, options, remaining - 1
+        )
+    return response
 
 
 def safe_request(
@@ -410,14 +437,6 @@ def safe_request(
     url: str,
     *,
     session: requests.Session | None = None,
-    allowed_hosts: Iterable[str] | None = None,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
-    require_https: bool = False,
-    max_redirects: int = MAX_REDIRECTS,
-    strip_auth_on_redirect: bool = True,
     **kwargs: Any,
 ) -> requests.Response:
     """Make an SSRF-safe ``requests`` call with manually validated redirects.
@@ -430,63 +449,62 @@ def safe_request(
     else:
         session.trust_env = False
 
-    if "timeout" not in kwargs:
-        kwargs["timeout"] = DEFAULT_TIMEOUT
+    options = _extract_safety_options(kwargs)
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+
+    if kwargs.get("headers") is None:
+        kwargs["headers"] = {}
+    else:
+        kwargs["headers"] = dict(kwargs["headers"])
 
     method = method.upper()
     short = _method_shortcut(method)
-    flags = _safety_flags(
-        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
+    validate_url(url, **options)
+    return _request_with_redirects(
+        session, method, short, url, kwargs, options, options["max_redirects"]
     )
-    validate_url(url, allowed_hosts=allowed_hosts, **flags)
 
-    current_url = url
-    headers = dict(kwargs.pop("headers", {}) or {})
 
-    for hop in range(max_redirects + 1):
-        response = _send_request(session, method, short, current_url, headers, **kwargs)
-        if not _is_redirect_response(response):
-            return response
-        if hop == max_redirects:
-            raise TooManyRedirectsError(
-                f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
-            )
+def _is_allowed_scheme(scheme: str | None) -> bool:
+    """Return True when the scheme is missing or in the allowed set."""
+    if scheme is None:
+        return True
+    return scheme.lower() in ALLOWED_SCHEMES
 
-        new_url = _extract_redirect_url(current_url, response)
-        validate_url(new_url, allowed_hosts=allowed_hosts, **flags)
-        current_url, headers, kwargs = _prepare_redirect(
-            current_url, new_url, headers, kwargs, strip_auth_on_redirect
-        )
 
-    raise TooManyRedirectsError(
-        f"Maximum redirect hops ({max_redirects}) exceeded starting from {url!r}"
-    )
+def _redirect_body(req: urllib.request.Request) -> bytes | None:
+    """Preserve the request body for methods that may carry one."""
+    method = req.get_method()
+    if method in _BODY_METHODS:
+        return req.data
+    return None
+
+
+def _filter_headers(
+    headers: dict[str, str], old_host: str, new_host: str, strip_auth: bool
+) -> dict[str, str]:
+    """Preserve auth headers only when the redirect stays on the same host."""
+    if strip_auth and old_host.lower() != new_host.lower():
+        cleaned: dict[str, str] = {}
+        for key, value in headers.items():
+            if key.lower() in _AUTH_HEADERS:
+                continue
+            cleaned[key] = value
+        return cleaned
+    return dict(headers)
 
 
 class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
     """Redirect handler that validates every hop and strips cross-host auth."""
 
-    def __init__(
-        self,
-        *,
-        allowed_hosts: Iterable[str] | None = None,
-        allow_loopback: bool = False,
-        allow_private: bool = False,
-        allow_link_local: bool = False,
-        allow_cgnat: bool = False,
-        require_https: bool = False,
-        max_redirects: int = MAX_REDIRECTS,
-    ):
-        self._allowed_hosts = allowed_hosts
-        self._flags = _safety_flags(
-            allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
-        )
-        self.max_redirections = max_redirects
+    def __init__(self, **safety_kwargs: Any):
+        self._options = _extract_safety_options(safety_kwargs)
+        self.max_redirections = self._options["max_redirects"]
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         """Validate the redirect and build a sanitized follow-up request."""
         parsed = urllib.parse.urlsplit(newurl)
-        if parsed.scheme and parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        if not _is_allowed_scheme(parsed.scheme):
             raise urllib.error.HTTPError(
                 newurl,
                 code,
@@ -495,14 +513,15 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
                 fp,
             )
 
-        validate_url(newurl, allowed_hosts=self._allowed_hosts, **self._flags)
+        validate_url(newurl, **self._options)
 
         old_host = urllib.parse.urlsplit(req.full_url).hostname or ""
         new_host = parsed.hostname or ""
-        new_headers = self._filter_headers(req.headers, old_host, new_host)
+        strip_auth = self._options.get("strip_auth_on_redirect", True)
+        new_headers = _filter_headers(req.headers, old_host, new_host, strip_auth)
 
         method = req.get_method()
-        data = req.data if method in _BODY_METHODS else None
+        data = _redirect_body(req)
         return urllib.request.Request(
             newurl,
             data=data,
@@ -511,17 +530,6 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
             origin_req_host=req.origin_req_host,
             unverifiable=True,
         )
-
-    def _filter_headers(
-        self, headers: dict[str, str], old_host: str, new_host: str
-    ) -> dict[str, str]:
-        """Preserve auth headers only when the redirect stays on the same host."""
-        keep_auth = old_host.lower() == new_host.lower()
-        return {
-            k: v
-            for k, v in headers.items()
-            if k.lower() not in _AUTH_HEADERS or keep_auth
-        }
 
 
 def _collapse_timeout(timeout: float | tuple[float, float]) -> float:
@@ -576,26 +584,17 @@ def safe_urlopen(
     headers: Mapping[str, str] | None = None,
     method: str | None = None,
     timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
-    allowed_hosts: Iterable[str] | None = None,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
-    require_https: bool = False,
-    max_redirects: int = MAX_REDIRECTS,
-    max_bytes: int = DEFAULT_MAX_BYTES,
     context: ssl.SSLContext | None = None,
+    **safety_kwargs: Any,
 ) -> SafeResponse:
     """Open ``url`` safely with ``urllib`` and return a read-once response.
 
     Redirects are validated hop-by-hop, auth headers are stripped on
     cross-host hops, and the response body is bounded by ``max_bytes``.
     """
+    options = _extract_safety_options(safety_kwargs)
     timeout = _collapse_timeout(timeout)
-    flags = _safety_flags(
-        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
-    )
-    validate_url(url, allowed_hosts=allowed_hosts, **flags)
+    validate_url(url, **options)
 
     req = urllib.request.Request(
         url,
@@ -604,25 +603,10 @@ def safe_urlopen(
         method=method,
     )
 
-    redirect_handler = _ValidatingRedirectHandler(
-        allowed_hosts=allowed_hosts,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-        require_https=require_https,
-        max_redirects=max_redirects,
-    )
+    redirect_handler = _ValidatingRedirectHandler(**options)
     opener = _build_safe_opener(redirect_handler, context)
-
-    try:
-        resp, body = _read_body(opener, req, timeout, max_bytes)
-    except urllib.error.HTTPError as exc:
-        if isinstance(exc, UnsafeURLError):
-            raise
-        raise
-
-    return _make_safe_response(resp, body, max_bytes)
+    resp, body = _read_body(opener, req, timeout, options["max_bytes"])
+    return _make_safe_response(resp, body, options["max_bytes"])
 
 
 def _check_content_type(
@@ -630,8 +614,10 @@ def _check_content_type(
 ) -> None:
     """Raise if the response Content-Type is not in the expected set."""
     content_type = headers.get("Content-Type", "").lower()
-    if not any(t in content_type for t in expected_types):
-        raise UnsafeURLError(f"Unexpected Content-Type for {url!r}: {content_type!r}")
+    for t in expected_types:
+        if t in content_type:
+            return
+    raise UnsafeURLError(f"Unexpected Content-Type for {url!r}: {content_type!r}")
 
 
 def _check_content_length(headers: dict[str, str], max_bytes: int) -> None:
@@ -663,35 +649,13 @@ def safe_download(
     destination: str | BinaryIO,
     *,
     timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
-    max_bytes: int = DEFAULT_MAX_BYTES,
-    allowed_hosts: Iterable[str] | None = None,
-    allow_loopback: bool = False,
-    allow_private: bool = False,
-    allow_link_local: bool = False,
-    allow_cgnat: bool = False,
-    require_https: bool = False,
     expected_types: Iterable[str] | None = None,
-    **kwargs: Any,
+    **safety_kwargs: Any,
 ) -> None:
     """Stream a remote resource to ``destination`` with size and host checks."""
-    flags = _safety_flags(
-        allow_loopback, allow_private, allow_link_local, allow_cgnat, require_https
-    )
-    validate_url(url, allowed_hosts=allowed_hosts, **flags)
-
-    resp = safe_urlopen(
-        url,
-        timeout=timeout,
-        allowed_hosts=allowed_hosts,
-        allow_loopback=allow_loopback,
-        allow_private=allow_private,
-        allow_link_local=allow_link_local,
-        allow_cgnat=allow_cgnat,
-        require_https=require_https,
-        max_redirects=kwargs.pop("max_redirects", MAX_REDIRECTS),
-        max_bytes=max_bytes,
-    )
-
+    options = _extract_safety_options(safety_kwargs)
+    resp = safe_urlopen(url, timeout=timeout, **options)
+    max_bytes = options["max_bytes"]
     if expected_types:
         _check_content_type(resp.headers, expected_types, url)
     _check_content_length(resp.headers, max_bytes)
@@ -712,6 +676,23 @@ def build_safe_session(
         total_retries=total_retries,
         backoff_factor=backoff_factor,
     )
+
+
+def _safety_flags(
+    allow_loopback: bool,
+    allow_private: bool,
+    allow_link_local: bool,
+    allow_cgnat: bool,
+    require_https: bool,
+) -> dict[str, bool]:
+    """Bundle the boolean safety flags for CLI callers."""
+    return {
+        "allow_loopback": allow_loopback,
+        "allow_private": allow_private,
+        "allow_link_local": allow_link_local,
+        "allow_cgnat": allow_cgnat,
+        "require_https": require_https,
+    }
 
 
 if __name__ == "__main__":

--- a/media-streaming/scripts/bootstrap-jellyfin-local.py
+++ b/media-streaming/scripts/bootstrap-jellyfin-local.py
@@ -65,6 +65,54 @@ def _body_has_password(body: dict | None) -> bool:
     return bool(keys & {"password", "pw"})
 
 
+def _request_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": CLIENT_HDR,
+    }
+    if token:
+        headers["Authorization"] = f"MediaBrowser Token={token}"
+    return headers
+
+
+def _encode_body(body: dict | None) -> bytes | None:
+    if body is None:
+        return None
+    return json.dumps(body).encode()
+
+
+def _parse_response_body(raw: bytes) -> object:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode())
+    except json.JSONDecodeError:
+        return raw.decode(errors="replace")
+
+
+def _parse_http_error(exc: urllib.error.HTTPError) -> tuple[int, object]:
+    raw = exc.read()
+    if not raw:
+        return exc.code, None
+    try:
+        return exc.code, json.loads(raw.decode())
+    except json.JSONDecodeError:
+        return exc.code, raw.decode(errors="replace")
+
+
+def _https_required_for_credentials(
+    host: str, token: str | None, body: dict | None
+) -> bool:
+    has_credentials = token is not None or _body_has_password(body)
+    return (
+        has_credentials and not _is_loopback_host(host) and not JELLYFIN_ALLOW_INSECURE
+    )
+
+
+def _non_loopback_allowed() -> bool:
+    return bool(JELLYFIN_ALLOWED_HOSTS - _LOOPBACK_HOSTS)
+
+
 def http(
     method: str,
     path: str,
@@ -76,53 +124,29 @@ def http(
     full_url = f"{BASE}{path}"
     parsed = urllib.parse.urlsplit(BASE)
     host = (parsed.hostname or "").lower()
-    has_credentials = token is not None or _body_has_password(body)
-    require_https = (
-        has_credentials and not _is_loopback_host(host) and not JELLYFIN_ALLOW_INSECURE
-    )
-
-    has_non_loopback_allowed = bool(JELLYFIN_ALLOWED_HOSTS - _LOOPBACK_HOSTS)
-
-    data = None if body is None else json.dumps(body).encode()
-    headers: dict[str, str] = {
-        "Content-Type": "application/json",
-        "Authorization": CLIENT_HDR,
-    }
-    if token:
-        headers["Authorization"] = f"MediaBrowser Token={token}"
+    require_https = _https_required_for_credentials(host, token, body)
+    allow_private = _non_loopback_allowed()
 
     try:
         resp = safe_urlopen(
             full_url,
-            data=data,
-            headers=headers,
+            data=_encode_body(body),
+            headers=_request_headers(token),
             method=method,
             timeout=timeout,
             allowed_hosts=JELLYFIN_ALLOWED_HOSTS,
             allow_loopback=True,
-            allow_private=has_non_loopback_allowed,
-            allow_link_local=has_non_loopback_allowed,
-            allow_cgnat=has_non_loopback_allowed,
+            allow_private=allow_private,
+            allow_link_local=allow_private,
+            allow_cgnat=allow_private,
             require_https=require_https,
         )
     except UnsafeURLError as exc:
         raise ValueError(f"Unsafe JELLYFIN_URL or redirect: {exc}") from exc
-    except urllib.error.HTTPError as e:
-        raw = e.read()
-        try:
-            payload: object = json.loads(raw.decode()) if raw else None
-        except json.JSONDecodeError:
-            payload = raw.decode(errors="replace") if raw else None
-        return e.code, payload
+    except urllib.error.HTTPError as exc:
+        return _parse_http_error(exc)
 
-    code = resp.status
-    raw = resp.body
-    if not raw:
-        return code, None
-    try:
-        return code, json.loads(raw.decode())
-    except json.JSONDecodeError:
-        return code, raw.decode(errors="replace")
+    return resp.status, _parse_response_body(resp.body)
 
 
 def _launchctl_bin() -> str:

--- a/media-streaming/scripts/bootstrap-jellyfin-local.py
+++ b/media-streaming/scripts/bootstrap-jellyfin-local.py
@@ -12,18 +12,38 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 import secrets
 import shutil
 import string
 import subprocess  # nosec B404 — used only for fixed launchctl argv (no shell)
-import sys
 import time
 import urllib.error
 import urllib.parse
-import urllib.request
-from pathlib import Path
+
+from lib.safe_http import UnsafeURLError, safe_urlopen
 
 BASE = os.environ.get("JELLYFIN_URL", "http://127.0.0.1:8096").rstrip("/")
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+_USER_ALLOWED_HOSTS = [
+    h.strip()
+    for h in os.environ.get("JELLYFIN_ALLOWED_HOSTS", "").split(",")
+    if h.strip()
+]
+JELLYFIN_ALLOWED_HOSTS = set(_LOOPBACK_HOSTS) | set(_USER_ALLOWED_HOSTS)
+JELLYFIN_ALLOW_INSECURE = os.environ.get("JELLYFIN_ALLOW_INSECURE", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 MOUNT = Path(os.environ.get("JELLYFIN_MEDIA_ROOT", Path.home() / "CloudMedia/mounted"))
 JF_DIR = Path.home() / "Library/Application Support/jellyfin"
 CREDS = JF_DIR / "local-admin.credentials"
@@ -34,6 +54,17 @@ CLIENT_HDR = (
 )
 
 
+def _is_loopback_host(host: str) -> bool:
+    return host.lower() in _LOOPBACK_HOSTS
+
+
+def _body_has_password(body: dict | None) -> bool:
+    if not isinstance(body, dict):
+        return False
+    keys = {k.lower() for k in body}
+    return bool(keys & {"password", "pw"})
+
+
 def http(
     method: str,
     path: str,
@@ -42,30 +73,40 @@ def http(
     token: str | None = None,
     timeout: float = 30.0,
 ) -> tuple[int, object]:
-    data = None if body is None else json.dumps(body).encode()
-    req = urllib.request.Request(
-        f"{BASE}{path}",
-        data=data,
-        method=method,
-        headers={"Content-Type": "application/json", "Authorization": CLIENT_HDR},
+    full_url = f"{BASE}{path}"
+    parsed = urllib.parse.urlsplit(BASE)
+    host = (parsed.hostname or "").lower()
+    has_credentials = token is not None or _body_has_password(body)
+    require_https = (
+        has_credentials and not _is_loopback_host(host) and not JELLYFIN_ALLOW_INSECURE
     )
+
+    has_non_loopback_allowed = bool(JELLYFIN_ALLOWED_HOSTS - _LOOPBACK_HOSTS)
+
+    data = None if body is None else json.dumps(body).encode()
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "Authorization": CLIENT_HDR,
+    }
     if token:
-        req.add_header("Authorization", f"MediaBrowser Token={token}")
-    # SECURITY: BASE is loopback by default; reject non-http(s) schemes.
-    if not BASE.startswith(("http://", "https://")):
-        raise ValueError(f"Refusing non-http(s) JELLYFIN_URL: {BASE!r}")
+        headers["Authorization"] = f"MediaBrowser Token={token}"
+
     try:
-        with urllib.request.urlopen(
-            req, timeout=timeout
-        ) as resp:  # nosec B310 — http(s) only via BASE gate
-            raw = resp.read()
-            code = resp.getcode()
-            if not raw:
-                return code, None
-            try:
-                return code, json.loads(raw.decode())
-            except json.JSONDecodeError:
-                return code, raw.decode(errors="replace")
+        resp = safe_urlopen(
+            full_url,
+            data=data,
+            headers=headers,
+            method=method,
+            timeout=timeout,
+            allowed_hosts=JELLYFIN_ALLOWED_HOSTS,
+            allow_loopback=True,
+            allow_private=has_non_loopback_allowed,
+            allow_link_local=has_non_loopback_allowed,
+            allow_cgnat=has_non_loopback_allowed,
+            require_https=require_https,
+        )
+    except UnsafeURLError as exc:
+        raise ValueError(f"Unsafe JELLYFIN_URL or redirect: {exc}") from exc
     except urllib.error.HTTPError as e:
         raw = e.read()
         try:
@@ -73,6 +114,15 @@ def http(
         except json.JSONDecodeError:
             payload = raw.decode(errors="replace") if raw else None
         return e.code, payload
+
+    code = resp.status
+    raw = resp.body
+    if not raw:
+        return code, None
+    try:
+        return code, json.loads(raw.decode())
+    except json.JSONDecodeError:
+        return code, raw.decode(errors="replace")
 
 
 def _launchctl_bin() -> str:

--- a/media-streaming/scripts/validate-jellyfin.sh
+++ b/media-streaming/scripts/validate-jellyfin.sh
@@ -7,6 +7,10 @@
 #   2 = soft: server up but wizard/auth not finished (expected pre-HITL)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 BASE_URL="${JELLYFIN_URL:-http://127.0.0.1:8096}"
@@ -38,6 +42,31 @@ echo "URL:   $BASE_URL"
 echo "Mount: $MOUNT_POINT"
 echo
 
+# SSRF guard: validate JELLYFIN_URL before any curl sends credentials to it.
+host="$(python3 -c "import urllib.parse, sys; print(urllib.parse.urlsplit(sys.argv[1]).hostname or '')" "$BASE_URL")"
+is_loopback=0
+case "$host" in
+127.0.0.1 | localhost | ::1) is_loopback=1 ;;
+esac
+
+ssrf_args=("--check-url" "$BASE_URL")
+if [[ $is_loopback -eq 1 ]]; then
+	ssrf_args+=("--allow-loopback")
+fi
+if [[ -n ${JELLYFIN_ALLOWED_HOSTS-} ]]; then
+	ssrf_args+=("--allowed-hosts" "$JELLYFIN_ALLOWED_HOSTS")
+	ssrf_args+=("--allow-private" "--allow-link-local" "--allow-cgnat")
+fi
+if [[ $is_loopback -eq 0 && ${JELLYFIN_ALLOW_INSECURE:-0} != "1" ]]; then
+	ssrf_args+=("--require-https")
+fi
+if ! python3 -m lib.safe_http "${ssrf_args[@]}" >/dev/null 2>&1; then
+	bad "JELLYFIN_URL failed SSRF validation (host=$host; check JELLYFIN_ALLOWED_HOSTS / JELLYFIN_ALLOW_INSECURE)"
+	echo "Summary: pass=$pass soft=$soft fail=$fail"
+	exit 1
+fi
+ok "JELLYFIN_URL passed SSRF validation"
+
 # 1) Mount readable
 if [[ -d $MOUNT_POINT ]] && [[ -n "$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)" ]]; then
 	ok "CloudMedia mount has entries"
@@ -61,11 +90,11 @@ else
 fi
 
 # 2) HTTP health / startup
-http_code="$(curl -sS -o "$TMP_BODY" -w '%{http_code}' --max-time 5 "$BASE_URL/health" 2>/dev/null || echo '000')"
+http_code="$(curl -sS -o "$TMP_BODY" -w '%{http_code}' --connect-timeout 5 --max-time 5 --proto '=http,https' --max-redirs 0 "$BASE_URL/health" 2>/dev/null || echo '000')"
 if [[ $http_code == 200 ]]; then
 	ok "GET /health → 200"
 elif [[ $http_code == 000 ]]; then
-	http_code="$(curl -sS -o "$TMP_BODY" -w '%{http_code}' --max-time 5 "$BASE_URL/" 2>/dev/null || echo '000')"
+	http_code="$(curl -sS -o "$TMP_BODY" -w '%{http_code}' --connect-timeout 5 --max-time 5 --proto '=http,https' --max-redirs 0 "$BASE_URL/" 2>/dev/null || echo '000')"
 	if [[ $http_code == 2* || $http_code == 3* ]]; then
 		warn "Server responds on / (HTTP $http_code) but /health not ready — finish wizard?"
 	else
@@ -76,7 +105,7 @@ else
 fi
 
 # 3) Public system info (no auth)
-if curl -fsS --max-time 5 "$BASE_URL/System/Info/Public" -o "$TMP_INFO" 2>/dev/null; then
+if curl -fsS --connect-timeout 5 --max-time 5 --proto '=http,https' --max-redirs 0 "$BASE_URL/System/Info/Public" -o "$TMP_INFO" 2>/dev/null; then
 	ok "System/Info/Public reachable"
 	if command -v python3 >/dev/null 2>&1; then
 		set +e
@@ -102,7 +131,7 @@ fi
 
 # 4) Optional authenticated Items count
 if [[ -n $API_KEY ]]; then
-	items_json="$(curl -fsS --max-time 15 \
+	items_json="$(curl -fsS --connect-timeout 5 --max-time 15 --proto '=http,https' --max-redirs 0 \
 		-H "Authorization: MediaBrowser Token=$API_KEY" \
 		"$BASE_URL/Items?Recursive=true&IncludeItemTypes=Movie,Episode&Limit=5" 2>/dev/null || true)"
 	if [[ -n $items_json ]] && echo "$items_json" | grep -q '"Items"'; then

--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -47,6 +47,13 @@ Cache control:
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 import concurrent.futures
 import datetime as dt
 import hashlib
@@ -55,19 +62,15 @@ import json
 import logging
 import os
 import re
-import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
-from pathlib import Path
 from typing import Any, Iterable, Optional
 
 import feedparser
 import requests
 from dotenv import load_dotenv
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 # ============================================================
 # Constants
@@ -75,6 +78,42 @@ from urllib3.util.retry import Retry
 
 APP_NAME = "morning-brief"
 APP_VERSION = "3.0"
+
+from lib.safe_http import build_safe_session, safe_request
+
+MORNING_BRIEF_ALLOWED_HOSTS = frozenset(
+    {
+        "api.perplexity.ai",
+        "api.linear.app",
+        "api.open-meteo.com",
+        "readwise.io",
+        "horoscope-app-api.vercel.app",
+        "ohmanda.com",
+        "americaadapts.libsyn.com",
+        "thelensnola.org",
+        "lailluminator.com",
+        "www.wrkf.org",
+        "veritenews.org",
+        "thecurrentla.com",
+    }
+)
+
+VALID_ZODIAC_SIGNS = frozenset(
+    {
+        "aries",
+        "taurus",
+        "gemini",
+        "cancer",
+        "leo",
+        "virgo",
+        "libra",
+        "scorpio",
+        "sagittarius",
+        "capricorn",
+        "aquarius",
+        "pisces",
+    }
+)
 
 READWISE_SAVE_URL = "https://readwise.io/api/v3/save"
 PERPLEXITY_CHAT_URL = "https://api.perplexity.ai/chat/completions"
@@ -138,7 +177,6 @@ LINEAR_LABEL_BONUSES: dict[str, int] = {
 
 LINEAR_LABEL_BONUSES_ITEMS = tuple(LINEAR_LABEL_BONUSES.items())
 LINEAR_PRIORITY_SCORES = {1: 80, 2: 60, 3: 30, 4: 10}
-
 
 
 HOROSCOPE_ENDPOINTS_TEMPLATE = [
@@ -410,19 +448,8 @@ def build_retry_session(
     total: int = 3,
     backoff_factor: float = 1.0,
 ) -> requests.Session:
-    """Create a requests session with retry logic."""
-    session = requests.Session()
-    retry = Retry(
-        total=total,
-        connect=total,
-        read=total,
-        backoff_factor=backoff_factor,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset(["GET", "POST"]),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
+    """Create a requests session with retry logic and disabled proxy env vars."""
+    session = build_safe_session(total_retries=total, backoff_factor=backoff_factor)
     session.headers.update(
         {
             "User-Agent": f"MorningBrief/{APP_VERSION} (+https://internal-brief.local)",
@@ -466,8 +493,11 @@ class PerplexityClient:
         }
 
         try:
-            response = working.post(
+            response = safe_request(
+                "POST",
                 PERPLEXITY_CHAT_URL,
+                session=working,
+                allowed_hosts={"api.perplexity.ai"},
                 headers={
                     "Authorization": f"Bearer {self.api_key}",
                     "Content-Type": "application/json",
@@ -568,13 +598,14 @@ def html_li(content: str) -> str:
 def html_ul(items: Iterable[str]) -> str:
     item_list = list(items)
     if not item_list:
-        return "<ul><li class=\"empty-state\">No items</li></ul>"
+        return '<ul><li class="empty-state">No items</li></ul>'
     return f"<ul>{''.join(item_list)}</ul>"
 
 
 _EMOJI_HEADING_PATTERN = re.compile(
     r"^([\U0001F000-\U0001FAFF\U00002600-\U000027BF\u2600-\u27BF]+)\s+(.*)$"
 )
+
 
 def _render_heading(level: int, title: str, id_attr: str = "") -> str:
     safe_title = sanitize_text(title)
@@ -587,22 +618,20 @@ def _render_heading(level: int, title: str, id_attr: str = "") -> str:
     if match:
         icon = match.group(1)
         clean_title = match.group(2)
-        return (
-            f'<h{level}{id_str}><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
-        )
+        return f'<h{level}{id_str}><span aria-hidden="true">{icon}</span> {clean_title}</h{level}>'
 
     return f"<h{level}{id_str}>{safe_title}</h{level}>"
 
 
 def html_section(title: str, body: str) -> str:
-    section_id = re.sub(r'[^a-z0-9]+', '-', sanitize_text(title).lower()).strip('-')
+    section_id = re.sub(r"[^a-z0-9]+", "-", sanitize_text(title).lower()).strip("-")
     if not section_id:
         section_id = "section"
     return f'<section role="region" aria-labelledby="{section_id}">\n{_render_heading(3, title, section_id)}\n{body}\n</section>'
 
 
 def html_subsection(title: str, body: str) -> str:
-    section_id = re.sub(r'[^a-z0-9]+', '-', sanitize_text(title).lower()).strip('-')
+    section_id = re.sub(r"[^a-z0-9]+", "-", sanitize_text(title).lower()).strip("-")
     if not section_id:
         section_id = "subsection"
     return f'<section role="region" aria-labelledby="{section_id}">\n{_render_heading(4, title, section_id)}\n{body}\n</section>'
@@ -825,12 +854,23 @@ def fetch_weather(
         return WeatherSnapshot(**cached)
 
     try:
+        lat = float(config.lat)
+        lon = float(config.lon)
+        if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
+            raise ValueError(f"invalid coordinates lat={lat} lon={lon}")
+
         url = (
-            f"https://api.open-meteo.com/v1/forecast?latitude={config.lat}&longitude={config.lon}"
+            f"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}"
             "&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max"
             "&current_weather=true&temperature_unit=fahrenheit&timezone=auto"
         )
-        response = session.get(url, timeout=DEFAULT_TIMEOUT)
+        response = safe_request(
+            "GET",
+            url,
+            session=session,
+            allowed_hosts={"api.open-meteo.com"},
+            timeout=DEFAULT_TIMEOUT,
+        )
         response.raise_for_status()
         data = response.json()
 
@@ -868,12 +908,25 @@ def fetch_weather(
         return WeatherSnapshot("N/A", "N/A", "N/A", "Weather data unavailable.")
 
 
-def _process_horoscope_endpoint(session: requests.Session, zodiac_sign: str, tmpl: dict) -> Optional[str]:
+def _process_horoscope_endpoint(
+    session: requests.Session, zodiac_sign: str, tmpl: dict
+) -> Optional[str]:
     """Helper to process a single horoscope endpoint."""
+    if zodiac_sign.lower() not in VALID_ZODIAC_SIGNS:
+        logger.warning("Invalid zodiac sign %r", zodiac_sign)
+        return None
+
     url = tmpl.get("url") or tmpl["url_fn"](zodiac_sign)
     params = tmpl["params_fn"](zodiac_sign)
     try:
-        response = session.get(url, params=params, timeout=HOROSCOPE_TIMEOUT)
+        response = safe_request(
+            "GET",
+            url,
+            session=session,
+            allowed_hosts={"horoscope-app-api.vercel.app", "ohmanda.com"},
+            params=params,
+            timeout=HOROSCOPE_TIMEOUT,
+        )
         response.raise_for_status()
         extracted = extract_horoscope_text(response.json())
         if extracted:
@@ -901,7 +954,13 @@ def _get_first_successful_result(futures: list) -> Optional[str]:
 
 def fetch_horoscope(session: requests.Session, zodiac_sign: str) -> str:
     """Fetch horoscope using a hedged concurrent request strategy."""
-    default_text = "Trust your instincts and prioritize tasks that reduce future stress."
+    default_text = (
+        "Trust your instincts and prioritize tasks that reduce future stress."
+    )
+
+    if zodiac_sign.lower() not in VALID_ZODIAC_SIGNS:
+        logger.warning("Invalid zodiac sign %r; using default", zodiac_sign)
+        return default_text
 
     executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=min(len(HOROSCOPE_ENDPOINTS_TEMPLATE) or 1, 32)
@@ -910,7 +969,9 @@ def fetch_horoscope(session: requests.Session, zodiac_sign: str) -> str:
 
     try:
         for i, tmpl in enumerate(HOROSCOPE_ENDPOINTS_TEMPLATE):
-            futures.append(executor.submit(_process_horoscope_endpoint, session, zodiac_sign, tmpl))
+            futures.append(
+                executor.submit(_process_horoscope_endpoint, session, zodiac_sign, tmpl)
+            )
 
             if i == len(HOROSCOPE_ENDPOINTS_TEMPLATE) - 1:
                 break
@@ -972,8 +1033,11 @@ def fetch_linear_focus_items(
     }
 
     try:
-        response = session.post(
+        response = safe_request(
+            "POST",
             LINEAR_GRAPHQL_URL,
+            session=session,
+            allowed_hosts={"api.linear.app"},
             headers={
                 "Authorization": config.linear_api_key,
                 "Content-Type": "application/json",
@@ -1113,8 +1177,11 @@ def fetch_linear_queue_snapshot(
     """
 
     try:
-        response = session.post(
+        response = safe_request(
+            "POST",
             LINEAR_GRAPHQL_URL,
+            session=session,
+            allowed_hosts={"api.linear.app"},
             headers={
                 "Authorization": config.linear_api_key,
                 "Content-Type": "application/json",
@@ -1162,7 +1229,13 @@ def fetch_single_feed(
     session = build_retry_session(total=2, backoff_factor=0.5)
 
     try:
-        response = session.get(url, timeout=DEFAULT_TIMEOUT)
+        response = safe_request(
+            "GET",
+            url,
+            session=session,
+            allowed_hosts=MORNING_BRIEF_ALLOWED_HOSTS,
+            timeout=DEFAULT_TIMEOUT,
+        )
         response.raise_for_status()
         feed = feedparser.parse(response.content)
 
@@ -1210,7 +1283,13 @@ def fetch_podcast_section(llm: PerplexityClient, *, limit: int = 3) -> SectionRe
     session = build_retry_session(total=2, backoff_factor=0.5)
 
     try:
-        response = session.get(AMERICA_ADAPTS_RSS_URL, timeout=DEFAULT_TIMEOUT)
+        response = safe_request(
+            "GET",
+            AMERICA_ADAPTS_RSS_URL,
+            session=session,
+            allowed_hosts=MORNING_BRIEF_ALLOWED_HOSTS,
+            timeout=DEFAULT_TIMEOUT,
+        )
         response.raise_for_status()
         feed = feedparser.parse(response.content)
 
@@ -1265,7 +1344,10 @@ def fetch_podcast_section(llm: PerplexityClient, *, limit: int = 3) -> SectionRe
     except Exception as exc:
         logger.error("Podcast error: %s", exc)
         return SectionResult(
-            html_section("🎧 Latest from America Adapts", "<p><em>Could not fetch episodes today.</em></p>"),
+            html_section(
+                "🎧 Latest from America Adapts",
+                "<p><em>Could not fetch episodes today.</em></p>",
+            ),
             [],
         )
 
@@ -1453,8 +1535,11 @@ def save_to_reader(
     tags = sorted(set(["morning-routine", "dashboard"] + (extra_tags or [])))
 
     try:
-        response = session.post(
+        response = safe_request(
+            "POST",
             READWISE_SAVE_URL,
+            session=session,
+            allowed_hosts={"readwise.io"},
             headers={"Authorization": f"Token {config.readwise_token}"},
             json={
                 "url": f"https://internal-brief.local/daily-{unique_id}",

--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -949,16 +949,18 @@ def _submit_horoscope_calls(
 
 
 def _first_horoscope_result(
-    futures: list[concurrent.futures.Future], timeout: float
-) -> str | None:
+    futures: list[concurrent.futures.Future], timeout: float, default_text: str
+) -> str:
     """Return the first successful future result within ``timeout`` seconds."""
     try:
         for future in concurrent.futures.as_completed(futures, timeout=timeout):
-            if not future.exception() and future.result():
+            if future.exception():
+                continue
+            if future.result():
                 return future.result()
     except concurrent.futures.TimeoutError:
         pass
-    return None
+    return default_text
 
 
 def fetch_horoscope(session: requests.Session, zodiac_sign: str) -> str:
@@ -971,17 +973,14 @@ def fetch_horoscope(session: requests.Session, zodiac_sign: str) -> str:
         logger.warning("Invalid zodiac sign %r; using default", zodiac_sign)
         return default_text
 
-    max_workers = min(len(HOROSCOPE_ENDPOINTS_TEMPLATE) or 1, 32)
+    template_count = len(HOROSCOPE_ENDPOINTS_TEMPLATE)
+    max_workers = max(1, min(template_count, 32))
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
     try:
         futures = _submit_horoscope_calls(executor, session, zodiac_sign)
-        result = _first_horoscope_result(futures, HOROSCOPE_TIMEOUT)
-        if result:
-            return result
+        return _first_horoscope_result(futures, HOROSCOPE_TIMEOUT, default_text)
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
-
-    return default_text
 
 
 def fetch_linear_focus_items(

--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -936,19 +936,28 @@ def _process_horoscope_endpoint(
     return None
 
 
-def _has_successful_result(futures: list) -> bool:
-    """Check if any future in the list succeeded with a non-None result."""
-    for future in futures:
-        if not future.exception() and future.result():
-            return True
-    return False
+def _submit_horoscope_calls(
+    executor: concurrent.futures.ThreadPoolExecutor,
+    session: requests.Session,
+    zodiac_sign: str,
+) -> list[concurrent.futures.Future]:
+    """Submit a horoscope request for every configured endpoint."""
+    return [
+        executor.submit(_process_horoscope_endpoint, session, zodiac_sign, tmpl)
+        for tmpl in HOROSCOPE_ENDPOINTS_TEMPLATE
+    ]
 
 
-def _get_first_successful_result(futures: list) -> Optional[str]:
-    """Return the first successful result from completed futures."""
-    for future in concurrent.futures.as_completed(futures):
-        if not future.exception() and future.result():
-            return future.result()
+def _first_horoscope_result(
+    futures: list[concurrent.futures.Future], timeout: float
+) -> str | None:
+    """Return the first successful future result within ``timeout`` seconds."""
+    try:
+        for future in concurrent.futures.as_completed(futures, timeout=timeout):
+            if not future.exception() and future.result():
+                return future.result()
+    except concurrent.futures.TimeoutError:
+        pass
     return None
 
 
@@ -962,35 +971,13 @@ def fetch_horoscope(session: requests.Session, zodiac_sign: str) -> str:
         logger.warning("Invalid zodiac sign %r; using default", zodiac_sign)
         return default_text
 
-    executor = concurrent.futures.ThreadPoolExecutor(
-        max_workers=min(len(HOROSCOPE_ENDPOINTS_TEMPLATE) or 1, 32)
-    )
-    futures = []
-
+    max_workers = min(len(HOROSCOPE_ENDPOINTS_TEMPLATE) or 1, 32)
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
     try:
-        for i, tmpl in enumerate(HOROSCOPE_ENDPOINTS_TEMPLATE):
-            futures.append(
-                executor.submit(_process_horoscope_endpoint, session, zodiac_sign, tmpl)
-            )
-
-            if i == len(HOROSCOPE_ENDPOINTS_TEMPLATE) - 1:
-                break
-
-            pending = [f for f in futures if not f.done()]
-            if not pending:
-                continue
-
-            done, _ = concurrent.futures.wait(
-                pending, timeout=1.5, return_when=concurrent.futures.FIRST_COMPLETED
-            )
-
-            if _has_successful_result(done):
-                break
-
-        result = _get_first_successful_result(futures)
+        futures = _submit_horoscope_calls(executor, session, zodiac_sign)
+        result = _first_horoscope_result(futures, HOROSCOPE_TIMEOUT)
         if result:
             return result
-
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
 

--- a/tests/test_safe_http.py
+++ b/tests/test_safe_http.py
@@ -35,15 +35,23 @@ def _addr_record(ip_str: str, port: int) -> tuple:
     return (socket.AF_INET, socket.SOCK_STREAM, 0, "", (str(ip), port))
 
 
+def _is_ip(addr: str) -> bool:
+    """Return True when ``addr`` is already a valid IP string."""
+    try:
+        ipaddress.ip_address(addr)
+        return True
+    except ValueError:
+        return False
+
+
 def _getaddrinfo_stub(host: str, port: int, *_, **__):
     """Deterministic resolver for tests."""
     ip_strs = _HOST_IPS.get(host)
     if ip_strs is not None:
         return [_addr_record(ip, port) for ip in ip_strs]
-    try:
+    if _is_ip(host):
         return [_addr_record(host, port)]
-    except ValueError:
-        return []
+    return []
 
 
 @patch("lib.safe_http.socket.getaddrinfo", new=_getaddrinfo_stub)

--- a/tests/test_safe_http.py
+++ b/tests/test_safe_http.py
@@ -1,0 +1,298 @@
+"""Unit tests for lib.safe_http SSRF helpers."""
+
+from __future__ import annotations
+
+import http.server
+import ipaddress
+import os
+import socket
+import tempfile
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lib import safe_http
+
+
+def _getaddrinfo_stub(host: str, port: int, *_, **__):
+    """Deterministic resolver for tests."""
+    loopback_v4 = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", port))
+    loopback_v6 = (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", port, 0, 0))
+    public = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", port))
+    private = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.5", port))
+    metadata = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port))
+    cgnat = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("100.64.0.5", port))
+    mapped = (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        0,
+        "",
+        ("::ffff:127.0.0.1", port, 0, 0),
+    )
+
+    if host in ("127.0.0.1", "localhost"):
+        return [loopback_v4]
+    if host == "::1":
+        return [loopback_v6]
+    if host in ("example.com", "other.example.com", "sub.example.com"):
+        return [public]
+    if host == "private.example.com":
+        return [private]
+    if host == "metadata.example.com":
+        return [metadata]
+    if host == "cgnat.example.com":
+        return [cgnat]
+    if host == "mapped.example.com":
+        return [mapped]
+    try:
+        ip = ipaddress.ip_address(host)
+        if isinstance(ip, ipaddress.IPv6Address):
+            return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", (str(ip), port, 0, 0))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (str(ip), port))]
+    except ValueError:
+        return []
+
+
+@patch("lib.safe_http.socket.getaddrinfo", new=_getaddrinfo_stub)
+class TestValidateUrl(unittest.TestCase):
+    def test_public_host_allowed(self):
+        host, port, ips = safe_http.validate_url("https://example.com/path")
+        self.assertEqual(host, "example.com")
+        self.assertEqual(port, 443)
+
+    def test_public_ip_allowed(self):
+        safe_http.validate_url("http://1.1.1.1/")
+
+    def test_loopback_blocked_by_default(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://127.0.0.1:8096/")
+
+    def test_loopback_allowed(self):
+        safe_http.validate_url("http://127.0.0.1:8096/", allow_loopback=True)
+
+    def test_private_host_blocked(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://private.example.com/")
+
+    def test_private_host_allowed(self):
+        safe_http.validate_url("http://private.example.com/", allow_private=True)
+
+    def test_metadata_address_blocked(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://metadata.example.com/")
+
+    def test_cgnat_blocked(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://cgnat.example.com/")
+
+    def test_ipv4_mapped_loopback_blocked(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://mapped.example.com/")
+
+    def test_non_http_scheme_rejected(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("file:///etc/passwd")
+
+    def test_userinfo_rejected(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://api.com@evil.com/")
+
+    def test_allowed_hosts_exact(self):
+        safe_http.validate_url(
+            "http://private.example.com/",
+            allowed_hosts={"private.example.com"},
+            allow_private=True,
+        )
+
+    def test_allowed_hosts_subdomain(self):
+        safe_http.validate_url(
+            "http://sub.example.com/",
+            allowed_hosts={"example.com"},
+        )
+
+    def test_allowed_hosts_with_port(self):
+        safe_http.validate_url(
+            "http://127.0.0.1:8096/",
+            allowed_hosts={"127.0.0.1:8096"},
+            allow_loopback=True,
+        )
+
+    def test_require_https(self):
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.validate_url("http://example.com/", require_https=True)
+        safe_http.validate_url("https://example.com/", require_https=True)
+
+
+@patch("lib.safe_http.socket.getaddrinfo", new=_getaddrinfo_stub)
+class TestSafeRequest(unittest.TestCase):
+    def _make_session(self, responses):
+        session = MagicMock()
+        session.request.side_effect = responses
+        session.get.side_effect = responses
+        session.post.side_effect = responses
+        return session
+
+    def test_basic_get(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        session = self._make_session([resp])
+        result = safe_http.safe_request("GET", "https://example.com/", session=session)
+        self.assertEqual(result, resp)
+        session.get.assert_called_once()
+        (call_url,) = session.get.call_args[0]
+        self.assertEqual(call_url, "https://example.com/")
+
+    def test_cross_host_redirect_strips_auth(self):
+        redirect = MagicMock()
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://other.example.com/"}
+        final = MagicMock()
+        final.status_code = 200
+        final.headers = {}
+        session = self._make_session([redirect, final])
+
+        safe_http.safe_request(
+            "GET",
+            "https://example.com/",
+            session=session,
+            headers={"Authorization": "Bearer secret"},
+            allowed_hosts={"example.com", "other.example.com"},
+        )
+
+        first_call = session.get.call_args_list[0]
+        second_call = session.get.call_args_list[1]
+        self.assertEqual(first_call.kwargs["headers"]["Authorization"], "Bearer secret")
+        self.assertNotIn("Authorization", second_call.kwargs["headers"])
+
+    def test_redirect_to_non_allowed_host_fails(self):
+        redirect = MagicMock()
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://evil.com/"}
+        session = self._make_session([redirect])
+
+        with self.assertRaises(safe_http.UnsafeURLError):
+            safe_http.safe_request(
+                "GET",
+                "https://example.com/",
+                session=session,
+                allowed_hosts={"example.com"},
+            )
+
+    def test_too_many_redirects(self):
+        redirect = MagicMock()
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://example.com/next"}
+        session = self._make_session([redirect] * (safe_http.MAX_REDIRECTS + 1))
+
+        with self.assertRaises(safe_http.TooManyRedirectsError):
+            safe_http.safe_request("GET", "https://example.com/", session=session)
+
+
+class TestSafeUrlopen(unittest.TestCase):
+    def _run_server(self, handler):
+        server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        return server, port
+
+    def test_simple_get(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *args):
+                pass
+
+        server, port = self._run_server(Handler)
+        try:
+            resp = safe_http.safe_urlopen(
+                f"http://127.0.0.1:{port}/",
+                allow_loopback=True,
+            )
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.body, b"ok")
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_redirect_to_disallowed_host_fails(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(302)
+                self.send_header("Location", "http://private.example.com/")
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server, port = self._run_server(Handler)
+        try:
+            with self.assertRaises(safe_http.UnsafeURLError):
+                safe_http.safe_urlopen(
+                    f"http://127.0.0.1:{port}/",
+                    allow_loopback=True,
+                    allowed_hosts={"127.0.0.1"},
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_size_limit(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", "100")
+                self.end_headers()
+                self.wfile.write(b"x" * 100)
+
+            def log_message(self, *args):
+                pass
+
+        server, port = self._run_server(Handler)
+        try:
+            with self.assertRaises(safe_http.UnsafeURLError):
+                safe_http.safe_urlopen(
+                    f"http://127.0.0.1:{port}/",
+                    allow_loopback=True,
+                    max_bytes=10,
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_safe_download(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", "3")
+                self.end_headers()
+                self.wfile.write(b"abc")
+
+            def log_message(self, *args):
+                pass
+
+        server, port = self._run_server(Handler)
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                dest = tmp.name
+            safe_http.safe_download(
+                f"http://127.0.0.1:{port}/",
+                dest,
+                allow_loopback=True,
+                max_bytes=10,
+            )
+            with open(dest, "rb") as f:
+                self.assertEqual(f.read(), b"abc")
+            os.unlink(dest)
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safe_http.py
+++ b/tests/test_safe_http.py
@@ -13,42 +13,35 @@ from unittest.mock import MagicMock, patch
 
 from lib import safe_http
 
+_HOST_IPS = {
+    "127.0.0.1": ["127.0.0.1"],
+    "localhost": ["127.0.0.1"],
+    "::1": ["::1"],
+    "example.com": ["1.1.1.1"],
+    "other.example.com": ["1.1.1.1"],
+    "sub.example.com": ["1.1.1.1"],
+    "private.example.com": ["192.168.1.5"],
+    "metadata.example.com": ["169.254.169.254"],
+    "cgnat.example.com": ["100.64.0.5"],
+    "mapped.example.com": ["::ffff:127.0.0.1"],
+}
+
+
+def _addr_record(ip_str: str, port: int) -> tuple:
+    """Build a single ``getaddrinfo``-style tuple for an IP string."""
+    ip = ipaddress.ip_address(ip_str)
+    if isinstance(ip, ipaddress.IPv6Address):
+        return (socket.AF_INET6, socket.SOCK_STREAM, 0, "", (str(ip), port, 0, 0))
+    return (socket.AF_INET, socket.SOCK_STREAM, 0, "", (str(ip), port))
+
 
 def _getaddrinfo_stub(host: str, port: int, *_, **__):
     """Deterministic resolver for tests."""
-    loopback_v4 = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", port))
-    loopback_v6 = (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", port, 0, 0))
-    public = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", port))
-    private = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.5", port))
-    metadata = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port))
-    cgnat = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("100.64.0.5", port))
-    mapped = (
-        socket.AF_INET6,
-        socket.SOCK_STREAM,
-        0,
-        "",
-        ("::ffff:127.0.0.1", port, 0, 0),
-    )
-
-    if host in ("127.0.0.1", "localhost"):
-        return [loopback_v4]
-    if host == "::1":
-        return [loopback_v6]
-    if host in ("example.com", "other.example.com", "sub.example.com"):
-        return [public]
-    if host == "private.example.com":
-        return [private]
-    if host == "metadata.example.com":
-        return [metadata]
-    if host == "cgnat.example.com":
-        return [cgnat]
-    if host == "mapped.example.com":
-        return [mapped]
+    ip_strs = _HOST_IPS.get(host)
+    if ip_strs is not None:
+        return [_addr_record(ip, port) for ip in ip_strs]
     try:
-        ip = ipaddress.ip_address(host)
-        if isinstance(ip, ipaddress.IPv6Address):
-            return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", (str(ip), port, 0, 0))]
-        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (str(ip), port))]
+        return [_addr_record(host, port)]
     except ValueError:
         return []
 


### PR DESCRIPTION
## What

Resolves ABHI-1550 by introducing a shared `lib.safe_http` SSRF guard and routing all outbound HTTP in `morning-brief.py` and `bootstrap-jellyfin-local.py` through it.

## Why

Both scripts previously made direct `requests` / `urllib.request` calls without host validation, scheme hardening, redirect inspection, or proxy-env bypass. A malicious `JELLYFIN_URL` or crafted input could have caused the admin password/API token to be sent to an attacker-controlled host.

## How

- Added `lib/safe_http.py` with:
  - `validate_url` – scheme allowlist, userinfo/IDNA rejection, host allowlist with `host:port` support, DNS resolution, and IP classification (`is_global` / loopback / private / link-local / CGNAT).
  - `safe_request` – `requests` wrapper with `trust_env=False`, manual redirect loop, auth stripping on cross-host hops, and bounded redirects.
  - `safe_urlopen` / `safe_download` – `urllib` equivalents with a validating redirect handler, `ProxyHandler({})`, and size limits.
  - CLI `python3 -m lib.safe_http --check-url <URL>` for shell-script pre-flight checks.
- Updated `scripts/morning-brief/morning-brief.py` to use `build_safe_session` + `safe_request` for all external calls, added `zodiac_sign` allowlist and `lat`/`lon` range validation.
- Updated `media-streaming/scripts/bootstrap-jellyfin-local.py` to gate credentials: non-loopback authenticated calls require HTTPS unless `JELLYFIN_ALLOW_INSECURE=1`; `JELLYFIN_ALLOWED_HOSTS` supports explicit per-host allowlist.
- Updated `media-streaming/scripts/validate-jellyfin.sh` to run the `safe_http` CLI before any `curl` and hardened `curl` with `--proto '=http,https'`, `--max-redirs 0`, and explicit timeouts.
- Updated `.claude` / `.agents` `save-to-spotify` skill markdown examples to use `safe_request` / `safe_download` and document approved Spotify CDN hosts.
- Enabled `S310` in `.trunk/configs/ruff.toml` with a per-file exemption only for `lib/safe_http.py`.
- Added hermetic `tests/test_safe_http.py` with mocked `socket.getaddrinfo` covering hostile URLs, redirects, and the default `http://127.0.0.1:8096` case.

## Testing

- `make test-python` passed (416 tests).
- `python3 -m py_compile` on all modified Python files.
- `trunk check` on the changed files reports no new issues.
- `python3 -m lib.safe_http --check-url http://127.0.0.1:8096 --allow-loopback` returns `OK`.
- `bash -n media-streaming/scripts/validate-jellyfin.sh` passes.

Note: `make lint` (global `trunk check --all`) still reports pre-existing bandit B101 / ruff issues in untouched files.

## Security

This change hardens the HTTP trust boundary for the affected scripts. Jellyfin admin credentials and API tokens are now restricted to loopback or an explicit `JELLYFIN_ALLOWED_HOSTS` allowlist, and authenticated non-loopback traffic requires HTTPS by default. Proxy environment variables are ignored for all safe_http callers.

---

## Checklist

- [x] `make test-python` passes locally
- [x] `trunk check` on changed files reports no new issues
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation updated where behavior changed
- [x] Branch name follows the convention in CONTRIBUTING.md

Link to Devin session: https://app.devin.ai/sessions/51800312e95d438fae8641a69bbe1ee2
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->