### PR TITLE
[Code Quality] Refactor test_media_server_env_vars.sh to eliminate 7-second sleep delays

### DIFF
--- a/tests/test_media_server_env_vars.sh
+++ b/tests/test_media_server_env_vars.sh
@@ -118,7 +118,7 @@ wait_for_log_marker() {
 	local timeout_ms="${3:-2000}"
 	local waited=0
 	while ((waited < timeout_ms)); do
-		[[ -f "$file" ]] && grep -q "$marker" "$file" 2>/dev/null && return 0
+		[[ -f $file ]] && grep -q "$marker" "$file" 2>/dev/null && return 0
 		sleep 0.05
 		waited=$((waited + 50))
 	done

--- a/tests/test_media_server_env_vars.sh
+++ b/tests/test_media_server_env_vars.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # Setup Mock Environment
-HOME=$(mktemp -d)
-export HOME
+MOCK_HOME=$(mktemp -d)
+export HOME="$MOCK_HOME"
 MOCK_BIN=$(mktemp -d)
 mkdir -p "$HOME/Library/Logs"
+trap 'rm -rf "$MOCK_BIN" "$MOCK_HOME"' EXIT
 
 # Mock pkill to prevent killing real processes
 cat >"$MOCK_BIN/pkill" <<'EOF'
@@ -86,27 +87,43 @@ echo "1.2.3.4"
 EOF
 chmod +x "$MOCK_BIN/curl"
 
-# Create mock pkill to avoid killing real processes during tests
-cat >"$MOCK_BIN/pkill" <<'EOF'
-#!/bin/bash
-# This mock intentionally does nothing and always succeeds.
-# It prevents tests from terminating real processes on the host.
-exit 0
-EOF
-chmod +x "$MOCK_BIN/pkill"
-
-# Create mock ps to avoid depending on the host process table
+# Mock ps always succeeds so final-media-server.sh's `ps -p $SERVER_PID`
+# check passes even when the mock rclone exits immediately.
 cat >"$MOCK_BIN/ps" <<'EOF'
 #!/bin/bash
-# Minimal mock of ps: prints no processes and exits successfully.
-# Adjust as needed if tests rely on specific ps output.
 exit 0
 EOF
 chmod +x "$MOCK_BIN/ps"
+
+# Mock sleep to collapse long cosmetic delays (spinner_wait, daemon startup
+# grace periods) while still allowing sub-second polling sleeps to pass
+# through to the real /bin/sleep.
+cat >"$MOCK_BIN/sleep" <<'EOF'
+#!/bin/bash
+case "${1:-0}" in
+    0.*) exec /bin/sleep "$1" ;;
+    *)   exit 0 ;;
+esac
+EOF
+chmod +x "$MOCK_BIN/sleep"
+
 export PATH="$MOCK_BIN:$PATH"
 
-# Setup dummy LOGS
-mkdir -p "$HOME/Library/Logs"
+# Poll a file until a marker string appears or a timeout is reached.
+# Useful for tests that start a background process and must wait for it to
+# write expected output before asserting.
+wait_for_log_marker() {
+	local file="$1"
+	local marker="$2"
+	local timeout_ms="${3:-2000}"
+	local waited=0
+	while ((waited < timeout_ms)); do
+		[[ -f "$file" ]] && grep -q "$marker" "$file" 2>/dev/null && return 0
+		sleep 0.05
+		waited=$((waited + 50))
+	done
+	return 1
+}
 
 # Test 1: media-server-daemon.sh
 echo "Test 1: media-server-daemon.sh"
@@ -133,13 +150,13 @@ fi
 
 # Test 2: final-media-server.sh
 echo "Test 2: final-media-server.sh"
-# This script uses nohup and & so we need to be careful.
-# But since our mock rclone exits, it should be fine?
-# Wait, final-media-server.sh checks `ps -p $SERVER_PID`.
-# If mock rclone exits immediately, ps will fail and script will say failed.
-# We need mock rclone to sleep a bit.
+# Execute the real script. The $MOCK_BIN/sleep shim collapses cosmetic
+# spinner delays, and the $MOCK_BIN/ps mock lets the script proceed even
+# though the mock rclone exits immediately.
 
-# Update mock rclone to sleep
+# Update mock rclone: write env vars (with <UNSET> diagnostics) and arg
+# checks, then exit immediately. The `ps` mock always succeeds, so we don't
+# need a long-lived background process.
 cat >"$MOCK_BIN/rclone" <<'EOF'
 #!/bin/bash
 if [[ "$1" == "listremotes" ]]; then
@@ -147,9 +164,10 @@ if [[ "$1" == "listremotes" ]]; then
     exit 0
 fi
 if [[ "$1" == "serve" ]]; then
