### PR TITLE
fix(visual-recap): recap-cli + token sanitize + MDX hardeners (salvag…

### DIFF
--- a/.github/gitleaks.toml
+++ b/.github/gitleaks.toml
@@ -189,7 +189,7 @@ regexes = [
     '''^secrets\.result$''',
     # Prose stopwords after "secret|password|…" (?P<secret> value). Real
     # credentials are never a single English stopword like these.
-    '''(?i)^(presence|scanning|false-positive|allowlist|detection|validation|management|injection|exfiltration)$''',
+    '''(?i)^(presence|scanning|false-positive|allowlist|detection|validation|management|injection|exfiltration|contained|embedded)$''',
 ]
 paths = [
     '''(?i)test''',

--- a/.github/workflows/pr-visual-recap.yml
+++ b/.github/workflows/pr-visual-recap.yml
@@ -253,13 +253,37 @@ jobs:
           # in .git/config (it uses GH_TOKEN for gh API calls, never git push).
           persist-credentials: false
 
+      # SECURITY: GitHub Secrets paste often embeds CR/LF mid-JWT. undici then
+      # rejects Authorization via Headers.append ("invalid header value"), and
+      # recap-cli's Bearer redact only matches one [A-Za-z0-9._-]+ run — the JWT
+      # remainder after the break leaks into the sticky comment (Lesson 0ei).
+      - name: Sanitize PLAN_RECAP_TOKEN
+        env:
+          RAW_PLAN_RECAP_TOKEN: ${{ secrets.PLAN_RECAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          CLEAN="$(printf '%s' "${RAW_PLAN_RECAP_TOKEN:-}" | tr -d '[:space:]')"
+          CLEAN="$(printf '%s' "$CLEAN" | sed -E 's/^[Bb][Ee][Aa][Rr][Ee][Rr]//')"
+          if [ -z "$CLEAN" ]; then
+            echo "::error::PLAN_RECAP_TOKEN is empty after whitespace sanitize"
+            exit 1
+          fi
+          if ! printf '%s' "$CLEAN" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "::error::PLAN_RECAP_TOKEN has non-token characters after sanitize — re-mint and paste as one line (no wraps)"
+            exit 1
+          fi
+          # Mask before exporting so later logs cannot print the cleaned value.
+          echo "::add-mask::$CLEAN"
+          printf 'PLAN_RECAP_TOKEN=%s\n' "$CLEAN" >> "$GITHUB_ENV"
+
       # Dogfood trusted base-branch source inside this monorepo, else install the
       # published package once. Never execute PR-head recap CLI code.
       - name: Resolve recap CLI
         id: cli
         env:
-          # Optional: pin the consumer CLI version (e.g. "1.2.3"). Defaults to
+          # Optional: pin @agent-native/recap-cli (e.g. "0.4.7"). Defaults to
           # "latest" when unset. Set via repository variable RECAP_CLI_VERSION.
+          # Do not pin @agent-native/core versions here (Lesson 0eh).
           RECAP_CLI_VERSION: ${{ vars.RECAP_CLI_VERSION || 'latest' }}
         run: |
           if [ "$GITHUB_REPOSITORY" = "BuilderIO/agent-native" ] && [ -f packages/core/src/cli/index.ts ]; then
@@ -296,23 +320,32 @@ jobs:
       - name: Install published recap CLI
         if: steps.cli.outputs.local != 'true'
         env:
+          # Pins @agent-native/recap-cli (NOT @agent-native/core). Core's
+          # published bin falls back to spawn("tsx") when npm extract makes
+          # src/ newer than dist/ — and tsx is not on PATH → ENOENT (Lesson 0eh).
           RECAP_CLI_VERSION: ${{ vars.RECAP_CLI_VERSION || 'latest' }}
         run: |
           set -euo pipefail
           VERSION="$RECAP_CLI_VERSION"
           if [ "$VERSION" = "latest" ]; then
-            VERSION="$(npm view @agent-native/core@latest version)"
+            VERSION="$(npm view @agent-native/recap-cli@latest version)"
           fi
           for attempt in 1 2 3; do
-            if npm install --prefix "$RUNNER_TEMP/recap-cli" --no-audit --no-fund "@agent-native/core@$VERSION" tsx; then
+            # DEPENDENCY: @agent-native/recap-cli — lightweight built CLI for
+            # PR visual recap (dist/cli.js). Do not substitute @agent-native/core.
+            if npm install --prefix "$RUNNER_TEMP/recap-cli" --no-audit --no-fund "@agent-native/recap-cli@$VERSION"; then
               break
             fi
             if [ "$attempt" = "3" ]; then exit 1; fi
             sleep $((attempt * 10))
           done
-          npm install --prefix "$RUNNER_TEMP/recap-cli" --no-audit --no-fund tsx
-          echo "RECAP_CLI=$RUNNER_TEMP/recap-cli/node_modules/.bin/agent-native" >> "$GITHUB_ENV"
-          echo "RECAP_PLAYWRIGHT=$RUNNER_TEMP/recap-cli/node_modules/.bin/playwright" >> "$GITHUB_ENV"
+          RECAP_BIN_DIR="$RUNNER_TEMP/recap-cli/node_modules/.bin"
+          test -x "$RECAP_BIN_DIR/agent-native"
+          # Smoke: fail the job early if the binary cannot start (avoids opaque
+          # collect-diff failures later).
+          "$RECAP_BIN_DIR/agent-native" recap --help >/dev/null
+          echo "RECAP_CLI=$RECAP_BIN_DIR/agent-native" >> "$GITHUB_ENV"
+          echo "RECAP_PLAYWRIGHT=$RECAP_BIN_DIR/playwright" >> "$GITHUB_ENV"
 
       - name: Start visual recap check
         id: recap_check
@@ -483,7 +516,7 @@ jobs:
           # DEPENDENCY: opencode-ai@1.18.3 — headless agent CLI (same stack as
           # CodeScene PR refactoring) — pinned 2026-07-17
           for attempt in 1 2 3; do
-            if npm install --prefix "$RUNNER_TEMP/opencode" --no-audit --no-fund "opencode-ai@1.18.3" tsx; then
+            if npm install --prefix "$RUNNER_TEMP/opencode" --no-audit --no-fund "opencode-ai@1.18.3"; then
               break
             fi
             if [ "$attempt" = "3" ]; then exit 1; fi
@@ -578,7 +611,12 @@ jobs:
                 '  2) recap-plan.mdx - full plan MDX (raw markdown/MDX, not JSON-escaped)' \
                 '  3) recap-canvas.mdx - canvas MDX (or empty file)' \
                 '  4) recap-prototype.mdx - prototype MDX (or empty file)' \
-                'The CI job will assemble these into valid recap-source.json for you.'
+                'The CI job will assemble these into valid recap-source.json for you.' \
+                '' \
+                'Diff block tip: before/after/code string values must be valid JS' \
+                'string literals (JSON.stringify-safe). Shell character classes that' \
+                'contain a backslash-quote sequence will break Plan MDX/acorn parse;' \
+                'double-escape backslashes inside those quoted Diff props.'
             } > recap-prompt.opencode.md
             "$OPENCODE_BIN" run \
               -m "$OPENCODE_MODEL" \
@@ -669,6 +707,8 @@ jobs:
 
       # Assemble OpenCode sidecar MDX files into strict JSON when present, then
       # sanitize any agent-written recap-source.json (raw controls in strings).
+      # Also rewrite Diff before/after/code props that break Plan MDX/acorn
+      # (Lesson 0ej — shell \\" inside JS strings).
       - name: Sanitize recap-source.json
         id: sanitize
         if: steps.diff.outputs.tiny != 'true' && steps.scan.outputs.suppressed != 'true'
@@ -680,6 +720,10 @@ jobs:
           node <<'NODE'
           const fs = require("fs");
           const path = "recap-source.json";
+          const {
+            fixMdxContent,
+            fixRecapSourcePayload,
+          } = require("./scripts/fix-recap-mdx-diff-strings.js");
           const emit = (ok, reason, repaired) => {
             const out = process.env.GITHUB_OUTPUT;
             if (out) {
@@ -700,6 +744,36 @@ jobs:
             }
           };
           const readOptional = (p) => (fs.existsSync(p) ? fs.readFileSync(p, "utf8") : "");
+          const fixAndMaybeWriteMdx = (filePath, text) => {
+            if (!text)
+              return {
+                text: "",
+                fixed: 0,
+                details: {
+                  diff: 0,
+                  jsxAttr: 0,
+                  arrayAttr: 0,
+                  attrComma: 0,
+                  isolate: 0,
+                  balance: 0,
+                },
+              };
+            const result = fixMdxContent(text);
+            if (result.fixed > 0 && filePath) {
+              fs.writeFileSync(filePath, result.text);
+            }
+            return result;
+          };
+          const summarizeMdxFixes = (details) => {
+            const parts = [];
+            if (details.diff) parts.push(`${details.diff} Diff colon prop(s)`);
+            if (details.jsxAttr) parts.push(`${details.jsxAttr} Diff JSX attr(s)`);
+            if (details.arrayAttr) parts.push(`${details.arrayAttr} bare array attr(s)`);
+            if (details.attrComma) parts.push(`${details.attrComma} JSX attr comma(s)`);
+            if (details.isolate) parts.push(`${details.isolate} block-tag isolation(s)`);
+            if (details.balance) parts.push(`${details.balance} missing closer(s)`);
+            return parts.join(", ");
+          };
           const escapeControlsInStrings = (text) => {
             let out = "";
             let inStr = false;
@@ -741,11 +815,11 @@ jobs:
           };
 
           // Preferred path: assemble from sidecar files (OpenCode contract).
-          const planMdx = readOptional("recap-plan.mdx");
-          const canvasMdx = readOptional("recap-canvas.mdx");
-          const prototypeMdx = readOptional("recap-prototype.mdx");
+          const planRaw = readOptional("recap-plan.mdx");
+          const canvasRaw = readOptional("recap-canvas.mdx");
+          const prototypeRaw = readOptional("recap-prototype.mdx");
           const planState = readOptional("recap-plan-state.json");
-          if (planMdx.trim()) {
+          if (planRaw.trim()) {
             let meta = {};
             const metaRaw = readOptional("recap-meta.json");
             if (metaRaw) {
@@ -762,14 +836,45 @@ jobs:
                 ? meta.title.trim()
                 : `PR #${process.env.PR_NUMBER || "?"} visual recap`;
             const brief = typeof meta.brief === "string" ? meta.brief : "";
+            const plan = fixAndMaybeWriteMdx("recap-plan.mdx", planRaw);
+            const canvas = fixAndMaybeWriteMdx(
+              canvasRaw ? "recap-canvas.mdx" : "",
+              canvasRaw,
+            );
+            const prototype = fixAndMaybeWriteMdx(
+              prototypeRaw ? "recap-prototype.mdx" : "",
+              prototypeRaw,
+            );
+            const mdxFixed = plan.fixed + canvas.fixed + prototype.fixed;
+            const details = {
+              diff: plan.details.diff + canvas.details.diff + prototype.details.diff,
+              jsxAttr:
+                plan.details.jsxAttr + canvas.details.jsxAttr + prototype.details.jsxAttr,
+              arrayAttr:
+                plan.details.arrayAttr +
+                canvas.details.arrayAttr +
+                prototype.details.arrayAttr,
+              attrComma:
+                plan.details.attrComma +
+                canvas.details.attrComma +
+                prototype.details.attrComma,
+              isolate:
+                plan.details.isolate + canvas.details.isolate + prototype.details.isolate,
+              balance:
+                plan.details.balance + canvas.details.balance + prototype.details.balance,
+            };
             const mdx = {
-              "plan.mdx": planMdx,
-              "canvas.mdx": canvasMdx,
-              "prototype.mdx": prototypeMdx,
+              "plan.mdx": plan.text || planRaw,
+              "canvas.mdx": canvas.text || canvasRaw,
+              "prototype.mdx": prototype.text || prototypeRaw,
             };
             if (planState.trim()) mdx[".plan-state.json"] = planState;
             fs.writeFileSync(path, JSON.stringify({ title, brief, mdx }, null, 2) + "\n");
-            emit(true, "assembled recap-source.json from sidecar MDX files via JSON.stringify", true);
+            const reason =
+              mdxFixed > 0
+                ? `assembled recap-source.json from sidecar MDX; rewrote ${summarizeMdxFixes(details)}`
+                : "assembled recap-source.json from sidecar MDX files via JSON.stringify";
+            emit(true, reason, true);
             process.exit(0);
           }
 
@@ -780,32 +885,220 @@ jobs:
 
           const raw = fs.readFileSync(path, "utf8");
           let err = tryParse(raw);
-          if (!err) {
-            emit(true, "recap-source.json is valid JSON", false);
-            process.exit(0);
-          }
-          const fixed = escapeControlsInStrings(raw);
-          err = tryParse(fixed.text);
+          let text = raw;
+          let controlRepaired = 0;
           if (err) {
-            emit(
-              false,
-              `recap-source.json was not valid JSON after sanitize: ${err}. Prefer sidecar files (recap-plan.mdx + recap-meta.json).`,
-              false,
-            );
-            fs.writeFileSync("recap-url-reason.txt", `recap-source.json was not valid JSON: ${err}\n`);
+            const fixed = escapeControlsInStrings(raw);
+            err = tryParse(fixed.text);
+            if (err) {
+              emit(
+                false,
+                `recap-source.json was not valid JSON after sanitize: ${err}. Prefer sidecar files (recap-plan.mdx + recap-meta.json).`,
+                false,
+              );
+              fs.writeFileSync("recap-url-reason.txt", `recap-source.json was not valid JSON: ${err}\n`);
+              process.exit(0);
+            }
+            text = fixed.text;
+            controlRepaired = fixed.repaired;
+          }
+
+          const parsed = JSON.parse(text);
+          const { payload, fixed: mdxFixed, details } = fixRecapSourcePayload(parsed);
+          const notes = [];
+          if (controlRepaired > 0) {
+            notes.push(`repaired ${controlRepaired} unescaped control character(s)`);
+          }
+          if (mdxFixed > 0) {
+            notes.push(`rewrote ${summarizeMdxFixes(details)}`);
+          }
+          if (notes.length > 0) {
+            fs.writeFileSync(path, JSON.stringify(payload, null, 2) + "\n");
+            emit(true, notes.join("; "), true);
             process.exit(0);
           }
-          fs.writeFileSync(path, fixed.text);
-          emit(
-            true,
-            `repaired ${fixed.repaired} unescaped control character(s) in recap-source.json string literals`,
-            true,
-          );
+          if (controlRepaired === 0 && text !== raw) {
+            fs.writeFileSync(path, text);
+          }
+          emit(true, "recap-source.json is valid JSON", false);
           NODE
 
       - name: Publish recap source
         id: publish
         if: steps.diff.outputs.tiny != 'true' && steps.scan.outputs.suppressed != 'true' && steps.sanitize.outputs.ok == 'true'
+        continue-on-error: true
+        env:
+          PREV_PLAN_ID: ${{ steps.prev.outputs.plan_id }}
+        run: |
+          set -uo pipefail
+          ARGS=(--source recap-source.json --out recap-url.txt --repo "$GITHUB_REPOSITORY" --pr "$PR_NUMBER" --app-url "$PLAN_RECAP_APP_URL" --token "$PLAN_RECAP_TOKEN")
+          if [ -n "${PREV_PLAN_ID:-}" ]; then ARGS+=(--prev-plan-id "$PREV_PLAN_ID"); fi
+          ARGS+=(--source-type pull-request --source-repo "$GITHUB_REPOSITORY" --source-pr-number "$PR_NUMBER")
+          if [ "${PR_MERGED:-false}" = "true" ] || [ -n "${PR_MERGED_AT:-}" ]; then
+            ARGS+=(--source-pr-state merged)
+          elif [ -n "${PR_STATE:-}" ]; then
+            ARGS+=(--source-pr-state "$PR_STATE")
+          fi
+          if [ -n "${PR_MERGED_AT:-}" ]; then ARGS+=(--source-pr-merged-at "$PR_MERGED_AT"); fi
+          $RECAP_CLI recap publish "${ARGS[@]}"
+
+      # Prefer a second deterministic pass (Callout isolation / Diff strings) before
+      # spending another OpenCode turn — agent repair previously hung for 20+ min.
+      - name: Deterministic MDX repair after publish 422
+        id: mdx_repair
+        if: steps.publish.outputs.repairable == 'true'
+        run: |
+          set -euo pipefail
+          cp -f recap-source.json recap-source.initial.json
+          OUT="$(node scripts/fix-recap-mdx-diff-strings.js recap-source.json --write)"
+          echo "$OUT"
+          FIXED="$(node -e 'try{process.stdout.write(String(JSON.parse(process.argv[1]).fixed||0))}catch{process.stdout.write("0")}' "$OUT")"
+          echo "fixed=$FIXED" >> "$GITHUB_OUTPUT"
+          {
+            echo 'summary<<__RECAP_MDX_REPAIR_EOF__'
+            echo "$OUT"
+            echo '__RECAP_MDX_REPAIR_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish after deterministic MDX repair
+        id: publish_deterministic
+        if: steps.publish.outputs.repairable == 'true' && steps.mdx_repair.outputs.fixed != '0'
+        continue-on-error: true
+        env:
+          PREV_PLAN_ID: ${{ steps.prev.outputs.plan_id }}
+        run: |
+          set -uo pipefail
+          ARGS=(--source recap-source.json --out recap-url.txt --repo "$GITHUB_REPOSITORY" --pr "$PR_NUMBER" --app-url "$PLAN_RECAP_APP_URL" --token "$PLAN_RECAP_TOKEN")
+          if [ -n "${PREV_PLAN_ID:-}" ]; then ARGS+=(--prev-plan-id "$PREV_PLAN_ID"); fi
+          ARGS+=(--source-type pull-request --source-repo "$GITHUB_REPOSITORY" --source-pr-number "$PR_NUMBER")
+          if [ "${PR_MERGED:-false}" = "true" ] || [ -n "${PR_MERGED_AT:-}" ]; then
+            ARGS+=(--source-pr-state merged)
+          elif [ -n "${PR_STATE:-}" ]; then
+            ARGS+=(--source-pr-state "$PR_STATE")
+          fi
+          if [ -n "${PR_MERGED_AT:-}" ]; then ARGS+=(--source-pr-merged-at "$PR_MERGED_AT"); fi
+          $RECAP_CLI recap publish "${ARGS[@]}"
+
+      # One-shot agent repair only when deterministic retry did not publish a URL.
+      - name: Build one-shot recap repair prompt
+        id: repair_prompt
+        if: steps.publish.outputs.repairable == 'true' && steps.publish_deterministic.outputs.ok != 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -f recap-source.initial.json ]; then cp -f recap-source.json recap-source.initial.json; fi
+          $RECAP_CLI recap repair-prompt --source recap-source.json --reason-file recap-url-reason.txt --out recap-repair-prompt.md
+
+      - name: Repair recap source (OpenCode + Mistral)
+        id: opencode_repair
+        if: steps.publish.outputs.repairable == 'true' && steps.publish_deterministic.outputs.ok != 'true' && needs.gate.outputs.agent == 'opencode'
+        continue-on-error: true
+        timeout-minutes: 6
+        env:
+          OPENCODE_MODEL: ${{ steps.opencode_model.outputs.model }}
+        run: |
+          set -uo pipefail
+          TRUSTED_CFG="$RUNNER_TEMP/visual-recap-opencode.json"
+          if [ ! -f "$TRUSTED_CFG" ]; then
+            echo "::error::Trusted OpenCode config missing for repair; refusing to run."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          export OPENCODE_CONFIG="$TRUSTED_CFG"
+          cp "$TRUSTED_CFG" opencode.json
+          rm -f opencode-repair-events.jsonl opencode-repair-stderr.log opencode-repair-exit-code.txt
+          set +e
+          "$OPENCODE_BIN" run \
+            -m "$OPENCODE_MODEL" \
+            --format json \
+            --auto \
+            --title "pr-visual-recap-repair-${PR_NUMBER}" \
+            "$(cat recap-repair-prompt.md)" \
+            > opencode-repair-events.jsonl 2> opencode-repair-stderr.log
+          OPENCODE_REPAIR_STATUS="$?"
+          set -e
+          echo "$OPENCODE_REPAIR_STATUS" > opencode-repair-exit-code.txt
+          if [ "$OPENCODE_REPAIR_STATUS" -eq 0 ]; then echo "ok=true" >> "$GITHUB_OUTPUT"; else echo "ok=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Repair recap source (Claude Code)
+        id: claude_repair
+        if: steps.publish.outputs.repairable == 'true' && steps.publish_deterministic.outputs.ok != 'true' && needs.gate.outputs.agent == 'claude'
+        continue-on-error: true
+        timeout-minutes: 6
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -uo pipefail
+          CLAUDE_ALLOWED_TOOLS="Read,Write"
+          CLAUDE_ARGS=(-p "$(cat recap-repair-prompt.md)" --allowedTools "$CLAUDE_ALLOWED_TOOLS" --permission-mode dontAsk --output-format json)
+          if [ -n "${VISUAL_RECAP_MODEL:-}" ]; then CLAUDE_ARGS+=(--model "$VISUAL_RECAP_MODEL"); fi
+          rm -f claude-repair-result.json claude-repair-stderr.log
+          set +e
+          npx -y @anthropic-ai/claude-code@2 "${CLAUDE_ARGS[@]}" > claude-repair-result.json 2> claude-repair-stderr.log
+          CLAUDE_REPAIR_STATUS="$?"
+          set -e
+          echo "$CLAUDE_REPAIR_STATUS" > claude-repair-exit-code.txt
+          if [ "$CLAUDE_REPAIR_STATUS" -eq 0 ]; then echo "ok=true" >> "$GITHUB_OUTPUT"; else echo "ok=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Repair recap source (Codex)
+        id: codex_repair
+        if: steps.publish.outputs.repairable == 'true' && steps.publish_deterministic.outputs.ok != 'true' && needs.gate.outputs.agent == 'codex'
+        continue-on-error: true
+        timeout-minutes: 6
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -uo pipefail
+          printenv OPENAI_API_KEY | npx -y @openai/codex@0 login --with-api-key || true
+          CODEX_ARGS=(exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check)
+          if [ -n "${VISUAL_RECAP_MODEL:-}" ]; then CODEX_ARGS+=(--model "$VISUAL_RECAP_MODEL"); fi
+          case "${VISUAL_RECAP_REASONING:-}" in
+            none|minimal|low|medium|high|xhigh)
+              CODEX_ARGS+=(-c "model_reasoning_effort=\"$VISUAL_RECAP_REASONING\"") ;;
+            "") ;;
+            *) echo "Ignoring invalid VISUAL_RECAP_REASONING: $VISUAL_RECAP_REASONING" ;;
+          esac
+          rm -f codex-repair-events.jsonl codex-repair-stderr.log
+          set +e
+          npx -y @openai/codex@0 "${CODEX_ARGS[@]}" --json "$(cat recap-repair-prompt.md)" 2> codex-repair-stderr.log | tee codex-repair-events.jsonl
+          CODEX_REPAIR_STATUS="${PIPESTATUS[0]}"
+          set -e
+          echo "$CODEX_REPAIR_STATUS" > codex-repair-exit-code.txt
+          if [ "$CODEX_REPAIR_STATUS" -eq 0 ]; then echo "ok=true" >> "$GITHUB_OUTPUT"; else echo "ok=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Validate repaired recap source
+        id: repaired_source
+        if: steps.publish.outputs.repairable == 'true' && steps.publish_deterministic.outputs.ok != 'true' && steps.repair_prompt.outcome == 'success'
+        env:
+          REPAIR_AGENT_OK: ${{ steps.opencode_repair.outputs.ok || steps.claude_repair.outputs.ok || steps.codex_repair.outputs.ok }}
+        run: |
+          set -uo pipefail
+          REPAIR_REASON=""
+          if [ "${REPAIR_AGENT_OK:-false}" != "true" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            REPAIR_REASON="Repair agent exited unsuccessfully; repaired source was not published."
+          else
+            # Re-run Diff-string / Callout sanitize on whatever the repair agent wrote.
+            node scripts/fix-recap-mdx-diff-strings.js recap-source.json --write || true
+            VALIDATION_JSON="$(GITHUB_OUTPUT=/dev/null $RECAP_CLI recap validate-repair --original recap-source.initial.json --source recap-source.json --reason-file recap-url-reason.txt || true)"
+            REPAIR_OK="$(node -e 'try{process.stdout.write(JSON.parse(process.argv[1]).ok===true?"true":"false")}catch{process.stdout.write("false")}' "$VALIDATION_JSON")"
+            REPAIR_REASON="$(node -e 'try{process.stdout.write(JSON.parse(process.argv[1]).reason||"")}catch{process.stdout.write("Repair validation returned invalid output.")}' "$VALIDATION_JSON")"
+            echo "ok=$REPAIR_OK" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$REPAIR_REASON" ]; then
+            echo "$REPAIR_REASON" > recap-url-reason.txt
+          fi
+          {
+            echo 'reason<<__RECAP_REPAIR_REASON_EOF__'
+            printf '%s\n' "$REPAIR_REASON" | sed -E \
+              -e 's/[Bb]earer[[:space:]]+[^[:space:]"]+/Bearer [redacted]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[jwt redacted]/g' \
+              -e 's/[A-Za-z0-9_-]{40,}/[redacted]/g'
+            echo '__RECAP_REPAIR_REASON_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish repaired recap source
+        id: publish_repair
+        if: steps.repaired_source.outputs.ok == 'true'
         continue-on-error: true
         env:
           PREV_PLAN_ID: ${{ steps.prev.outputs.plan_id }}
@@ -888,7 +1181,12 @@ jobs:
           fi
           {
             echo 'reason<<__RECAP_URL_REASON_EOF__'
-            echo "$URL_REASON"
+            # SECURITY: scrub JWT fragments before they reach sticky comments
+            # (recap-cli redact misses mid-token newline splits — Lesson 0ei).
+            printf '%s\n' "$URL_REASON" | sed -E \
+              -e 's/[Bb]earer[[:space:]]+[^[:space:]"]+/Bearer [redacted]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[jwt redacted]/g' \
+              -e 's/[A-Za-z0-9_-]{40,}/[redacted]/g'
             echo '__RECAP_URL_REASON_EOF__'
           } >> "$GITHUB_OUTPUT"
 
@@ -899,7 +1197,7 @@ jobs:
         env:
           RECAP_AGENT: ${{ needs.gate.outputs.agent }}
           RECAP_BLOCK_REFERENCE_SUMMARY: ${{ steps.block_reference.outputs.summary }}
-          RECAP_PUBLISH_REASON: ${{ steps.publish.outputs.reason }}
+          RECAP_PUBLISH_REASON: ${{ steps.repaired_source.outputs.reason || steps.publish_repair.outputs.reason || steps.publish_deterministic.outputs.reason || steps.publish.outputs.reason }}
           RECAP_SANITIZE_OK: ${{ steps.sanitize.outputs.ok }}
           RECAP_SANITIZE_REASON: ${{ steps.sanitize.outputs.reason }}
         run: |
@@ -923,12 +1221,16 @@ jobs:
             exit 0
           fi
           if [ -n "${RECAP_PUBLISH_REASON:-}" ]; then
+            SCRUBBED="$(printf '%s' "$RECAP_PUBLISH_REASON" | sed -E \
+              -e 's/[Bb]earer[[:space:]]+[^[:space:]"]+/Bearer [redacted]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[jwt redacted]/g' \
+              -e 's/[A-Za-z0-9_-]{40,}/[redacted]/g')"
             {
               echo 'summary<<__RECAP_PUBLISH_SUMMARY_EOF__'
-              echo "$RECAP_PUBLISH_REASON"
+              printf '%s\n' "$SCRUBBED"
               echo '__RECAP_PUBLISH_SUMMARY_EOF__'
             } >> "$GITHUB_OUTPUT"
-            node -e 'process.stdout.write(JSON.stringify({ ok: true, summary: process.env.RECAP_PUBLISH_REASON || "" }) + "\n")'
+            RECAP_PUBLISH_REASON="$SCRUBBED" node -e 'process.stdout.write(JSON.stringify({ ok: true, summary: process.env.RECAP_PUBLISH_REASON || "" }) + "\n")'
             exit 0
           fi
           RESULT=claude-result.json
@@ -1022,17 +1324,29 @@ jobs:
           name: pr-visual-recap-source-${{ github.event.pull_request.number }}
           path: |
             recap-source.json
+            recap-source.initial.json
             recap-meta.json
             recap-plan.mdx
             recap-canvas.mdx
             recap-prototype.mdx
+            recap-url-reason.txt
+            recap-repair-prompt.md
             claude-result.json
             claude-stderr.log
+            claude-repair-result.json
+            claude-repair-stderr.log
+            claude-repair-exit-code.txt
             codex-events.jsonl
             codex-stderr.log
+            codex-repair-events.jsonl
+            codex-repair-stderr.log
+            codex-repair-exit-code.txt
             opencode-events.jsonl
             opencode-stderr.log
             opencode-exit-code.txt
+            opencode-repair-events.jsonl
+            opencode-repair-stderr.log
+            opencode-repair-exit-code.txt
           if-no-files-found: ignore
           retention-days: 14
 
@@ -1057,6 +1371,16 @@ jobs:
           RECAP_URL_REASON: ${{ steps.route_health.outputs.reason || steps.url.outputs.reason }}
         run: |
           set -euo pipefail
+          # SECURITY: defense-in-depth scrub before sticky comment (Lesson 0ei).
+          scrub_diag() {
+            printf '%s' "${1:-}" | sed -E \
+              -e 's/[Bb]earer[[:space:]]+[^[:space:]"]+/Bearer [redacted]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[jwt redacted]/g' \
+              -e 's/[A-Za-z0-9_-]{40,}/[redacted]/g'
+          }
+          RECAP_AGENT_SUMMARY="$(scrub_diag "${RECAP_AGENT_SUMMARY:-}")"
+          RECAP_URL_REASON="$(scrub_diag "${RECAP_URL_REASON:-}")"
+          export RECAP_AGENT_SUMMARY RECAP_URL_REASON
           $RECAP_CLI recap comment upsert --repo "$GITHUB_REPOSITORY" --issue "$PR_NUMBER" --token "$GH_TOKEN" --head-sha "$HEAD_SHA"
 
       - name: Complete visual recap check
@@ -1076,6 +1400,14 @@ jobs:
           RECAP_URL_REASON: ${{ steps.route_health.outputs.reason || steps.url.outputs.reason }}
         run: |
           set -uo pipefail
+          scrub_diag() {
+            printf '%s' "${1:-}" | sed -E \
+              -e 's/[Bb]earer[[:space:]]+[^[:space:]"]+/Bearer [redacted]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[jwt redacted]/g' \
+              -e 's/[A-Za-z0-9_-]{40,}/[redacted]/g'
+          }
+          RECAP_AGENT_SUMMARY="$(scrub_diag "${RECAP_AGENT_SUMMARY:-}")"
+          RECAP_URL_REASON="$(scrub_diag "${RECAP_URL_REASON:-}")"
           $RECAP_CLI recap check complete \
             --check-run-id "$CHECK_RUN_ID" \
             --plan-ok "$PLAN_OK" \

--- a/docs/pr-visual-recap-agent-backends.md
+++ b/docs/pr-visual-recap-agent-backends.md
@@ -19,7 +19,8 @@ billing differentiator. Vibe stays optional; Antigravity stays Phase 2 only.
 ## Hard contract (unchanged)
 
 1. Gate (draft/bot/fork/credential presence, `VISUAL_RECAP_AGENT` allowlist)
-2. Trusted `@agent-native/core` CLI builds `recap-prompt.md`
+2. Trusted `@agent-native/recap-cli` builds `recap-prompt.md` (not
+   `@agent-native/core` — core's published bin can `spawn tsx` and fail in CI)
 3. **Agent** must leave a non-empty `recap-source.json` in the workspace
 4. Deterministic `recap publish` → Plan URL → screenshot → sticky comment
 
@@ -88,13 +89,29 @@ Re-run jobs on a prior run.
 
 ## Operator checklist
 
-1. Confirm secrets: `MISTRAL_API_KEY`, `PLAN_RECAP_TOKEN`
+1. Confirm secrets: `MISTRAL_API_KEY`, `PLAN_RECAP_TOKEN` (paste as **one
+   line** — embedded newlines make publish fail with `Headers.append … invalid
+   header value` and can leak JWT fragments into the sticky comment; Lesson 0ei)
 2. Optional repo vars: `VISUAL_RECAP_AGENT=opencode`,
-   `VISUAL_RECAP_MODEL=mistral/mistral-medium-latest`
+   `VISUAL_RECAP_MODEL=mistral/mistral-medium-latest`,
+   `RECAP_CLI_VERSION` (pins `@agent-native/recap-cli`, not core)
 3. Open / ready-for-review a non-draft PR and confirm the sticky recap comment
-4. On failure, download `pr-visual-recap-source-*` artifact (`opencode-events.jsonl`,
-   `opencode-stderr.log`)
-5. Agent may emit raw newlines inside JSON string literals — workflow prefers
+4. On failure at **Collect bounded diff** with `spawn tsx ENOENT`: workflow is
+   still on `@agent-native/core` — must use `@agent-native/recap-cli` (Lesson 0eh)
+5. On `Headers.append` / `Bearer [redacted] <fragment>` in the sticky comment:
+   re-paste `PLAN_RECAP_TOKEN` as one line (workflow now strips whitespace) and
+   **rotate** the token if any JWT fragment was posted
+6. On agent failure, download `pr-visual-recap-source-*` artifact
+   (`opencode-events.jsonl`, `opencode-stderr.log`)
+7. Agent may emit raw newlines inside JSON string literals — workflow prefers
    OpenCode **sidecar files** (`recap-meta.json` + `recap-plan.mdx`, …) and
    assembles strict JSON via `JSON.stringify`; control-char sanitize remains a
    fallback for Claude/Codex single-file output.
+8. On `422 … Could not parse expression with acorn`, Callout/MDX structure
+   errors, or `Unexpected character \`[\` before attribute value`: workflow
+   rewrites Diff props, Diff JSX string attrs, bare `columns=`/`rows=` arrays,
+   illegal attr commas, and isolates Callout/Note blocks via
+   `scripts/fix-recap-mdx-diff-strings.js` before publish; re-publishes once
+   after a deterministic repair; then optionally runs a **time-capped** agent
+   repair when `repairable=true` (Lesson 0ej). Not a token issue — rotate
+   `PLAN_RECAP_TOKEN` only for auth / JWT-leak cases (0ei).

--- a/scripts/fix-recap-mdx-diff-strings.js
+++ b/scripts/fix-recap-mdx-diff-strings.js
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Deterministic MDX hardeners for Plan visual-recap publish (Lesson 0ej).
+ *
+ * 1) Diff `before`/`after`/`code` props: shell `\\"` inside JS strings ends the
+ *    string early → Plan 422 "Could not parse expression with acorn".
+ * 2) Block JSX (Callout/Note/…) mid-paragraph: MDX requires blank lines around
+ *    block elements → 422 "Expected the closing tag </Callout> either after…"
+ * 3) Unbalanced Callout-like tags: append missing closers.
+ * 4) JSX string attrs with embedded `"` → `{JSON.stringify(...)}`.
+ * 5) Bare array attrs (`columns=[…]`) → `columns={[…]}`; strip illegal commas
+ *    (delegated to ./lib/fix-recap-mdx-arrays.js).
+ *
+ * SECURITY: only rewrites text; does not execute MDX.
+ * Trust boundary: agent-written MDX is untrusted input; we normalize structure.
+ */
+
+const path = require("path");
+const {
+  fixBareArrayAttrs,
+  fixJsxAttrTrailingCommas,
+} = require(path.join(__dirname, "lib", "fix-recap-mdx-arrays.js"));
+
+/** @type {readonly string[]} */
+const BLOCK_TAGS = Object.freeze([
+  "Callout",
+  "Note",
+  "Warning",
+  "Tip",
+  "Info",
+  "Steps",
+  "Step",
+]);
+
+/** @type {Readonly<Record<string, string>>} */
+const SIMPLE_ESCAPES = Object.freeze({
+  n: "\n",
+  r: "\r",
+  t: "\t",
+  '"': '"',
+  "\\": "\\",
+  "/": "/",
+});
+
+/** Attr terminator for Diff/AnnotatedCode string values (exactly two spaces). */
+const JSX_ATTR_TERM_RE =
+  /\n  (?:before|after|code|summary|language|mode|annotations|filename|id)\s*=|\n\/>|\n<\/(?:Diff|AnnotatedCode)>/;
+
+/** @returns {Record<string, number>} */
+function emptyFixDetails() {
+  return {
+    diff: 0,
+    jsxAttr: 0,
+    arrayAttr: 0,
+    attrComma: 0,
+    isolate: 0,
+    balance: 0,
+  };
+}
+
+/**
+ * @param {Record<string, number>} target
+ * @param {Record<string, number>} source
+ * @returns {void}
+ */
+function addFixDetails(target, source) {
+  target.diff += source.diff;
+  target.jsxAttr += source.jsxAttr;
+  target.arrayAttr += source.arrayAttr;
+  target.attrComma += source.attrComma;
+  target.isolate += source.isolate;
+  target.balance += source.balance;
+}
+
+/**
+ * @param {Record<string, number>} details
+ * @returns {number}
+ */
+function sumFixDetails(details) {
+  return (
+    details.diff +
+    details.jsxAttr +
+    details.arrayAttr +
+    details.attrComma +
+    details.isolate +
+    details.balance
+  );
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {string} body
+ * @returns {boolean}
+ */
+function tryParseJsonStringBody(body) {
+  try {
+    JSON.parse(`"${body}"`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decode `\uXXXX` at `body[i]` where `body[i]` is already known to be `u`.
+ *
+ * @param {string} body
+ * @param {number} i index of the `u` after a backslash
+ * @returns {{ char: string, advance: number }}
+ */
+function decodeUnicodeEscape(body, i) {
+  const hex = body.slice(i + 1, i + 5);
+  if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+    return { char: "u", advance: 0 };
+  }
+  return {
+    char: String.fromCharCode(Number.parseInt(hex, 16)),
+    advance: 4,
+  };
+}
+
+/**
+ * Unescape a mostly-JSON string body without failing on shell-ish sequences.
+ * Unknown escapes keep both characters (e.g. `\s` stays `\s`).
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+function lenientUnescape(body) {
+  let out = "";
+  for (let i = 0; i < body.length; i += 1) {
+    if (body[i] !== "\\" || i + 1 >= body.length) {
+      out += body[i];
+      continue;
+    }
+    const next = body[i + 1];
+    i += 1;
+    if (Object.prototype.hasOwnProperty.call(SIMPLE_ESCAPES, next)) {
+      out += SIMPLE_ESCAPES[next];
+      continue;
+    }
+    if (next === "u") {
+      const decoded = decodeUnicodeEscape(body, i);
+      out += decoded.char;
+      i += decoded.advance;
+      continue;
+    }
+    out += `\\${next}`;
+  }
+  return out;
+}
+
+/**
+ * Rewrite Diff `before`/`after`/`code` quoted props via JSON.stringify when the
+ * existing body is not a valid JSON string payload.
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function fixDiffQuotedProps(mdx) {
+  const re = /^(\s*)(before|after|code):\s*"(.*)",\s*$/;
+  let fixed = 0;
+  const lines = mdx.split("\n");
+  const out = lines.map((line) => {
+    const match = line.match(re);
+    if (!match) return line;
+    const [, indent, key, body] = match;
+    if (tryParseJsonStringBody(body)) return line;
+    fixed += 1;
+    return `${indent}${key}: ${JSON.stringify(lenientUnescape(body))},`;
+  });
+  return { text: out.join("\n"), fixed };
+}
+
+/**
+ * Ensure common Plan block JSX tags are not stuck inside a markdown paragraph.
+ * Skips JSX attribute lines and heavily-indented code-sample lines so we do
+ * not corrupt Diff/AnnotatedCode string payloads.
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function isolateBlockElements(mdx) {
+  let fixed = 0;
+  const out = mdx.split("\n").map((line) => {
+    if (
+      /^\s*(?:before|after|code|summary|language|mode|annotations|filename|id)\s*=/.test(
+        line,
+      ) ||
+      /^\s{4,}/.test(line)
+    ) {
+      return line;
+    }
+    let next = line;
+    for (const tag of BLOCK_TAGS) {
+      const openRe = new RegExp(`([^\\n])(<${tag}\\b[^>]*>)`, "g");
+      next = next.replace(openRe, (_, prev, open) => {
+        fixed += 1;
+        return `${prev}\n\n${open}`;
+      });
+      const closeRe = new RegExp(`(<\\/${tag}>)([^\\n])`, "g");
+      next = next.replace(closeRe, (_, close, nextChar) => {
+        fixed += 1;
+        return `${close}\n\n${nextChar}`;
+      });
+    }
+    return next;
+  });
+  return { text: out.join("\n"), fixed };
+}
+
+/**
+ * Append missing closers for unbalanced Callout-like tags at prose indent only
+ * (open > close). Ignores tags buried in code samples / attr payloads.
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function balanceBlockTags(mdx) {
+  let text = mdx;
+  let fixed = 0;
+  for (const tag of BLOCK_TAGS) {
+    const open = (text.match(new RegExp(`^\\s{0,2}<${tag}\\b[^>]*>`, "gm")) || [])
+      .length;
+    const close = (text.match(new RegExp(`^\\s{0,2}</${tag}>`, "gm")) || []).length;
+    if (open > close) {
+      const missing = open - close;
+      text = `${text}\n${`</${tag}>`.repeat(missing)}\n`;
+      fixed += missing;
+    }
+  }
+  return { text, fixed };
+}
+
+/**
+ * @param {string} rest
+ * @returns {{ rawValue: string, consumed: number } | null}
+ */
+function findQuotedAttrEndOnLine(rest) {
+  const eol = rest.search(/\n/);
+  const line = eol >= 0 ? rest.slice(0, eol) : rest;
+  const endQuote = line.indexOf('"');
+  if (endQuote < 0) return null;
+  const rawValue = line.slice(0, endQuote);
+  if (rawValue === "" || tryParseJsonStringBody(rawValue)) return null;
+  return { rawValue, consumed: endQuote + 1 };
+}
+
+/**
+ * Locate the end of a JSX string attr value starting at `rest`.
+ *
+ * @param {string} rest
+ * @param {"quote" | "expr"} kind
+ * @returns {{ rawValue: string, consumed: number } | null}
+ */
+function findJsxStringAttrEnd(rest, kind) {
+  if (kind === "expr") {
+    const firstNl = rest.indexOf("\n");
+    const firstLine = firstNl < 0 ? rest : rest.slice(0, firstNl);
+    // Already a single-line JS string expression (including prior rewrites).
+    if (firstLine.includes('"}')) return null;
+  }
+
+  const term = rest.search(JSX_ATTR_TERM_RE);
+  if (term >= 0) {
+    return { rawValue: rest.slice(0, term), consumed: term };
+  }
+  if (kind !== "quote") return null;
+  return findQuotedAttrEndOnLine(rest);
+}
+
+/**
+ * Strip trailing quote / `"}` leftovers from a captured attr body.
+ *
+ * @param {string} rawValue
+ * @param {"quote" | "expr"} kind
+ * @returns {string}
+ */
+function trimJsxStringAttrBody(rawValue, kind) {
+  if (kind === "expr") {
+    return rawValue.replace(/"\}\s*$/, "").replace(/"\s*$/, "");
+  }
+  if (rawValue.endsWith('"')) return rawValue.slice(0, -1);
+  return rawValue;
+}
+
+/**
+ * Rewrite one Diff/AnnotatedCode string attr occurrence.
+ *
+ * @param {string} body
+ * @param {string} key
+ * @param {"quote" | "expr"} kind
+ * @returns {{ body: string, fixed: number }}
+ */
+function rewriteOneJsxStringAttr(body, key, kind) {
+  const startRe =
+    kind === "quote"
+      ? new RegExp(`(\\s)(${key})="`, "g")
+      : new RegExp(`(\\s)(${key})=\\{"`, "g");
+  let match;
+  while ((match = startRe.exec(body))) {
+    const valueStart = match.index + match[0].length;
+    const found = findJsxStringAttrEnd(body.slice(valueStart), kind);
+    if (!found) continue;
+    const content = lenientUnescape(
+      trimJsxStringAttrBody(found.rawValue, kind).replace(/\r\n/g, "\n"),
+    );
+    const expr = `${match[1]}${key}={${JSON.stringify(content)}}`;
+    const next =
+      body.slice(0, match.index) + expr + body.slice(valueStart + found.consumed);
+    return { body: next, fixed: 1 };
+  }
+  return { body, fixed: 0 };
+}
+
+/**
+ * Rewrite Diff/AnnotatedCode string props to `key={JSON.stringify(...)}` form.
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function fixDiffJsxStringAttrs(mdx) {
+  const keys = ["before", "after", "code", "summary"];
+  let text = mdx;
+  let fixed = 0;
+
+  for (let pass = 0; pass < 64; pass += 1) {
+    let passFixed = 0;
+    for (const key of keys) {
+      for (const kind of /** @type {const} */ (["quote", "expr"])) {
+        const result = rewriteOneJsxStringAttr(text, key, kind);
+        text = result.body;
+        passFixed += result.fixed;
+      }
+    }
+    if (passFixed === 0) break;
+    fixed += passFixed;
+  }
+  return { text, fixed };
+}
+
+/**
+ * Apply all deterministic MDX hardeners.
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number, details: Record<string, number> }}
+ */
+function fixMdxContent(mdx) {
+  const details = emptyFixDetails();
+  let text = mdx;
+  // Prose Callout isolation first (skip attr / deeply-indented lines).
+  // NOTE: do not auto-balance tags — code samples often contain Callout markup
+  // that is not real MDX structure (Lesson 0ej follow-on).
+  const isolated = isolateBlockElements(text);
+  text = isolated.text;
+  details.isolate = isolated.fixed;
+  const arrays = fixBareArrayAttrs(text);
+  text = arrays.text;
+  details.arrayAttr = arrays.fixed;
+  const commas = fixJsxAttrTrailingCommas(text);
+  text = commas.text;
+  details.attrComma = commas.fixed;
+  const diff = fixDiffQuotedProps(text);
+  text = diff.text;
+  details.diff = diff.fixed;
+  // JSX string attr rewrite last so JSON.stringify payloads stay opaque.
+  const jsx = fixDiffJsxStringAttrs(text);
+  text = jsx.text;
+  details.jsxAttr = jsx.fixed;
+  return { text, fixed: sumFixDetails(details), details };
+}
+
+/**
+ * @param {Record<string, unknown>} mdx
+ * @returns {{ nextMdx: Record<string, unknown>, fixed: number, details: Record<string, number> }}
+ */
+function fixMdxMapEntries(mdx) {
+  const details = emptyFixDetails();
+  let fixed = 0;
+  const nextMdx = { ...mdx };
+  for (const key of Object.keys(nextMdx)) {
+    if (!key.endsWith(".mdx") || typeof nextMdx[key] !== "string") continue;
+    const result = fixMdxContent(nextMdx[key]);
+    if (result.fixed === 0) continue;
+    nextMdx[key] = result.text;
+    fixed += result.fixed;
+    addFixDetails(details, result.details);
+  }
+  return { nextMdx, fixed, details };
+}
+
+/**
+ * Fix MDX files inside a recap-source.json payload.
+ *
+ * @param {unknown} payload
+ * @returns {{ payload: unknown, fixed: number, details: Record<string, number> }}
+ */
+function fixRecapSourcePayload(payload) {
+  const emptyDetails = emptyFixDetails();
+  if (!isPlainObject(payload)) {
+    return { payload, fixed: 0, details: emptyDetails };
+  }
+  const mdx = payload.mdx;
+  if (!isPlainObject(mdx)) {
+    return { payload, fixed: 0, details: emptyDetails };
+  }
+  const { nextMdx, fixed, details } = fixMdxMapEntries(mdx);
+  if (fixed === 0) return { payload, fixed: 0, details };
+  return { payload: { ...payload, mdx: nextMdx }, fixed, details };
+}
+
+module.exports = {
+  BLOCK_TAGS,
+  tryParseJsonStringBody,
+  lenientUnescape,
+  fixDiffQuotedProps,
+  fixDiffJsxStringAttrs,
+  fixBareArrayAttrs,
+  fixJsxAttrTrailingCommas,
+  isolateBlockElements,
+  balanceBlockTags,
+  fixMdxContent,
+  fixRecapSourcePayload,
+};
+
+function main(argv) {
+  const fs = require("fs");
+  const target = argv[2];
+  if (!target) {
+    process.stderr.write(
+      "usage: fix-recap-mdx-diff-strings.js <file.mdx|recap-source.json> [--write]\n",
+    );
+    process.exit(2);
+  }
+  const write = argv.includes("--write");
+  const raw = fs.readFileSync(target, "utf8");
+  if (target.endsWith(".json")) {
+    const parsed = JSON.parse(raw);
+    const { payload, fixed, details } = fixRecapSourcePayload(parsed);
+    const text = `${JSON.stringify(payload, null, 2)}\n`;
+    if (write && fixed > 0) fs.writeFileSync(target, text);
+    process.stdout.write(JSON.stringify({ ok: true, fixed, details, target }) + "\n");
+    return;
+  }
+  const { text, fixed, details } = fixMdxContent(raw);
+  if (write && fixed > 0) fs.writeFileSync(target, text);
+  process.stdout.write(JSON.stringify({ ok: true, fixed, details, target }) + "\n");
+}
+
+if (require.main === module) {
+  main(process.argv);
+}

