### PR TITLE
fix(ci): pin workflow action updates to commit SHAs only

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -486,6 +486,15 @@ def sha_for_tag(repo_id: str, tag: str) -> str:
     return ""
 
 
+def _pin_version(
+    current: str, version_hint: str | None
+) -> tuple[int, int, int] | None:
+    """Comparable version for a workflow pin (tag body or `# vX.Y.Z` hint)."""
+    if is_commit_sha(current):
+        return numeric_version(version_hint) if version_hint else None
+    return numeric_version(current)
+
+
 def target_ref(
     current: str, latest: str, *, version_hint: str | None = None
 ) -> str | None:
@@ -496,23 +505,16 @@ def target_ref(
     Commit SHA pins are never treated as version numbers; pass the trailing
     `# vX.Y.Z` comment as version_hint when comparing SHA pins.
     """
-    if is_commit_sha(current):
-        current_v = numeric_version(version_hint) if version_hint else None
-    else:
-        current_v = numeric_version(current)
     latest_v = numeric_version(latest)
     if not latest_v:
         return None
-    if current_v is not None and latest_v <= current_v:
-        return None
-    # SHA pin with no version comment: allow caller to SHA-compare against latest.
-    if current_v is None and not is_commit_sha(current):
-        return None
-    if current_v is None and is_commit_sha(current) and not version_hint:
+    current_v = _pin_version(current, version_hint)
+    if current_v is not None:
+        return latest if latest_v > current_v else None
+    # SHA pin with no usable version comment: caller SHA-compares after resolve.
+    if is_commit_sha(current) and not version_hint:
         return latest
-    if current_v is None:
-        return None
-    return latest
+    return None
 
 
 def append_publication_result(

--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -449,8 +449,17 @@ def latest_tag_for_action(repo_id: str) -> str:
     return _latest_tag_via_tags(repo_id)
 
 
+def is_commit_sha(ref: str) -> bool:
+    """True for full-length git commit SHAs used to pin Actions (Lesson 0z)."""
+    return bool(re.fullmatch(r"[0-9a-fA-F]{40}", ref))
+
+
 @functools.lru_cache(maxsize=1024)
 def numeric_version(text: str) -> tuple[int, int, int] | None:
+    # SECURITY: never parse commit SHAs as versions — hex digits match VERSION_PATTERN
+    # and previously caused SHA→floating-tag "upgrades" (Lesson 0z / supply-chain).
+    if is_commit_sha(text):
+        return None
     match = VERSION_PATTERN.search(text)
     if not match:
         return None
@@ -462,14 +471,47 @@ def tag_exists(repo_id: str, tag: str) -> bool:
     return proc.returncode == 0
 
 
-def target_ref(current: str, latest: str) -> str | None:
-    current_v = numeric_version(current)
+def sha_for_tag(repo_id: str, tag: str) -> str:
+    """Resolve a git tag to a full commit SHA (peel annotated tags)."""
+    data = gh_json(["api", f"repos/{repo_id}/git/ref/tags/{tag}"], default={})
+    obj = data.get("object") or {}
+    obj_type = obj.get("type")
+    sha = obj.get("sha") or ""
+    if obj_type == "commit":
+        return sha if is_commit_sha(sha) else ""
+    if obj_type == "tag" and sha:
+        tag_obj = gh_json(["api", f"repos/{repo_id}/git/tags/{sha}"], default={})
+        commit_sha = (tag_obj.get("object") or {}).get("sha") or ""
+        return commit_sha if is_commit_sha(commit_sha) else ""
+    return ""
+
+
+def target_ref(
+    current: str, latest: str, *, version_hint: str | None = None
+) -> str | None:
+    """
+    Return the latest *tag name* when an update is warranted.
+
+    Callers must resolve the tag to a commit SHA before writing workflow files.
+    Commit SHA pins are never treated as version numbers; pass the trailing
+    `# vX.Y.Z` comment as version_hint when comparing SHA pins.
+    """
+    if is_commit_sha(current):
+        current_v = numeric_version(version_hint) if version_hint else None
+    else:
+        current_v = numeric_version(current)
     latest_v = numeric_version(latest)
-    if not current_v or not latest_v:
+    if not latest_v:
         return None
-    if latest_v <= current_v:
+    if current_v is not None and latest_v <= current_v:
         return None
-    # Always return the full latest version to ensure the tag exists
+    # SHA pin with no version comment: allow caller to SHA-compare against latest.
+    if current_v is None and not is_commit_sha(current):
+        return None
+    if current_v is None and is_commit_sha(current) and not version_hint:
+        return latest
+    if current_v is None:
+        return None
     return latest
 
 

--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -21,6 +21,7 @@ from repository_automation_common import (
     ensure_gh_token,
     gh_json,
     git_output,
+    is_commit_sha,
     iso_day,
     latest_tag_for_action,
     matches_any,
@@ -29,13 +30,17 @@ from repository_automation_common import (
     run_process,
     run_shell_command,
     safe_pr_body,
+    sha_for_tag,
     tag_exists,
     target_ref,
     write_result,
     writes_allowed,
 )
 
-WORKFLOW_PATTERN = re.compile(r"(uses:\s*)([^@\s]+)@([^\s#]+)")
+# Optional trailing `# vX.Y.Z` comment is the version hint for SHA pins (Lesson 0z).
+WORKFLOW_PATTERN = re.compile(
+    r"(uses:\s*)([^@\s]+)@([^\s#]+)(?:[ \t]+#[ \t]*([^\n]*))?"
+)
 
 
 # ⚡ Bolt Optimization: Cache regex compilation and normalisation overhead for multiple checks inside loops.
@@ -220,34 +225,55 @@ def _extract_repo_id(action_ref: str) -> str | None:
     return "/".join(parts[:2])
 
 
-def _resolve_proposed_tag(
+def _resolve_proposed_pin(
     repo_id: str,
     current: str,
+    version_hint: str | None,
     latest_cache: dict[str, str],
     exists_cache: dict[tuple[str, str], bool],
-) -> str | None:
+    sha_cache: dict[tuple[str, str], str],
+) -> tuple[str, str] | None:
+    """
+    Return (pin_ref_with_comment, tag_name) for a SHA-only workflow update.
+
+    Never returns a floating tag as the write target (Lesson 0z / supply-chain).
+    """
     latest = latest_cache.get(repo_id)
     if latest is None:
         latest = latest_tag_for_action(repo_id)
         latest_cache[repo_id] = latest
-
-    proposed = target_ref(current, latest)
-    if not proposed or proposed == current:
+    if not latest:
         return None
 
-    cache_key = (repo_id, proposed)
+    proposed_tag = target_ref(current, latest, version_hint=version_hint)
+    if not proposed_tag:
+        return None
+
+    cache_key = (repo_id, proposed_tag)
     exists = exists_cache.get(cache_key)
     if exists is None:
-        exists = tag_exists(repo_id, proposed)
+        exists = tag_exists(repo_id, proposed_tag)
         exists_cache[cache_key] = exists
-
     if not exists:
         print(
-            f"Warning: Proposed tag {proposed} for {repo_id} does not exist. Skipping update."
+            f"Warning: Proposed tag {proposed_tag} for {repo_id} does not exist. Skipping update."
         )
         return None
 
-    return proposed
+    sha = sha_cache.get(cache_key)
+    if sha is None:
+        sha = sha_for_tag(repo_id, proposed_tag)
+        sha_cache[cache_key] = sha
+    if not sha or not is_commit_sha(sha):
+        print(
+            f"Warning: Could not resolve commit SHA for {repo_id}@{proposed_tag}. Skipping."
+        )
+        return None
+
+    if is_commit_sha(current) and current.lower() == sha.lower():
+        return None
+
+    return f"{sha} # {proposed_tag}", proposed_tag
 
 
 @functools.lru_cache(maxsize=512)
@@ -263,39 +289,47 @@ def evaluate_action_update(
     file_path: Path,
     latest_cache: dict[str, str],
     exists_cache: dict[tuple[str, str], bool],
+    sha_cache: dict[tuple[str, str], str],
 ) -> dict[str, Any] | None:
     action_ref = match.group(2)
     current = match.group(3)
+    version_hint = (match.group(4) or "").strip() or None
 
     repo_id = _extract_repo_id(action_ref)
     if not repo_id:
         return None
 
-    proposed = _resolve_proposed_tag(repo_id, current, latest_cache, exists_cache)
-    if not proposed:
+    resolved = _resolve_proposed_pin(
+        repo_id, current, version_hint, latest_cache, exists_cache, sha_cache
+    )
+    if not resolved:
         return None
+    proposed_pin, proposed_tag = resolved
+    compare_from = version_hint or current
 
     return {
         "old": match.group(0),
-        "new": f"{match.group(1)}{action_ref}@{proposed}",
+        "new": f"{match.group(1)}{action_ref}@{proposed_pin}",
         "file": str(file_path.relative_to(ROOT)),
         "action": action_ref,
         "current": current,
-        "target": proposed,
-        "major_bump": _is_major_bump(current, proposed),
+        "target": proposed_pin,
+        "target_tag": proposed_tag,
+        "major_bump": _is_major_bump(compare_from, proposed_tag),
     }
 
 
 def workflow_file_plans() -> list[dict[str, Any]]:
     latest_cache: dict[str, str] = {}
     exists_cache: dict[tuple[str, str], bool] = {}
+    sha_cache: dict[tuple[str, str], str] = {}
     plans = []
     for file_path in sorted((ROOT / ".github" / "workflows").glob("*.y*ml")):
         text = file_path.read_text()
         replacements = []
         for match in WORKFLOW_PATTERN.finditer(text):
             update = evaluate_action_update(
-                match, file_path, latest_cache, exists_cache
+                match, file_path, latest_cache, exists_cache, sha_cache
             )
             if update:
                 replacements.append(update)

--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -225,54 +226,69 @@ def _extract_repo_id(action_ref: str) -> str | None:
     return "/".join(parts[:2])
 
 
+@dataclass
+class _PinCaches:
+    """Shared lookup caches for workflow action pin resolution."""
+
+    latest: dict[str, str] = field(default_factory=dict)
+    exists: dict[tuple[str, str], bool] = field(default_factory=dict)
+    sha: dict[tuple[str, str], str] = field(default_factory=dict)
+
+
+def _latest_tag(repo_id: str, caches: _PinCaches) -> str:
+    cached = caches.latest.get(repo_id)
+    if cached is not None:
+        return cached
+    latest = latest_tag_for_action(repo_id)
+    caches.latest[repo_id] = latest
+    return latest
+
+
+def _tag_sha(repo_id: str, tag: str, caches: _PinCaches) -> str | None:
+    cache_key = (repo_id, tag)
+    exists = caches.exists.get(cache_key)
+    if exists is None:
+        exists = tag_exists(repo_id, tag)
+        caches.exists[cache_key] = exists
+    if not exists:
+        print(
+            f"Warning: Proposed tag {tag} for {repo_id} does not exist. Skipping update."
+        )
+        return None
+    sha = caches.sha.get(cache_key)
+    if sha is None:
+        sha = sha_for_tag(repo_id, tag)
+        caches.sha[cache_key] = sha
+    if not sha or not is_commit_sha(sha):
+        print(
+            f"Warning: Could not resolve commit SHA for {repo_id}@{tag}. Skipping."
+        )
+        return None
+    return sha
+
+
 def _resolve_proposed_pin(
     repo_id: str,
     current: str,
     version_hint: str | None,
-    latest_cache: dict[str, str],
-    exists_cache: dict[tuple[str, str], bool],
-    sha_cache: dict[tuple[str, str], str],
+    caches: _PinCaches,
 ) -> tuple[str, str] | None:
     """
     Return (pin_ref_with_comment, tag_name) for a SHA-only workflow update.
 
     Never returns a floating tag as the write target (Lesson 0z / supply-chain).
     """
-    latest = latest_cache.get(repo_id)
-    if latest is None:
-        latest = latest_tag_for_action(repo_id)
-        latest_cache[repo_id] = latest
+    latest = _latest_tag(repo_id, caches)
     if not latest:
         return None
-
     proposed_tag = target_ref(current, latest, version_hint=version_hint)
     if not proposed_tag:
         return None
-
-    cache_key = (repo_id, proposed_tag)
-    exists = exists_cache.get(cache_key)
-    if exists is None:
-        exists = tag_exists(repo_id, proposed_tag)
-        exists_cache[cache_key] = exists
-    if not exists:
-        print(
-            f"Warning: Proposed tag {proposed_tag} for {repo_id} does not exist. Skipping update."
-        )
+    sha = _tag_sha(repo_id, proposed_tag, caches)
+    if not sha:
         return None
-
-    sha = sha_cache.get(cache_key)
-    if sha is None:
-        sha = sha_for_tag(repo_id, proposed_tag)
-        sha_cache[cache_key] = sha
-    if not sha or not is_commit_sha(sha):
-        print(
-            f"Warning: Could not resolve commit SHA for {repo_id}@{proposed_tag}. Skipping."
-        )
-        return None
-
     if is_commit_sha(current) and current.lower() == sha.lower():
         return None
-
     return f"{sha} # {proposed_tag}", proposed_tag
 
 
@@ -287,9 +303,7 @@ def _is_major_bump(current: str, proposed: str) -> bool:
 def evaluate_action_update(
     match: re.Match[str],
     file_path: Path,
-    latest_cache: dict[str, str],
-    exists_cache: dict[tuple[str, str], bool],
-    sha_cache: dict[tuple[str, str], str],
+    caches: _PinCaches,
 ) -> dict[str, Any] | None:
     action_ref = match.group(2)
     current = match.group(3)
@@ -299,9 +313,7 @@ def evaluate_action_update(
     if not repo_id:
         return None
 
-    resolved = _resolve_proposed_pin(
-        repo_id, current, version_hint, latest_cache, exists_cache, sha_cache
-    )
+    resolved = _resolve_proposed_pin(repo_id, current, version_hint, caches)
     if not resolved:
         return None
     proposed_pin, proposed_tag = resolved
@@ -320,17 +332,13 @@ def evaluate_action_update(
 
 
 def workflow_file_plans() -> list[dict[str, Any]]:
-    latest_cache: dict[str, str] = {}
-    exists_cache: dict[tuple[str, str], bool] = {}
-    sha_cache: dict[tuple[str, str], str] = {}
+    caches = _PinCaches()
     plans = []
     for file_path in sorted((ROOT / ".github" / "workflows").glob("*.y*ml")):
         text = file_path.read_text()
         replacements = []
         for match in WORKFLOW_PATTERN.finditer(text):
-            update = evaluate_action_update(
-                match, file_path, latest_cache, exists_cache, sha_cache
-            )
+            update = evaluate_action_update(match, file_path, caches)
             if update:
                 replacements.append(update)
         if replacements:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1092,6 +1092,17 @@ upload), never downgrade SHA → tag. Close or rewrite the PR before re-triage.
 **Related:** Lesson 0y (nested unpinned actions inside composites). **Detection
 cost:** Low — bandit workflow fails before pytest on workflow-only diffs.
 
+## Lesson 0ei: Workflow updater `numeric_version` must ignore commit SHAs (2026-07-26)
+
+**Pattern:** Daily `workflow-updater` opened pc #1777 converting
+`actions/checkout@<40-char-sha> # v7.0.1` → `actions/checkout@v7.0.1` because
+`numeric_version()` ran `VERSION_PATTERN.search` on the SHA and matched leading
+hex digits as a “version” older than the latest tag. **Rule:** (1) `is_commit_sha`
+short-circuits version parsing; (2) updater writes only `sha # tag` pins; (3)
+compare SHA pins via the trailing `# vX.Y.Z` hint, never via the hex itself.
+**Related:** Lesson 0z. **Detection cost:** Low — any automation PR that replaces
+`@[0-9a-f]{40}` with `@v` is an instant escalate/close.
+
 ## Lesson 0cg: Jules Palette branches can duplicate with session-id suffix (2026-06-08)
 
 **Pattern:** ESP #1049 (`ux/fix-eof-crash`) and #1050

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -163,5 +163,38 @@ class TestRunShellCommand(unittest.TestCase):
         self.assertTrue(result["stdout"].endswith("... [truncated]"))
         self.assertTrue(result["stderr"].endswith("... [truncated]"))
 
+
+class TestActionRefPinning(unittest.TestCase):
+    """Lesson 0z / supply-chain: never treat commit SHAs as version numbers."""
+
+    CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+    def test_is_commit_sha(self):
+        self.assertTrue(rac.is_commit_sha(self.CHECKOUT_SHA))
+        self.assertFalse(rac.is_commit_sha("v7.0.1"))
+        self.assertFalse(rac.is_commit_sha("3d3c42e"))  # short SHA
+
+    def test_numeric_version_ignores_commit_sha(self):
+        # Regression: VERSION_PATTERN used to match hex digits inside SHAs
+        # (e.g. leading "3"), which made SHA pins look older than tag v7.
+        self.assertIsNone(rac.numeric_version(self.CHECKOUT_SHA))
+        self.assertEqual(rac.numeric_version("v7.0.1"), (7, 0, 1))
+
+    def test_target_ref_does_not_unpin_matching_sha(self):
+        self.assertIsNone(
+            rac.target_ref(self.CHECKOUT_SHA, "v7.0.1", version_hint="v7.0.1")
+        )
+
+    def test_target_ref_allows_sha_bump_when_hint_older(self):
+        self.assertEqual(
+            rac.target_ref(self.CHECKOUT_SHA, "v8.0.0", version_hint="v7.0.1"),
+            "v8.0.0",
+        )
+
+    def test_target_ref_tag_to_newer_tag_name(self):
+        # Caller must still resolve this tag name to a commit SHA before writing.
+        self.assertEqual(rac.target_ref("v4", "v5.0.0"), "v5.0.0")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Stop the Daily/Weekly workflow updater from replacing commit-SHA action pins with floating tags (root cause of closed PR #1777), and clear CodeScene complexity gates on the pin helpers.

## Why

`numeric_version()` treated hex digits inside 40-char SHAs as semver fragments, so already-pinned uses were “upgraded” to floating tags. The first fix introduced Complex Method / Complex Conditional in `target_ref` and `_resolve_proposed_pin`, failing CodeScene.

## How

- Detect commit SHAs and leave them pinned
- Resolve proposed updates via GitHub API to full SHA + version comment (`sha # vX.Y.Z`)
- Extract `_pin_version`, `_PinCaches`, `_latest_tag`, `_tag_sha` to keep helpers simple
- Unit tests for SHA detection and version parsing
- Lesson **0ei** in `tasks/lessons.md`

## Testing

- `python3 -m unittest tests.test_repository_automation_common -v` → 16 OK

## Security

Improves supply-chain posture: workflow plans must emit commit SHAs, never floating tags.

## Checklist

- [x] Unit tests for SHA pinning
- [x] CodeScene complexity reduced on pin helpers
- [x] No secrets included
- [x] Lesson documented (0ei)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4f3cdc3-f3ce-4a54-8379-7d2830a0a25e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4f3cdc3-f3ce-4a54-8379-7d2830a0a25e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

