### PR TITLE
security(ABHI-1515): remove source from fix_drafts.sh and validate env file permissions

### DIFF
--- a/fix_drafts.sh
+++ b/fix_drafts.sh
@@ -3,8 +3,46 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=scripts/ensure_gh_token.sh
-source "${SCRIPT_DIR}/scripts/ensure_gh_token.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: fix_drafts.sh REPO PR_NUMBER [REPO PR_NUMBER ...]
+
+Safely loads GH_TOKEN without sourcing external files, then marks each draft
+PR ready before merging it with --squash --delete-branch.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 2 || $(( $# % 2 )) -ne 0 ]]; then
+  echo "error: expected REPO PR_NUMBER pairs" >&2
+  usage >&2
+  exit 2
+fi
+
+GH_TOKEN="$(
+  cd "${SCRIPT_DIR}" && python3 - <<'PY'
+import sys
+from gh_token_env import load_gh_token_env, missing_gh_token_message
+
+env = load_gh_token_env()
+token = env.get("GH_TOKEN", "")
+if not token:
+    print(missing_gh_token_message(), file=sys.stderr)
+    sys.exit(1)
+print(token)
+PY
+)" || exit 1
+export GH_TOKEN
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required but not installed" >&2
+  exit 1
+fi
 
 fix_and_merge() {
   local repo="$1"
@@ -14,6 +52,13 @@ fix_and_merge() {
   gh pr merge "${pr}" --repo "${repo}" --squash --delete-branch
 }
 
-fix_and_merge "abhimehro/email-security-pipeline" "632"
-fix_and_merge "abhimehro/Hydrograph_Versus_Seatek_Sensors_Project" "102"
-fix_and_merge "abhimehro/personal-config" "743"
+while [[ $# -gt 0 ]]; do
+  repo="$1"
+  pr="$2"
+  if ! [[ "${pr}" =~ ^[0-9]+$ ]]; then
+    echo "error: invalid PR number for ${repo}: ${pr}" >&2
+    exit 2
+  fi
+  fix_and_merge "${repo}" "${pr}"
+  shift 2
+done

--- a/fix_drafts.sh
+++ b/fix_drafts.sh
@@ -24,6 +24,11 @@ if [[ $# -lt 2 || $(( $# % 2 )) -ne 0 ]]; then
   exit 2
 fi
 
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required but not installed" >&2
+  exit 1
+fi
+
 GH_TOKEN="$(
   cd "${SCRIPT_DIR}" && python3 - <<'PY'
 import sys
@@ -42,11 +47,6 @@ print(token)
 PY
 )" || exit 1
 export GH_TOKEN
-
-if ! command -v gh >/dev/null 2>&1; then
-  echo "error: gh CLI is required but not installed" >&2
-  exit 1
-fi
 
 fix_and_merge() {
   local repo="$1"

--- a/fix_drafts.sh
+++ b/fix_drafts.sh
@@ -29,7 +29,11 @@ GH_TOKEN="$(
 import sys
 from gh_token_env import load_gh_token_env, missing_gh_token_message
 
-env = load_gh_token_env()
+try:
+    env = load_gh_token_env()
+except PermissionError as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    sys.exit(1)
 token = env.get("GH_TOKEN", "")
 if not token:
     print(missing_gh_token_message(), file=sys.stderr)
@@ -52,13 +56,17 @@ fix_and_merge() {
   gh pr merge "${pr}" --repo "${repo}" --squash --delete-branch
 }
 
-while [[ $# -gt 0 ]]; do
-  repo="$1"
-  pr="$2"
+pairs=("$@")
+
+for (( i=0; i<${#pairs[@]}; i+=2 )); do
+  repo="${pairs[i]}"
+  pr="${pairs[i+1]}"
   if ! [[ "${pr}" =~ ^[0-9]+$ ]]; then
     echo "error: invalid PR number for ${repo}: ${pr}" >&2
     exit 2
   fi
-  fix_and_merge "${repo}" "${pr}"
-  shift 2
+done
+
+for (( i=0; i<${#pairs[@]}; i+=2 )); do
+  fix_and_merge "${pairs[i]}" "${pairs[i+1]}"
 done

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -34,9 +34,14 @@ def _validate_env_file_permissions(path: Path) -> None:
     except OSError:
         return
     if st.st_uid != os.getuid():
-        raise PermissionError(f"env file {path} is not owned by the current user")
+        raise PermissionError(
+            f"env file {path} is not owned by the current user; refuse to load"
+        )
     if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
-        raise PermissionError(f"env file {path} is writable by group or others")
+        raise PermissionError(
+            f"env file {path} must not be group- or world-writable "
+            f"(chmod 600 {path})"
+        )
 
 
 def parse_env_line(line: str, env_dict: dict[str, str]) -> None:

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -9,9 +9,9 @@ Precedence for ``GH_TOKEN``:
 2. Optional file from ``GH_TOKEN_ENV_FILE`` or well-known paths (legacy fallback)
 """
 
-import re
-
 import os
+import re
+import stat
 from functools import lru_cache
 from pathlib import Path
 from typing import Mapping
@@ -23,6 +23,20 @@ _LEGACY_RELATIVE_ENV = Path("../email-security-pipeline/GH_TOKEN.env")
 _COMMAND_SUBSTITUTION = re.compile(r"\$\(|`")
 
 _RUNBOOK = "docs/github-pat-rotation-runbook.md"
+
+
+def _validate_env_file_permissions(path: Path) -> None:
+    """Fail closed if the env file could be tampered with by another user."""
+    if not hasattr(os, "getuid"):
+        return
+    try:
+        st = path.stat()
+    except OSError:
+        return
+    if st.st_uid != os.getuid():
+        raise PermissionError(f"env file {path} is not owned by the current user")
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise PermissionError(f"env file {path} is writable by group or others")
 
 
 def parse_env_line(line: str, env_dict: dict[str, str]) -> None:
@@ -82,6 +96,7 @@ def _get_parsed_env_vars_from_file() -> dict[str, str]:
     path = resolve_gh_token_env_file()
     if path is None:
         return {}
+    _validate_env_file_permissions(path)
     return _read_env_file(path)
 
 

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import tempfile
 import unittest
 from pathlib import Path
@@ -78,6 +79,25 @@ class TestGhTokenEnv(unittest.TestCase):
         with patch("gh_token_env.resolve_gh_token_env_file", return_value=None):
             message = missing_gh_token_message()
         self.assertIn("github-pat-rotation-runbook", message)
+
+    def test_env_file_rejected_when_group_or_world_writable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "GH_TOKEN.env"
+            env_file.write_text("GH_TOKEN=file_token\n", encoding="utf-8")
+            env_file.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            with patch.dict(os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True):
+                with self.assertRaises(PermissionError):
+                    load_gh_token_env()
+
+    def test_env_file_rejected_when_not_owned_by_current_user(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "GH_TOKEN.env"
+            env_file.write_text("GH_TOKEN=file_token\n", encoding="utf-8")
+            env_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            with patch("gh_token_env.os.getuid", return_value=os.getuid() + 1):
+                with patch.dict(os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True):
+                    with self.assertRaises(PermissionError):
+                        load_gh_token_env()
 
 
 if __name__ == "__main__":

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -59,6 +59,7 @@ class TestGhTokenEnv(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             env_file = Path(tmp) / "GH_TOKEN.env"
             env_file.write_text("export GH_TOKEN=file_token\n", encoding="utf-8")
+            env_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
             with patch.dict(
                 os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
             ):

--- a/tests/test_pr_automation_scripts.py
+++ b/tests/test_pr_automation_scripts.py
@@ -6,21 +6,27 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-AUTOMATION_SCRIPTS = (
+LEGACY_AUTOMATION_SCRIPTS = (
     ROOT / "close_prs.sh",
     ROOT / "close_more.sh",
-    ROOT / "fix_drafts.sh",
 )
 
 
 class TestPrAutomationScripts(unittest.TestCase):
-    def test_scripts_do_not_source_external_env_files(self) -> None:
-        for script in AUTOMATION_SCRIPTS:
+    def test_legacy_scripts_do_not_source_external_env_files(self) -> None:
+        for script in LEGACY_AUTOMATION_SCRIPTS:
             with self.subTest(script=script.name):
                 content = script.read_text(encoding="utf-8")
                 self.assertNotRegex(content, r"(?m)^\s*source\s+.*GH_TOKEN\.env")
                 self.assertNotRegex(content, r"(?m)^\s*\.\s+.*GH_TOKEN\.env")
                 self.assertIn("ensure_gh_token.sh", content)
+
+    def test_fix_drafts_uses_python_loader(self) -> None:
+        content = (ROOT / "fix_drafts.sh").read_text(encoding="utf-8")
+        self.assertNotRegex(content, r"(?m)^\s*source\s+")
+        self.assertNotRegex(content, r"(?m)^\s*\.\s+")
+        self.assertNotIn("ensure_gh_token.sh", content)
+        self.assertIn("gh_token_env", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Removes the `source` command from `fix_drafts.sh` so it no longer executes a helper in the current shell, and loads `GH_TOKEN` via the safe Python parser in `gh_token_env.py`. Also generalizes `fix_drafts.sh` to accept `REPO PR_NUMBER` pairs.

## Why

`fix_drafts.sh` previously sourced `scripts/ensure_gh_token.sh` to export `GH_TOKEN`. Even though the helper itself is safe, the `source`/`.` pattern is the class of behaviour flagged by abhimehro/personal-config#1728 (CWE-78 command injection when untrusted files are involved). Loading the token directly through `gh_token_env.py` eliminates shell execution of the env loader and aligns with the established safe pattern.

## How

* `fix_drafts.sh` now runs a `python3` snippet that imports `gh_token_env.load_gh_token_env()`, prints the resolved `GH_TOKEN`, and exits non-zero with `missing_gh_token_message()` if one cannot be found.
* The script accepts `REPO PR_NUMBER` pairs, validates that PR numbers are numeric, and processes each pair in a loop.
* `gh_token_env.py` gained `_validate_env_file_permissions()` which is called before an env file is read. It rejects files that are not owned by the current user or that are writable by group/others.
* Tests updated:
  * `tests/test_pr_automation_scripts.py` now asserts `fix_drafts.sh` does not use `source`/`.` and references `gh_token_env`.
  * `tests/test_gh_token_env.py` adds coverage for group/world-writable and wrong-owner env files.

## Testing

* `make lint-errors` passed
* `python3 -m unittest tests.test_gh_token_env tests.test_pr_automation_scripts` passed
* `make test-quick` passed
* `python3 -m unittest discover -s tests -p 'test_*.py'` passed (396 tests)
* `shellcheck fix_drafts.sh` passed

## Security

This change closes the command-injection path described in abhimehro/personal-config#1728 / abhimehro/personal-config#1728 by removing `source` of any file from `fix_drafts.sh`. It also adds fail-closed permission validation so a tampered or overly-permissive `GH_TOKEN.env` cannot be silently loaded.

---

## Checklist

- [X] `make test-quick` passes locally
- [X] `make lint-errors` reports no new errors
- [X] No secrets, tokens, or `.env` files included
- [X] Behaviour changed (generalized args); usage documented in script header
- [X] Branch name follows `devin/abhi-1515-...` convention

Closes abhimehro/personal-config#1728

Link to Devin session: [https://app.devin.ai/sessions/2e14165ddca0411881093fee536cff76](<https://app.devin.ai/sessions/2e14165ddca0411881093fee536cff76>)<br>Requested by: @abhimehro

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)