--- a/scripts/lib/fix-recap-mdx-arrays.js
+++ b/scripts/lib/fix-recap-mdx-arrays.js
@@ -1,0 +1,161 @@
+"use strict";
+
+/**
+ * Bare JSX array-attr hardeners for Plan MDX (Lesson 0ej).
+ * Split from fix-recap-mdx-diff-strings.js to keep per-module complexity low.
+ */
+
+/** @type {ReadonlySet<string>} */
+const QUOTE_CHARS = Object.freeze(new Set(['"', "'", "`"]));
+
+/**
+ * @param {string} ch
+ * @returns {boolean}
+ */
+function isQuoteChar(ch) {
+  return QUOTE_CHARS.has(ch);
+}
+
+/**
+ * @param {string | null} quote
+ * @param {boolean} escape
+ * @param {string} ch
+ * @returns {{ quote: string | null, escape: boolean }}
+ */
+function stepQuotedChar(quote, escape, ch) {
+  if (escape) return { quote, escape: false };
+  if (ch === "\\") return { quote, escape: true };
+  if (ch === quote) return { quote: null, escape: false };
+  return { quote, escape: false };
+}
+
+/**
+ * @param {string} ch
+ * @param {number} depth
+ * @returns {number}
+ */
+function adjustArrayDepth(ch, depth) {
+  if (ch === "[") return depth + 1;
+  if (ch === "]") return depth - 1;
+  return depth;
+}
+
+/**
+ * @param {{ i: number, depth: number, quote: string | null, escape: boolean }} state
+ * @param {string} ch
+ * @returns {void}
+ */
+function advanceArrayScanState(state, ch) {
+  if (state.quote) {
+    const next = stepQuotedChar(state.quote, state.escape, ch);
+    state.quote = next.quote;
+    state.escape = next.escape;
+    return;
+  }
+  if (isQuoteChar(ch)) {
+    state.quote = ch;
+    return;
+  }
+  state.depth = adjustArrayDepth(ch, state.depth);
+}
+
+/**
+ * Advance past a JSON-ish array starting at `openIdx` (index of `[`).
+ *
+ * @param {string} text
+ * @param {number} openIdx
+ * @returns {number} index just past the matching `]`, or -1 if unbalanced
+ */
+function findMatchingArrayEnd(text, openIdx) {
+  const state = {
+    i: openIdx + 1,
+    depth: 1,
+    quote: /** @type {string | null} */ (null),
+    escape: false,
+  };
+  while (state.i < text.length) {
+    if (state.depth === 0) break;
+    const ch = text[state.i];
+    state.i += 1;
+    advanceArrayScanState(state, ch);
+  }
+  return state.depth === 0 ? state.i : -1;
+}
+
+/**
+ * Build `key={[…]}` replacement; for `rows=[…]}` only insert the opening `{`.
+ *
+ * @param {{ prefix: string, key: string, arraySlice: string, alreadyClosed: boolean }} parts
+ * @returns {string}
+ */
+function bareArrayReplacement(parts) {
+  const { prefix, key, arraySlice, alreadyClosed } = parts;
+  if (alreadyClosed) return `${prefix}${key}={${arraySlice}`;
+  return `${prefix}${key}={${arraySlice}}`;
+}
+
+/**
+ * Apply one bare-array rewrite at the first `key=[` match.
+ *
+ * @param {string} text
+ * @param {string} keys
+ * @returns {{ text: string, fixed: number } | null}
+ */
+function rewriteOneBareArray(text, keys) {
+  const match = new RegExp(`(\\s)(${keys})=\\[`).exec(text);
+  if (!match) return null;
+  const openIdx = match.index + match[0].length - 1;
+  const endIdx = findMatchingArrayEnd(text, openIdx);
+  if (endIdx < 0) return null;
+  const replacement = bareArrayReplacement({
+    prefix: match[1],
+    key: match[2],
+    arraySlice: text.slice(openIdx, endIdx),
+    alreadyClosed: text[endIdx] === "}",
+  });
+  return {
+    text: text.slice(0, match.index) + replacement + text.slice(endIdx),
+    fixed: 1,
+  };
+}
+
+/**
+ * Rewrite bare JSX array attrs (`columns=[…]`) to expression form (`columns={[…]}`).
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function fixBareArrayAttrs(mdx) {
+  const keys = "columns|rows|annotations|items|data|options|tabs";
+  let text = mdx;
+  let fixed = 0;
+  for (let n = 0; n < 64; n += 1) {
+    const result = rewriteOneBareArray(text, keys);
+    if (!result) break;
+    text = result.text;
+    fixed += result.fixed;
+  }
+  return { text, fixed };
+}
+
+/**
+ * Remove illegal commas between JSX attributes (`columns={…},` → `columns={…}`).
+ *
+ * @param {string} mdx
+ * @returns {{ text: string, fixed: number }}
+ */
+function fixJsxAttrTrailingCommas(mdx) {
+  let fixed = 0;
+  const text = mdx.replace(/(["}\]])(,)(\s*\n\s*[A-Za-z_][\w-]*=)/g, (_, end, _comma, next) => {
+    fixed += 1;
+    return `${end}${next}`;
+  });
+  return { text, fixed };
+}
+
+module.exports = {
+  findMatchingArrayEnd,
+  bareArrayReplacement,
+  fixBareArrayAttrs,
+  fixJsxAttrTrailingCommas,
+};

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,24 @@
 # Lessons Learned
 
+## Lesson 0ei: PLAN_RECAP_TOKEN newlines break publish AND leak JWT into comments (2026-07-21)
+
+**Pattern:** Visual recap sticky comment showed `Headers.append: "Bearer
+[redacted] <jwt-remainder>" is an invalid header value` instead of a plan
+link. Publish never produced a URL. **Root cause:** (1) `PLAN_RECAP_TOKEN`
+org credential had embedded CR/LF (wrapped paste). undici rejects
+`Authorization` values with control chars. (2) `@agent-native/recap-cli`
+`sanitizeAgentFailureSummary` only redacts `Bearer\s+[A-Za-z0-9._-]{8,}` —
+a mid-token newline ends that match early, so the JWT payload/signature after
+the break is posted to the PR. `.trim()` on the token does **not** remove
+internal whitespace.
+**Rule:** (1) Strip **all** whitespace from `PLAN_RECAP_TOKEN` at job start
+(`tr -d '[:space:]'`), drop accidental `Bearer` prefix, `::add-mask::`, then
+export via `GITHUB_ENV`. (2) Scrub sticky-comment diagnostics for Bearer /
+JWT / long base64url runs before upsert. (3) Paste secrets as a single line;
+if a JWT fragment ever lands in a PR comment, **rotate** the org service
+token immediately. (4) Do not rely on recap-cli redact alone for newline-split
+tokens.
+
 ## Lesson 0du: Gitleaks first capture group becomes Secret (2026-07-17)
 
 **Pattern:** `personal-config-generic-secret` used `(secret|password|…)[\s\-_:=]+…`

--- a/tests/test_fix_recap_mdx_diff_strings.sh
+++ b/tests/test_fix_recap_mdx_diff_strings.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/fix-recap-mdx-diff-strings.js (Lesson 0ej).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXER="$ROOT/scripts/fix-recap-mdx-diff-strings.js"
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Case 1: broken Diff after: with shell [^[:space:]\\"] — must rewrite.
+# NOTE: two backslashes before the quote (JS: \\ then " ends the string early).
+cat >"$TEST_DIR/broken.mdx" <<'MDX'
+<Diff
+            language="yaml"
+            mode="split"
+            before: "safe before",
+            after: "sed -E -e 's/[Bb]earer[[:space:]]+[^[:space:]\\"]+/Bearer [redacted]/g'",
+            annotations: [
+              {
+MDX
+
+node -e '
+const { fixDiffQuotedProps, tryParseJsonStringBody } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const afterLine = raw.split("\n").find((l) => /^\s*after:/.test(l));
+if (!afterLine) process.exit(10);
+const m = afterLine.match(/after:\s*"(.*)",\s*$/);
+if (!m) process.exit(11);
+if (tryParseJsonStringBody(m[1])) {
+  console.error("expected invalid JSON string body");
+  process.exit(2);
+}
+const { text, fixed } = fixDiffQuotedProps(raw);
+if (fixed !== 1) {
+  console.error("expected fixed=1, got", fixed);
+  process.exit(3);
+}
+const fixedLine = text.split("\n").find((l) => /^\s*after:/.test(l));
+const fixedTok = fixedLine.match(/after:\s*(.*),$/)[1];
+JSON.parse(fixedTok); // rewritten value must be a valid JSON string token
+fs.writeFileSync(process.argv[3], text);
+' "$FIXER" "$TEST_DIR/broken.mdx" "$TEST_DIR/fixed.mdx"
+check "rewrites broken Diff after prop" test -f "$TEST_DIR/fixed.mdx"
+
+# Case 2: already-valid Diff line is left alone.
+cat >"$TEST_DIR/ok.mdx" <<'MDX'
+            after: "hello \"world\" and \\n newline",
+MDX
+node -e '
+const { fixDiffQuotedProps } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed } = fixDiffQuotedProps(raw);
+if (fixed !== 0) process.exit(2);
+if (text !== raw) process.exit(3);
+' "$FIXER" "$TEST_DIR/ok.mdx"
+check "leaves valid Diff props unchanged" true
+
+# Case 3: recap-source.json plan.mdx path.
+node -e '
+const { fixRecapSourcePayload } = require(process.argv[1]);
+const fs = require("fs");
+const broken = fs.readFileSync(process.argv[2], "utf8");
+const payload = { title: "t", brief: "", mdx: { "plan.mdx": broken, "canvas.mdx": "" } };
+const { payload: next, fixed } = fixRecapSourcePayload(payload);
+if (fixed !== 1) process.exit(2);
+const body = next.mdx["plan.mdx"].split("\n").find((l) => l.includes("after:")).match(/after:\s*(.*),$/)[1];
+JSON.parse(body);
+' "$FIXER" "$TEST_DIR/broken.mdx"
+check "fixes plan.mdx inside recap-source payload" true
+
+# Case 4: CLI --write on the real failing artifact shape (if present).
+if [[ -f /tmp/recap-fail-1733/recap-plan.mdx ]]; then
+  cp /tmp/recap-fail-1733/recap-plan.mdx "$TEST_DIR/artifact.mdx"
+  OUT=$(node "$FIXER" "$TEST_DIR/artifact.mdx" --write)
+  check "artifact fixer reports fixed>=1" node -e 'const j=JSON.parse(process.argv[1]); process.exit(j.fixed>=1?0:1)' "$OUT"
+  # Re-run: idempotent
+  OUT2=$(node "$FIXER" "$TEST_DIR/artifact.mdx" --write)
+  check "artifact fixer is idempotent" node -e 'const j=JSON.parse(process.argv[1]); process.exit(j.fixed===0?0:1)' "$OUT2"
+fi
+
+# Case 5: MDX compile gate when @mdx-js/mdx is available.
+if [[ -d /tmp/recap-fail-1733/node_modules/@mdx-js/mdx ]]; then
+  (
+    cd /tmp/recap-fail-1733
+    node <<'NODE'
+    const fs = require("fs");
+    const { fixMdxContent } = require("/workspace/scripts/fix-recap-mdx-diff-strings.js");
+    (async () => {
+      const { compile } = await import("@mdx-js/mdx");
+      const raw = fs.readFileSync("recap-plan.mdx", "utf8");
+      let rawFailed = false;
+      try { await compile(raw); } catch { rawFailed = true; }
+      if (!rawFailed) process.exit(2);
+      const { text, fixed } = fixMdxContent(raw);
+      if (fixed < 1) process.exit(3);
+      await compile(text);
+    })().catch((e) => { console.error(e); process.exit(1); });
+NODE
+  )
+  check "artifact MDX compiles after fix" true
+fi
+
+# Case 6: Callout mid-paragraph must be isolated onto its own lines.
+cat >"$TEST_DIR/callout.mdx" <<'MDX'
+Intro text <Callout kind="info">Heads up</Callout> trailing text
+MDX
+node -e '
+const { fixMdxContent } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed } = fixMdxContent(raw);
+if (fixed < 1) process.exit(2);
+if (!text.includes("\n\n<Callout") || !text.includes("</Callout>\n\n")) process.exit(3);
+' "$FIXER" "$TEST_DIR/callout.mdx"
+check "isolates Callout out of a paragraph" true
+
+# Case 7: missing Callout closer is appended.
+node -e '
+const { balanceBlockTags } = require(process.argv[1]);
+const { text, fixed } = balanceBlockTags("<Callout>hi\n");
+if (fixed !== 1 || !text.includes("</Callout>")) process.exit(2);
+' "$FIXER"
+check "balances missing Callout closer" true
+
+# Case 8: JSX after="..." with embedded \" must become after={...}.
+cat >"$TEST_DIR/jsx-attr.mdx" <<'MDX'
+<Diff
+  summary="demo"
+  before=""
+  after="        # rejects Authorization via Headers.append (\"invalid header value\"), and
+        # more"
+  annotations={[]}
+/>
+MDX
+node -e '
+const { fixMdxContent } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed, details } = fixMdxContent(raw);
+if (details.jsxAttr < 1) { console.error(details); process.exit(2); }
+if (!/after=\{/.test(text)) process.exit(3);
+if (/after="/.test(text)) process.exit(4);
+JSON.parse(text.match(/after=\{([\s\S]*?)\}/)[1]);
+' "$FIXER" "$TEST_DIR/jsx-attr.mdx"
+check "rewrites Diff JSX after= attrs to expressions" true
+
+# Case 9: live artifact from run 29853720898 — JSX attrs + code={ multiline.
+if [[ -f /tmp/vr-art/recap-plan.mdx ]]; then
+  node -e '
+const { fixMdxContent } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync("/tmp/vr-art/recap-plan.mdx", "utf8");
+const { text, fixed, details } = fixMdxContent(raw);
+if (fixed < 1 || details.jsxAttr < 1) { console.error(details); process.exit(2); }
+const again = fixMdxContent(text);
+if (again.fixed !== 0) { console.error("not idempotent", again.details); process.exit(3); }
+fs.writeFileSync("/tmp/vr-art/recap-plan.fixed-final.mdx", text);
+' "$FIXER"
+  check "artifact JSX Diff/AnnotatedCode attrs rewrite" true
+  if [[ -d /tmp/recap-fail-1733/node_modules/@mdx-js/mdx ]]; then
+    node <<'NODE'
+    const fs = require("fs");
+    (async () => {
+      const { compile } = await import("/tmp/recap-fail-1733/node_modules/@mdx-js/mdx/index.js");
+      await compile(fs.readFileSync("/tmp/vr-art/recap-plan.fixed-final.mdx", "utf8"));
+    })().catch((e) => { console.error(e.message); process.exit(1); });
+NODE
+    check "artifact MDX compiles after JSX attr fix" true
+  fi
+fi
+
+# Case 10: bare columns=[…] must become columns={[…]}.
+cat >"$TEST_DIR/bare-array.mdx" <<'MDX'
+<Table
+  columns=[{"key":"a","label":"A"},{"key":"b","label":"B"}]
+  rows=[{"a":"1","b":"2"}]
+/>
+MDX
+node -e '
+const { fixBareArrayAttrs, fixMdxContent } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed } = fixBareArrayAttrs(raw);
+if (fixed !== 2) { console.error("expected 2 array fixes, got", fixed); process.exit(2); }
+if (!/columns=\{\[/.test(text) || !/rows=\{\[/.test(text)) process.exit(3);
+if (/columns=\[/.test(text) || /rows=\[/.test(text)) process.exit(4);
+const again = fixBareArrayAttrs(text);
+if (again.fixed !== 0) process.exit(5);
+const full = fixMdxContent(raw);
+if (full.details.arrayAttr !== 2) process.exit(6);
+' "$FIXER" "$TEST_DIR/bare-array.mdx"
+check "rewrites bare columns=/rows= array attrs" true
+
+# Case 11: illegal commas between JSX attrs are stripped.
+# NOTE: the pattern targets `…},` / `…],` / `…",` before the next attr line.
+cat >"$TEST_DIR/attr-comma.mdx" <<'MDX'
+<Table
+  columns={[{"key":"a"}]},
+  rows={[{"a":"1"}]}
+/>
+MDX
+node -e '
+const { fixJsxAttrTrailingCommas } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed } = fixJsxAttrTrailingCommas(raw);
+if (fixed !== 1) { console.error("expected 1 comma fix, got", fixed, text); process.exit(2); }
+if (/}\s*,\s*\n/.test(text)) process.exit(3);
+if (!/columns=\{\[{"key":"a"\}\]\}\s*\n\s*rows=/.test(text)) process.exit(4);
+' "$FIXER" "$TEST_DIR/attr-comma.mdx"
+check "strips illegal commas between JSX attrs" true
+
+# Case 12: rows=[…]} (stray closing brace) only inserts opening `{`.
+cat >"$TEST_DIR/half-brace.mdx" <<'MDX'
+  rows=[{"a":1}]}
+MDX
+node -e '
+const { fixBareArrayAttrs } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const { text, fixed } = fixBareArrayAttrs(raw);
+if (fixed !== 1) process.exit(2);
+if (!/rows=\{\[{"a":1\}\]\}/.test(text)) { console.error(text); process.exit(3); }
+if (/rows=\{\[.*\]\}\}/.test(text)) process.exit(4);
+' "$FIXER" "$TEST_DIR/half-brace.mdx"
+check "half-braced rows=[…]} only inserts opening brace" true
+
+# Case 13: live artifact from run with bare array attrs (vr-art2).
+if [[ -f /tmp/vr-art2/recap-plan.mdx ]]; then
+  node -e '
+const { fixMdxContent } = require(process.argv[1]);
+const fs = require("fs");
+const raw = fs.readFileSync("/tmp/vr-art2/recap-plan.mdx", "utf8");
+const { text, fixed, details } = fixMdxContent(raw);
+if (fixed < 1 || details.arrayAttr < 1) { console.error(details); process.exit(2); }
+const again = fixMdxContent(text);
+if (again.fixed !== 0) { console.error("not idempotent", again.details); process.exit(3); }
+fs.writeFileSync("/tmp/vr-art2/recap-plan.fixed-arrays.mdx", text);
+' "$FIXER"
+  check "artifact bare array attrs rewrite" true
+  if [[ -d /tmp/recap-fail-1733/node_modules/@mdx-js/mdx ]]; then
+    node <<'NODE'
+    const fs = require("fs");
+    (async () => {
+      const { compile } = await import("/tmp/recap-fail-1733/node_modules/@mdx-js/mdx/index.js");
+      try {
+        await compile(fs.readFileSync("/tmp/vr-art2/recap-plan.mdx", "utf8"));
+        process.exit(2);
+      } catch { /* expected raw fail */ }
+      await compile(fs.readFileSync("/tmp/vr-art2/recap-plan.fixed-arrays.mdx", "utf8"));
+    })().catch((e) => { console.error(e.message); process.exit(1); });
+NODE
+    check "artifact MDX compiles after array-attr fix" true
+  fi
+fi
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
…es #1748)

Re-apply #1748 onto current main. Journal conflict in tasks/lessons.md resolved append-only (Lesson 0ei only; S2). Drops force-merge of the original salvage branch.

Refs: #1748 #1733 (salvage source)

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- The problem this PR solves, or the motivation behind it. -->

## How

<!-- Brief explanation of the approach. Highlight any non-obvious design decisions. -->

## Testing

<!-- How did you verify this works? Examples:
  - `make test-quick` passed
  - `make test` passed
  - Manual steps: describe what you ran and what you observed
-->

## Security

<!-- Any security implications, trust-boundary changes, or secrets-handling decisions.
     If none, write "No security impact." -->

---

## Checklist

- [ ] `make test-quick` passes locally
- [ ] `make lint` reports no new errors
- [ ] No secrets, tokens, or `.env` files included
- [ ] Documentation updated if behaviour changed
- [ ] Branch name follows the convention in CONTRIBUTING.md (section "Branch naming")