-    echo "MOCK RCLONE SERVE CALLED" > "$HOME/Library/Logs/media-server.log"
-    echo "ENV_RCLONE_USER=$RCLONE_USER" >> "$HOME/Library/Logs/media-server.log"
-    echo "ENV_RCLONE_PASS=$RCLONE_PASS" >> "$HOME/Library/Logs/media-server.log"
+    : > "$HOME/Library/Logs/media-server.log"
+    echo "MOCK RCLONE SERVE CALLED" >> "$HOME/Library/Logs/media-server.log"
+    echo "ENV_RCLONE_USER=${RCLONE_USER-<UNSET>}" >> "$HOME/Library/Logs/media-server.log"
+    echo "ENV_RCLONE_PASS=${RCLONE_PASS-<UNSET>}" >> "$HOME/Library/Logs/media-server.log"
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -166,7 +184,6 @@ if [[ "$1" == "serve" ]]; then
                 ;;
         esac
     done
-    sleep 2
     exit 0
 fi
 EOF
@@ -180,9 +197,10 @@ chmod +x "$MOCK_BIN/rclone"
 # But final-media-server.sh uses ~/Library/Logs which expands to $HOME/Library/Logs.
 LOG_FILE="$HOME/Library/Logs/media-server.log"
 
-# Fail fast with a clear message if the log file was not created
-if [[ ! -f $LOG_FILE ]]; then
-	echo "FAIL: expected log file not found: $LOG_FILE"
+# Wait for the background rclone to flush its credential markers to the log
+# before asserting. This avoids fixed-sleep races.
+if ! wait_for_log_marker "$LOG_FILE" "ENV_RCLONE_PASS=" 2000; then
+	echo "FAIL: expected log file not found or missing credential marker: $LOG_FILE"
 	echo "Hint: final-media-server.sh may have failed before writing the log."
 	exit 1
 fi
@@ -210,5 +228,4 @@ else
 	echo "PASS: final-media-server.sh no args"
 fi
 
-rm -rf "$MOCK_BIN" "$HOME"
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Refactor `tests/test_media_server_env_vars.sh` to remove the ~7 seconds of fixed sleep time introduced by `final-media-server.sh`'s cosmetic spinners and the mock `rclone`'s 2-second sleep, without replacing the real script with a tautological focused mock.

## Why

`test_media_server_env_vars.sh` was the slowest test in the suite at ~9.1s (measured 9.067s). The delay came from:

- `final-media-server.sh` `spinner_wait 2` (cleanup)
- `final-media-server.sh` `spinner_wait 5` (server startup)
- The test's mock `rclone` `sleep 2` (to keep the process alive for `ps -p`)

The previous plan proposed bypassing `final-media-server.sh` entirely with a hand-written `final-media-server-test.sh` mock that hardcoded the expected env vars. That would have made the test pass regardless of whether the real script reintroduced `--user`/`--pass` arguments, so it was rejected.

## How

- Added a `$MOCK_BIN/sleep` shim that:
  - passes through sub-second sleeps (`0.*`) for polling loops
  - no-ops whole-second sleeps used by `spinner_wait` and startup grace periods
- Kept the real `./media-streaming/scripts/final-media-server.sh` invocation
- Kept the `$MOCK_BIN/ps` mock (returns 0) so `final-media-server.sh` proceeds even though the mock `rclone` now exits immediately
- Removed the 2-second `sleep` from the mock `rclone`
- Added `wait_for_log_marker()` to poll for `ENV_RCLONE_PASS=` in the log instead of relying on fixed sleeps
- Changed env-var echoes to `${RCLONE_USER-<UNSET>}` / `${RCLONE_PASS-<UNSET>}` for clearer failure diagnostics if credentials are not exported
- Renamed the temp home dir to `MOCK_HOME`, exported it as `HOME`, and added an `EXIT` trap so temp dirs are cleaned even on `exit 1`
- Removed the duplicate `pkill` mock and the redundant trailing `rm -rf`

## Testing

- `time bash tests/test_media_server_env_vars.sh` → **0.069s** (was 9.067s)
- `bash tests/run_all_tests.sh` → **42/45 passed, 3 skipped** (expected macOS-only skips)
- `make lint-errors` → clean
- `make test-quick` → clean
- `trunk check tests/test_media_server_env_vars.sh` → no issues, formatting auto-applied
- **Teeth check**: temporarily patched `final-media-server.sh` to pass `--user "$WEB_USER" --pass "$WEB_PASS"`, then ran the test:
  - Test 2 failed with `FAIL: final-media-server.sh still uses args`
  - Log showed `ARG_USER=mockuser` and `ARG_PASS=mockpass`
  - Reverted the temporary patch; test passes again

## Security

No security impact. The change is in a test file only; no production credentials or interfaces were modified. The test continues to assert that `final-media-server.sh` does not leak credentials as `rclone` CLI flags.

## Checklist

- [x] `make test-quick` passes locally
- [x] `make lint-errors` reports no new errors
- [x] `trunk check tests/test_media_server_env_vars.sh` reports no issues
- [x] No secrets, tokens, or `.env` files included
- [x] Documentation not needed (test-only change, behavior unchanged)
- [x] Branch name follows Linear's suggested `devin/abhi-1513-...`

Link to Devin session: https://app.devin.ai/sessions/455503e6a2614cd7bbede42184a6c3a9
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->