### PR TITLE
security(ABHI-1548): harden PR automation against CWE-78 command injection

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -111,6 +111,33 @@ jobs:
           bandit -r . -x ./.git -x ./node_modules -x ./configs/.config/mole -x ./archive -x 'mole.*' --skip B101 -ll -q || true
           echo "✅ Python linting complete"
 
+  security-gate:
+    name: CWE-78 Security Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install security scanners
+        run: pip install ruff bandit
+
+      - name: Ruff shell/subprocess rules (S602, S605)
+        run: ruff check . --select S602,S605
+
+      - name: Bandit shell/subprocess rules (B602, B605)
+        run: bandit -r . -t B602,B605 -ll
+
+      - name: Verify AST regression test passes
+        run: python3 -m unittest tests.test_vulnerability_fix -v
+
   test:
     name: Run All Tests (shell + Python)
     runs-on: ubuntu-latest

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -652,3 +652,29 @@ treated strictly as patterns and not parsed as command-line options.
 **Vulnerability:** Option Injection (CWE-88 variant). Found remaining shell scripts using `pkill` that did not include the `--` delimiter before the process name argument when other flags were present.
 **Learning:** When invoking `pkill` with dynamic variables or even static strings that could be refactored to variables, you must explicitly separate options from arguments using the `--` delimiter to prevent them from being parsed as flags.
 **Prevention:** Always use the `--` argument delimiter before positional arguments when using `pkill`.
+
+## 2026-07-27 - CWE-78 Command Injection Remediation in PR Automation Scripts
+
+**Vulnerability:** The PR automation scripts (`parse_inventory.py`, `categorize_ready.py`, `detect_duplicates.py`, `run_merges.py`) previously invoked `gh` via `subprocess.run(..., shell=True)` with user-controlled `repo`/`pr` strings parsed from Markdown inventory files.
+
+**Changes made (baseline commit `106cd316b111f44536d1a25c82c8a48a2259d734`, changes in working tree):**
+- Added a shared, typed PR-reference validator in `pr_reference.py` that parses `owner/name#number` once, rejects whitespace/control characters, extra path segments, leading `-`, empty components, and non-positive/non-decimal PR numbers. Invalid rows in batch processing emit a filename/line-number diagnostic and are skipped; a strict mode is available for fail-fast callers.
+- Rewrote `detect_duplicates.py` to use a static GraphQL document with declared variables and pass `owner`, `name`, and PR number separately through `gh api graphql` `-f`/`-F` fields, eliminating string interpolation in the query.
+- Consolidated token loading across `parse_inventory.py`, `categorize_ready.py`, `detect_duplicates.py`, and `run_merges.py` by importing `gh_token_env.load_gh_token_env`. `gh_token_env.py` now resolves the legacy `GH_TOKEN.env` path relative to `Path(__file__).resolve().parent`, only injects `GH_TOKEN` into the child environment, and emits a `DeprecationWarning` when the legacy path is used.
+- All `gh` subprocess wrappers now use an argument list, omit `shell`, set `timeout=120`, capture output, and avoid printing `GH_TOKEN` or the full environment in error messages.
+
+**Audit scope and findings:**
+- Searched `*.py` for `subprocess\.`, `os\.system`, `os\.popen`, `commands\.`, `eval\s*\(`, and `exec\s*\(`. No `shell=True` or shell-based execution was found in production Python. The only `exec` is in `tests/test_vulnerability_fix.py` operating on a self-constructed AST (`# nosec B102`).
+- `scratch_inventory.py` and `scratch_triage.py` use list-based `subprocess.run` with hardcoded repo lists and do not consume the same Markdown inventory data; they were left unchanged per the ticket's scope guidance, with a follow-up recommended for timeout/env-loader consistency.
+- GitHub Actions workflows do not directly interpolate untrusted PR metadata into `run:` blocks for these scripts. `pr-visual-recap.yml` binds numeric/boolean/SHA PR fields and sanitized secrets via `env:` before use.
+
+**Verification commands and results:**
+- `make lint-errors` — passed (no SC2155/SC2145 violations).
+- `python3 -m unittest discover -s tests -p 'test_*.py'` — 451 tests passed.
+- `uvx ruff check --select S602,S605 .` — passed.
+- `uvx bandit -r . -t B602,B605 -ll` — no issues identified.
+- `trunk check <changed files>` — no new issues.
+
+**Accepted exclusions:**
+- `tests/test_vulnerability_fix.py` intentionally uses `exec(code, mod.__dict__)` to load isolated AST nodes for regression testing; the input AST is built from the repository's own source, not attacker-controlled.
+- `scratch_inventory.py` / `scratch_triage.py` are out of scope for this fix; they do not load `GH_TOKEN.env` and operate on hardcoded repo lists, but should be hardened with timeouts and the shared env loader in a follow-up.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -657,7 +657,7 @@ treated strictly as patterns and not parsed as command-line options.
 
 **Vulnerability:** The PR automation scripts (`parse_inventory.py`, `categorize_ready.py`, `detect_duplicates.py`, `run_merges.py`) previously invoked `gh` via `subprocess.run(..., shell=True)` with user-controlled `repo`/`pr` strings parsed from Markdown inventory files.
 
-**Changes made (baseline commit `106cd316b111f44536d1a25c82c8a48a2259d734`, changes in working tree):**
+**Changes made (audited commit `ff9ec673aa9ad7d5444c41e87ae49b7c05ddbfa5`, baseline `106cd316b111f44536d1a25c82c8a48a2259d734`):**
 - Added a shared, typed PR-reference validator in `pr_reference.py` that parses `owner/name#number` once, rejects whitespace/control characters, extra path segments, leading `-`, empty components, and non-positive/non-decimal PR numbers. Invalid rows in batch processing emit a filename/line-number diagnostic and are skipped; a strict mode is available for fail-fast callers.
 - Rewrote `detect_duplicates.py` to use a static GraphQL document with declared variables and pass `owner`, `name`, and PR number separately through `gh api graphql` `-f`/`-F` fields, eliminating string interpolation in the query.
 - Consolidated token loading across `parse_inventory.py`, `categorize_ready.py`, `detect_duplicates.py`, and `run_merges.py` by importing `gh_token_env.load_gh_token_env`. `gh_token_env.py` now resolves the legacy `GH_TOKEN.env` path relative to `Path(__file__).resolve().parent`, only injects `GH_TOKEN` into the child environment, and emits a `DeprecationWarning` when the legacy path is used.
@@ -670,7 +670,7 @@ treated strictly as patterns and not parsed as command-line options.
 
 **Verification commands and results:**
 - `make lint-errors` — passed (no SC2155/SC2145 violations).
-- `python3 -m unittest discover -s tests -p 'test_*.py'` — 451 tests passed.
+- `python3 -m unittest discover -s tests -p 'test_*.py'` — 452 tests passed.
 - `uvx ruff check --select S602,S605 .` — passed.
 - `uvx bandit -r . -t B602,B605 -ll` — no issues identified.
 - `trunk check <changed files>` — no new issues.

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,5 +1,5 @@
 # Generic, formatter-friendly config.
-select = ["B", "D3", "D4", "E", "F", "S310"]
+select = ["B", "D3", "D4", "E", "F", "S310", "S602", "S605"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.
 ignore = ["E501"]

--- a/categorize_ready.py
+++ b/categorize_ready.py
@@ -1,52 +1,35 @@
-from concurrent.futures import ThreadPoolExecutor
 import json
-import os
 import subprocess
-from functools import lru_cache
+import sys
+from concurrent.futures import ThreadPoolExecutor
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_token_env
+from pr_reference import PRReference
 
 
 def run_gh(cmd_list):
-    env = _load_gh_token_env()
-    result = subprocess.run(cmd_list, capture_output=True, text=True, env=env)
+    """Call ``gh`` and return parsed JSON, or None on failure/timeout."""
+    env = load_gh_token_env()
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"gh command timed out: {cmd_list[0] if cmd_list else cmd_list}",
+            file=sys.stderr,
+        )
+        return None
     if result.returncode != 0:
         return None
     try:
         return json.loads(result.stdout)
-    except:
+    except json.JSONDecodeError:
         return None
 
 
@@ -88,14 +71,10 @@ _CATEGORIES = (
 
 def get_category_from_title(title: str) -> str:
     title = title.lower()
-
-    # ⚡ Bolt Optimization: Iterate over a predefined tuple of categories to avoid
-    # dictionary allocation overhead on every function call
     for cat_name, keywords in _CATEGORIES:
         for kw in keywords:
             if kw in title:
                 return cat_name
-
     return "PERFORMANCE/REFACTOR/UI/FEATURE"
 
 
@@ -108,16 +87,15 @@ categorized = {
 
 
 def fetch_pr_info(pr):
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    repo, _, pr_id = pr.partition("#")
+    ref = PRReference.from_string(pr)
     info = run_gh(
         [
             "gh",
             "pr",
             "view",
-            str(pr_id),
+            str(ref.number),
             "-R",
-            str(repo),
+            ref.repo,
             "--json",
             "title,mergeStateStatus",
         ]
@@ -125,16 +103,13 @@ def fetch_pr_info(pr):
     return pr, info
 
 
-    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
 with ThreadPoolExecutor(max_workers=min(len(ready_prs) or 1, 32)) as executor:
-    # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls while preserving order using map()
     results = executor.map(fetch_pr_info, ready_prs)
 
 for pr, info in results:
     if not info:
         continue
 
-    # Exclude unstable/dirty
     if info.get("mergeStateStatus") in ["DIRTY", "CONFLICTING"]:
         print(f"Skipping {pr} because it is {info.get('mergeStateStatus')}")
         continue
@@ -142,7 +117,7 @@ for pr, info in results:
     title = info.get("title", "")
     cat = get_category_from_title(title)
 
-    categorized[cat].append((pr, info.get("title")))
+    categorized[cat].append((pr, title))
 
 for cat, items in categorized.items():
     print(f"\n{cat}:")

--- a/detect_duplicates.py
+++ b/detect_duplicates.py
@@ -1,50 +1,32 @@
 import json
-import os
 import subprocess
+import sys
 from collections import defaultdict
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line or line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-@lru_cache(maxsize=None)
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_token_env
+from pr_reference import PRReference
 
 
 def run_gh(cmd_list):
-    env = _load_gh_token_env()
-    result = subprocess.run(cmd_list, capture_output=True, text=True, env=env)
+    """Call ``gh`` and return parsed JSON, or None on failure/timeout."""
+    env = load_gh_token_env()
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"gh command timed out: {cmd_list[0]}", file=sys.stderr)
+        return None
     if result.returncode != 0:
         return None
     try:
         return json.loads(result.stdout)
-    except Exception:
+    except json.JSONDecodeError:
         return None
 
 
@@ -52,22 +34,20 @@ def _process_pr_result(res, file_groups):
     if not res:
         return
     repo, info = res
-    # ⚡ Bolt Optimization: Removed intermediate dictionary wrappers to allow direct sorting of strings
     files = tuple(sorted(info.get("files", ())))
     file_groups[(repo, files)].append(info)
 
 
-def _build_graphql_query(chunk):
+def _build_graphql_query(refs):
+    """Build a static GraphQL query with declared variables for the given PRs."""
+    var_decls = []
     query_parts = []
-    for j, pr in enumerate(chunk):
-        repo, _, pr_id = pr.partition("#")
-        # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-        owner, _, name = repo.partition("/")
-        if not name:
-            continue
+    fields = []
+    for j, ref in enumerate(refs):
+        var_decls.append(f"$owner{j}: String!, $name{j}: String!, $pr{j}: Int!")
         query_parts.append(f"""
-        pr{j}: repository(owner: "{owner}", name: "{name}") {{
-            pullRequest(number: {pr_id}) {{
+        pr{j}: repository(owner: $owner{j}, name: $name{j}) {{
+            pullRequest(number: $pr{j}) {{
                 number
                 title
                 files(first: 100) {{
@@ -78,9 +58,20 @@ def _build_graphql_query(chunk):
             }}
         }}
         """)
+        fields.extend(
+            [
+                "-f",
+                f"owner{j}={ref.owner}",
+                "-f",
+                f"name{j}={ref.name}",
+                "-F",
+                f"pr{j}={ref.number}",
+            ]
+        )
     if not query_parts:
-        return None
-    return "query { " + " ".join(query_parts) + " }"
+        return None, None
+    query = "query (" + ", ".join(var_decls) + ") { " + " ".join(query_parts) + " }"
+    return query, fields
 
 
 def _extract_pr_data(repo, pr_result):
@@ -94,27 +85,28 @@ def _extract_pr_data(repo, pr_result):
     nodes = files_data.get("nodes") if files_data else None
     files = [node["path"] for node in nodes if "path" in node] if nodes else []
 
-    return (repo, {
-        "number": pr_data.get("number"),
-        "title": pr_data.get("title"),
-        "files": files
-    })
+    return (
+        repo,
+        {
+            "number": pr_data.get("number"),
+            "title": pr_data.get("title"),
+            "files": files,
+        },
+    )
 
-def _process_graphql_response(result, chunk, file_groups):
+
+def _process_graphql_response(result, refs, file_groups):
     if not result:
         return
-    # ⚡ Bolt Optimization: Avoid eager empty dictionary allocation
     data = result.get("data")
     if not data:
         return
-    for j, pr in enumerate(chunk):
-        repo, _, _ = pr.partition("#")
-        # ⚡ Bolt Optimization: Avoid eager empty dictionary allocation
+    for j, ref in enumerate(refs):
         pr_result = data.get(f"pr{j}")
         if not pr_result:
             continue
 
-        res = _extract_pr_data(repo, pr_result)
+        res = _extract_pr_data(ref.repo, pr_result)
         if res:
             _process_pr_result(res, file_groups)
 
@@ -122,13 +114,29 @@ def _process_graphql_response(result, chunk, file_groups):
 def _group_prs_by_files(ready_only):
     file_groups = defaultdict(list)
     chunk_size = 50
+    source = "tasks/pr-triage.md"
     for i in range(0, len(ready_only), chunk_size):
         chunk = ready_only[i : i + chunk_size]
-        query = _build_graphql_query(chunk)
+        refs = []
+        for offset, pr in enumerate(chunk):
+            line_number = i + offset + 1
+            try:
+                ref = PRReference.from_string(pr)
+            except ValueError as exc:
+                print(
+                    f"skipping invalid PR reference at {source}:{line_number}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            refs.append(ref)
+        if not refs:
+            continue
+        query, fields = _build_graphql_query(refs)
         if not query:
             continue
-        result = run_gh(["gh", "api", "graphql", "-f", f"query={query}"])
-        _process_graphql_response(result, chunk, file_groups)
+        cmd = ["gh", "api", "graphql", "-f", f"query={query}", *fields]
+        result = run_gh(cmd)
+        _process_graphql_response(result, refs, file_groups)
     return file_groups
 
 
@@ -200,8 +208,6 @@ def rewrite_triage_file(lines, ready_prs, duplicates, ready_only):
         f.write("\n".join(sections) + "\n")
 
 
-
-
 def _extract_ready_prs(content):
     ready_prs = []
     idx = 0
@@ -209,16 +215,16 @@ def _extract_ready_prs(content):
         idx = content.find("- abhimehro/", idx)
         if idx == -1:
             break
-        # using chr(10) to avoid multiline string interpolation issues in my script
-        if idx > 0 and content[idx-1] != chr(10):
+        if idx > 0 and content[idx - 1] != chr(10):
             idx += 1
             continue
         end_idx = content.find(chr(10), idx)
         if end_idx == -1:
             end_idx = len(content)
-        ready_prs.append(content[idx+2:end_idx].strip())
+        ready_prs.append(content[idx + 2 : end_idx].strip())
         idx = end_idx
     return ready_prs
+
 
 def _get_pre_ready_text(content):
     ready_idx = content.find(chr(10) + "## READY" + chr(10))
@@ -229,6 +235,7 @@ def _get_pre_ready_text(content):
     else:
         ready_idx = len(content)
     return content[:ready_idx]
+
 
 def main():
     try:
@@ -245,8 +252,6 @@ def main():
     duplicates = get_duplicates(ready_only)
     print("Duplicates:", duplicates)
 
-    # ⚡ Bolt Optimization: Use splitlines with keepends to emulate readlines() only when absolutely needed
-    # for rewrite_triage_file compatibility
     lines = content.splitlines(keepends=True)
     rewrite_triage_file(lines, ready_prs, duplicates, ready_only)
     print("Done")

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -91,31 +91,50 @@ def _read_env_file(path: Path) -> dict[str, str]:
     return parsed
 
 
+def _override_env_path() -> Path | None:
+    """Return the env file from ``GH_TOKEN_ENV_FILE`` if configured and valid."""
+    override = os.environ.get("GH_TOKEN_ENV_FILE", "").strip()
+    if not override:
+        return None
+    candidate = Path(override).expanduser()
+    if candidate.is_file():
+        return candidate
+    raise FileNotFoundError(
+        f"GH_TOKEN_ENV_FILE does not exist or is not a file: {candidate}"
+    )
+
+
+def _xdg_env_path() -> Path | None:
+    """Return the XDG config path if it exists."""
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if not xdg:
+        return None
+    candidate = Path(xdg).expanduser() / "personal-config" / "GH_TOKEN.env"
+    return candidate if candidate.is_file() else None
+
+
+def _home_env_path() -> Path | None:
+    """Return the home config path if it exists."""
+    candidate = Path.home() / ".config" / "personal-config" / "GH_TOKEN.env"
+    return candidate if candidate.is_file() else None
+
+
+def _legacy_env_path() -> Path | None:
+    """Return the script-relative legacy path if it exists."""
+    return _LEGACY_RELATIVE_ENV if _LEGACY_RELATIVE_ENV.is_file() else None
+
+
 def resolve_gh_token_env_file() -> Path | None:
     """Return the first existing GH_TOKEN env file path, or None."""
-    override = os.environ.get("GH_TOKEN_ENV_FILE", "").strip()
-    if override:
-        candidate = Path(override).expanduser()
-        if candidate.is_file():
-            return candidate
-        raise FileNotFoundError(
-            f"GH_TOKEN_ENV_FILE does not exist or is not a file: {candidate}"
-        )
-
-    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    if xdg:
-        xdg_path = Path(xdg).expanduser() / "personal-config" / "GH_TOKEN.env"
-        if xdg_path.is_file():
-            return xdg_path
-
-    home_config = Path.home() / ".config" / "personal-config" / "GH_TOKEN.env"
-    if home_config.is_file():
-        return home_config
-
-    legacy = _LEGACY_RELATIVE_ENV
-    if legacy.is_file():
-        return legacy
-
+    for candidate_fn in (
+        _override_env_path,
+        _xdg_env_path,
+        _home_env_path,
+        _legacy_env_path,
+    ):
+        path = candidate_fn()
+        if path is not None:
+            return path
     return None
 
 
@@ -124,6 +143,13 @@ def _get_parsed_env_vars_from_file() -> dict[str, str]:
     path = resolve_gh_token_env_file()
     if path is None:
         return {}
+    if path == _LEGACY_RELATIVE_ENV:
+        warnings.warn(
+            f"legacy GH_TOKEN.env path is deprecated: {_LEGACY_RELATIVE_ENV}; "
+            "set GH_TOKEN or GH_TOKEN_ENV_FILE instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     return _read_env_file(path)
 
 
@@ -134,20 +160,11 @@ def load_gh_token_env(base: Mapping[str, str] | None = None) -> dict[str, str]:
     1. ``GH_TOKEN`` already present in ``base``/``os.environ``.
     2. ``GH_TOKEN`` read from ``GH_TOKEN_ENV_FILE`` or a well-known path.
     """
-    env = dict(base if base is not None else os.environ)
+    if base is None:
+        base = os.environ
+    env = dict(base)
     if env.get("GH_TOKEN"):
         return env
-
-    used_path = resolve_gh_token_env_file()
-    if used_path is None:
-        return env
-    if used_path == _LEGACY_RELATIVE_ENV:
-        warnings.warn(
-            f"legacy GH_TOKEN.env path is deprecated: {_LEGACY_RELATIVE_ENV}; "
-            "set GH_TOKEN or GH_TOKEN_ENV_FILE instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     file_vars = _get_parsed_env_vars_from_file()
     # Only the token value is required for ``gh``; do not inject unrelated keys.

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -12,12 +12,18 @@ Precedence for ``GH_TOKEN``:
 import os
 import re
 import stat
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import Mapping
 
 # Legacy path referenced in ABHI-954 / TruffleHog finding (gitignored, out of repo).
-_LEGACY_RELATIVE_ENV = Path("../email-security-pipeline/GH_TOKEN.env")
+# Resolved relative to this source file so it is stable regardless of the process
+# working directory.
+_BASE_DIR = Path(__file__).resolve().parent
+_LEGACY_RELATIVE_ENV = (
+    _BASE_DIR.parent / "email-security-pipeline" / "GH_TOKEN.env"
+).resolve()
 
 # SECURITY: reject command substitution in parsed values.
 _COMMAND_SUBSTITUTION = re.compile(r"\$\(|`")
@@ -92,6 +98,9 @@ def resolve_gh_token_env_file() -> Path | None:
         candidate = Path(override).expanduser()
         if candidate.is_file():
             return candidate
+        raise FileNotFoundError(
+            f"GH_TOKEN_ENV_FILE does not exist or is not a file: {candidate}"
+        )
 
     xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
     if xdg:
@@ -119,11 +128,31 @@ def _get_parsed_env_vars_from_file() -> dict[str, str]:
 
 
 def load_gh_token_env(base: Mapping[str, str] | None = None) -> dict[str, str]:
-    """Build an environment dict for ``gh`` subprocess calls."""
+    """Build an environment dict for ``gh`` subprocess calls.
+
+    Precedence:
+    1. ``GH_TOKEN`` already present in ``base``/``os.environ``.
+    2. ``GH_TOKEN`` read from ``GH_TOKEN_ENV_FILE`` or a well-known path.
+    """
     env = dict(base if base is not None else os.environ)
     if env.get("GH_TOKEN"):
         return env
-    env.update(_get_parsed_env_vars_from_file())
+
+    used_path = resolve_gh_token_env_file()
+    if used_path is None:
+        return env
+    if used_path == _LEGACY_RELATIVE_ENV:
+        warnings.warn(
+            f"legacy GH_TOKEN.env path is deprecated: {_LEGACY_RELATIVE_ENV}; "
+            "set GH_TOKEN or GH_TOKEN_ENV_FILE instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    file_vars = _get_parsed_env_vars_from_file()
+    # Only the token value is required for ``gh``; do not inject unrelated keys.
+    if "GH_TOKEN" in file_vars:
+        env["GH_TOKEN"] = file_vars["GH_TOKEN"]
     return env
 
 

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -56,11 +56,11 @@ def _parse_repo_name(line):
         match = _REPO_LINK_PATTERN.search(line)
         if match:
             return parse_repo_name(
-                match.group(1).strip(), source="tasks/pr-inventory.md"
+                match.group(1).strip(), loc=("tasks/pr-inventory.md", None)
             )
         return None
     if line.startswith("## "):
-        return parse_repo_name(line[3:].strip(), source="tasks/pr-inventory.md")
+        return parse_repo_name(line[3:].strip(), loc=("tasks/pr-inventory.md", None))
     return None
 
 
@@ -91,7 +91,7 @@ def _parse_row_record(line, current_repo, line_number):
     repo_col, pr_id, author, checks, hints = _extract_pr_row_fields(parts)
     if repo_col:
         effective_repo = parse_repo_name(
-            repo_col, source="tasks/pr-inventory.md", line=line_number
+            repo_col, loc=("tasks/pr-inventory.md", line_number)
         )
     else:
         effective_repo = current_repo
@@ -100,7 +100,7 @@ def _parse_row_record(line, current_repo, line_number):
     if not _is_valid_pr_row(author, hints):
         return None
     ref = parse_pr_reference(
-        effective_repo, pr_id, source="tasks/pr-inventory.md", line=line_number
+        effective_repo, pr_id, loc=("tasks/pr-inventory.md", line_number)
     )
     if ref is None:
         return None

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -1,48 +1,17 @@
 import json
 import re
-import os
 import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from functools import lru_cache
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_token_env
+from pr_reference import parse_pr_reference, parse_repo_name
 
 
 def run_gh(repo, pr):
-    env = _load_gh_token_env()
+    """Call ``gh pr view`` and return JSON, or None on failure/timeout."""
+    env = load_gh_token_env()
     cmd = [
         "gh",
         "pr",
@@ -53,8 +22,18 @@ def run_gh(repo, pr):
         "--json",
         "files,updatedAt,mergeStateStatus",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
-
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"gh pr view timed out for {repo}#{pr}", file=sys.stderr)
+        return None
     if result.returncode != 0:
         return None
     try:
@@ -64,41 +43,40 @@ def run_gh(repo, pr):
 
 
 def _should_skip_table_row(line):
-    # ⚡ Bolt Optimization: Use fast index checking to avoid function overhead for lines not starting with |,
-    # and use a tuple with .startswith() to collapse sequential checks and avoid redundant allocations
     if not line or line[0] != "|":
         return True
     return line.startswith(("| # |", "| ---"))
 
 
-_REPO_LINK_PATTERN = re.compile(r'\[(.*?)\]\(.*?\)')
+_REPO_LINK_PATTERN = re.compile(r"\[(.*?)\]\(.*?\)")
+
 
 def _parse_repo_name(line):
     if line.startswith("### "):
         match = _REPO_LINK_PATTERN.search(line)
         if match:
-            return match.group(1).strip()
+            return parse_repo_name(
+                match.group(1).strip(), source="tasks/pr-inventory.md"
+            )
         return None
-    return line[3:].strip() if line.startswith("## ") else None
+    if line.startswith("## "):
+        return parse_repo_name(line[3:].strip(), source="tasks/pr-inventory.md")
+    return None
 
 
-def _is_valid_pr_row(pr_id, author, hints):
-    if not pr_id.isdigit():
-        return False
+def _is_valid_pr_row(author, hints):
     return author.endswith("[bot]") or hints
 
 
 def _extract_pr_row_fields(parts):
     repo_col = parts[1].strip()
-    if repo_col:
-        return (
-            repo_col,
-            parts[2].strip(),
-            parts[3].strip(),
-            parts[6].strip(),
-            parts[9].strip(),
-        )
-    return "", parts[2].strip(), parts[3].strip(), parts[6].strip(), parts[9].strip()
+    return (
+        repo_col,
+        parts[2].strip(),
+        parts[3].strip(),
+        parts[6].strip(),
+        parts[9].strip(),
+    )
 
 
 def _ensure_repo_bucket(repo_name, repos):
@@ -106,20 +84,30 @@ def _ensure_repo_bucket(repo_name, repos):
         repos[repo_name] = []
 
 
-def _parse_row_record(line, current_repo):
+def _parse_row_record(line, current_repo, line_number):
     parts = line.split("|")
     if len(parts) <= 9:
         return None
     repo_col, pr_id, author, checks, hints = _extract_pr_row_fields(parts)
-    effective_repo = repo_col or current_repo
+    if repo_col:
+        effective_repo = parse_repo_name(
+            repo_col, source="tasks/pr-inventory.md", line=line_number
+        )
+    else:
+        effective_repo = current_repo
     if effective_repo is None:
         return None
-    if not _is_valid_pr_row(pr_id, author, hints):
+    if not _is_valid_pr_row(author, hints):
         return None
-    return effective_repo, {"pr": pr_id, "checks": checks}
+    ref = parse_pr_reference(
+        effective_repo, pr_id, source="tasks/pr-inventory.md", line=line_number
+    )
+    if ref is None:
+        return None
+    return ref.repo, {"pr": str(ref.number), "checks": checks}
 
 
-def _process_inventory_line(line, current_repo, repos):
+def _process_inventory_line(line, current_repo, repos, line_number):
     repo_name = _parse_repo_name(line)
     if repo_name:
         _ensure_repo_bucket(repo_name, repos)
@@ -128,7 +116,7 @@ def _process_inventory_line(line, current_repo, repos):
     if _should_skip_table_row(line):
         return current_repo
 
-    row_record = _parse_row_record(line, current_repo)
+    row_record = _parse_row_record(line, current_repo, line_number)
     if row_record:
         effective_repo, payload = row_record
         _ensure_repo_bucket(effective_repo, repos)
@@ -137,11 +125,11 @@ def _process_inventory_line(line, current_repo, repos):
     return current_repo
 
 
-def parse_inventory_lines(lines):
+def parse_inventory_lines(lines, *, source="tasks/pr-inventory.md"):
     repos = {}
     current_repo = None
-    for line in lines:
-        current_repo = _process_inventory_line(line, current_repo, repos)
+    for line_number, line in enumerate(lines, start=1):
+        current_repo = _process_inventory_line(line, current_repo, repos, line_number)
     return repos
 
 
@@ -169,7 +157,7 @@ def _get_pr_category(info, checks, now=None):
         return "SUPERSEDED"
 
     merge_status = info.get("mergeStateStatus", "")
-    # ⚡ Bolt Optimization: Delay expensive datetime parsing by short-circuiting behind checks_failing
+    # Delay expensive datetime parsing by short-circuiting behind checks_failing
     checks_failing = _is_checks_failing(checks)
 
     if checks_failing and _is_pr_stale(info.get("updatedAt", ""), now):
@@ -204,7 +192,6 @@ def _categorize_pr_task(args):
 def _load_inventory_lines(filepath):
     try:
         with open(filepath, "r") as f:
-            # ⚡ Bolt Optimization: Use generator to yield lines lazily, avoiding full-file memory allocation overhead
             yield from f
     except FileNotFoundError:
         return
@@ -226,12 +213,9 @@ def main():
         return
     triage = {"SUPERSEDED": [], "STALE": [], "CONFLICTING": [], "READY": []}
 
-    # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up categorization
-    # Also pass a pre-computed UTC 'now' object to avoid allocating the time on every task.
     now = datetime.now(timezone.utc)
     tasks = [(repo, pr_info, now) for repo, prs in repos.items() for pr_info in prs]
 
-    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
     with ThreadPoolExecutor(max_workers=min(len(tasks) or 1, 32)) as executor:
         for result in executor.map(_categorize_pr_task, tasks):
             if result:

--- a/pr_reference.py
+++ b/pr_reference.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import re
 import sys
 from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
 
 
 class InvalidPrReferenceError(ValueError):
@@ -20,24 +23,28 @@ _CONTROL_OR_SPACE_RE = re.compile(r"[\s\0-\x1f\x7f]")
 _PR_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
 
 
-def _check_component(component: str, kind: str) -> None:
-    if not component:
+def _format_location(source: str | None, line: int | None) -> str:
+    return f"{source or '<unknown>'}:{line or '?' }"
+
+
+def _validate_component(value: str, kind: str, regex: re.Pattern | None = None) -> None:
+    """Validate a single value and raise a descriptive error if it is unsafe."""
+    if not value:
         raise InvalidPrReferenceError(f"{kind} is empty")
-    if component[0] == "-":
+    if value[0] == "-":
         raise InvalidPrReferenceError(
-            f"{kind} starts with an option-like '-': {component!r}"
+            f"{kind} starts with an option-like '-': {value!r}"
         )
-    if _CONTROL_OR_SPACE_RE.search(component):
+    if _CONTROL_OR_SPACE_RE.search(value):
         raise InvalidPrReferenceError(
-            f"{kind} contains whitespace/control characters: {component!r}"
+            f"{kind} contains whitespace/control characters: {value!r}"
         )
-    if not _OWNER_NAME_RE.match(component):
-        raise InvalidPrReferenceError(
-            f"{kind} contains invalid characters: {component!r}"
-        )
+    if regex is not None and not regex.match(value):
+        raise InvalidPrReferenceError(f"{kind} contains invalid characters: {value!r}")
 
 
 def _split_repo(repo: str) -> tuple[str, str]:
+    """Split and validate an ``owner/name`` string."""
     repo = repo.strip()
     if not repo:
         raise InvalidPrReferenceError("repo reference is empty")
@@ -45,34 +52,40 @@ def _split_repo(repo: str) -> tuple[str, str]:
         raise InvalidPrReferenceError(
             f"repo reference contains whitespace/control characters: {repo!r}"
         )
-    slash_count = repo.count("/")
-    if slash_count != 1:
+    if repo.count("/") != 1:
         raise InvalidPrReferenceError(
-            f"repo must be exactly owner/name (got {slash_count} '/'): {repo!r}"
+            f"repo must be exactly owner/name (got {repo.count('/')} '/'): {repo!r}"
         )
     owner, name = repo.split("/", 1)
-    _check_component(owner, "owner")
-    _check_component(name, "repo name")
+    _validate_component(owner, "owner", _OWNER_NAME_RE)
+    _validate_component(name, "repo name", _OWNER_NAME_RE)
     return owner, name
 
 
 def _parse_pr_number(pr: str) -> int:
+    """Validate and parse a positive decimal PR number."""
     pr = pr.strip()
-    if not pr:
-        raise InvalidPrReferenceError("PR number is empty")
-    if _CONTROL_OR_SPACE_RE.search(pr):
-        raise InvalidPrReferenceError(
-            f"PR number contains whitespace/control characters: {pr!r}"
-        )
-    if pr[0] == "-":
-        raise InvalidPrReferenceError(
-            f"PR number starts with an option-like '-': {pr!r}"
-        )
-    if not _PR_NUMBER_RE.match(pr):
-        raise InvalidPrReferenceError(
-            f"PR number must be a positive decimal integer: {pr!r}"
-        )
+    _validate_component(pr, "PR number", _PR_NUMBER_RE)
     return int(pr)
+
+
+def _run_parser(
+    parser: Callable[..., T],
+    *args: object,
+    source: str | None,
+    line: int | None,
+    strict: bool,
+    label: str,
+) -> T | None:
+    """Run a parser, printing a diagnostic or raising on invalid input."""
+    try:
+        return parser(*args)
+    except InvalidPrReferenceError as exc:
+        location = _format_location(source, line)
+        if strict:
+            raise InvalidPrReferenceError(f"{location}: {exc}") from exc
+        print(f"skipping invalid {label} at {location}: {exc}", file=sys.stderr)
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,43 +121,37 @@ class PRReference:
         return cls.from_parts(repo, pr)
 
 
-def _format_location(source: str | None, line: int | None) -> str:
-    return f"{source or '<unknown>'}:{line or '?'}"
-
-
 def parse_repo_name(
     repo: str,
     *,
-    source: str | None = None,
-    line: int | None = None,
+    loc: tuple[str, int] | None = None,
     strict: bool = False,
 ) -> str | None:
     """Validate a repo name and return ``owner/name``, or skip with a diagnostic."""
-    try:
-        owner, name = _split_repo(repo)
-        return f"{owner}/{name}"
-    except InvalidPrReferenceError as exc:
-        location = _format_location(source, line)
-        if strict:
-            raise InvalidPrReferenceError(f"{location}: {exc}") from exc
-        print(f"skipping invalid repo name at {location}: {exc}", file=sys.stderr)
-        return None
+    source, line = loc if loc else (None, None)
+    result = _run_parser(
+        _split_repo, repo, source=source, line=line, strict=strict, label="repo name"
+    )
+    return f"{result[0]}/{result[1]}" if result else None
 
 
 def parse_pr_reference(
     repo: str,
     pr: str,
     *,
-    source: str | None = None,
-    line: int | None = None,
+    loc: tuple[str, int] | None = None,
     strict: bool = False,
 ) -> PRReference | None:
     """Validate a ``repo`` + ``pr`` pair and return a typed value, or skip with a diagnostic."""
-    try:
-        return PRReference.from_parts(repo, pr)
-    except InvalidPrReferenceError as exc:
-        location = _format_location(source, line)
-        if strict:
-            raise InvalidPrReferenceError(f"{location}: {exc}") from exc
-        print(f"skipping invalid PR reference at {location}: {exc}", file=sys.stderr)
+    source, line = loc if loc else (None, None)
+    owner_name = _run_parser(
+        _split_repo, repo, source=source, line=line, strict=strict, label="repo name"
+    )
+    if owner_name is None:
         return None
+    number = _run_parser(
+        _parse_pr_number, pr, source=source, line=line, strict=strict, label="PR number"
+    )
+    if number is None:
+        return None
+    return PRReference(owner_name[0], owner_name[1], number)

--- a/pr_reference.py
+++ b/pr_reference.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import re
 import sys
 from dataclasses import dataclass
-from typing import Callable, TypeVar
-
-T = TypeVar("T")
+from typing import Any, Callable
 
 
 class InvalidPrReferenceError(ValueError):
@@ -22,24 +20,25 @@ _CONTROL_OR_SPACE_RE = re.compile(r"[\s\0-\x1f\x7f]")
 # Positive decimal integer (no sign, no leading zeros, no whitespace).
 _PR_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
 
+_PARSER_LABELS = {
+    "_split_repo": "repo name",
+    "_parse_pr_number": "PR number",
+}
+
 
 def _format_location(source: str | None, line: int | None) -> str:
-    return f"{source or '<unknown>'}:{line or '?' }"
+    return f"{source or '<unknown>'}:{line or '?'}"
 
 
-def _validate_component(value: str, kind: str, regex: re.Pattern | None = None) -> None:
+def _validate_component(value: str, kind: str, regex: re.Pattern) -> None:
     """Validate a single value and raise a descriptive error if it is unsafe."""
     if not value:
         raise InvalidPrReferenceError(f"{kind} is empty")
-    if value[0] == "-":
-        raise InvalidPrReferenceError(
-            f"{kind} starts with an option-like '-': {value!r}"
-        )
     if _CONTROL_OR_SPACE_RE.search(value):
         raise InvalidPrReferenceError(
             f"{kind} contains whitespace/control characters: {value!r}"
         )
-    if regex is not None and not regex.match(value):
+    if not regex.match(value):
         raise InvalidPrReferenceError(f"{kind} contains invalid characters: {value!r}")
 
 
@@ -70,18 +69,19 @@ def _parse_pr_number(pr: str) -> int:
 
 
 def _run_parser(
-    parser: Callable[..., T],
-    *args: object,
-    source: str | None,
-    line: int | None,
-    strict: bool,
-    label: str,
-) -> T | None:
-    """Run a parser, printing a diagnostic or raising on invalid input."""
+    parser: Callable[[str], Any],
+    value: str,
+    *,
+    loc: tuple[str, int] | None = None,
+    strict: bool = False,
+) -> Any | None:
+    """Run a single-argument parser, printing a diagnostic or raising on invalid input."""
     try:
-        return parser(*args)
+        return parser(value)
     except InvalidPrReferenceError as exc:
+        source, line = loc if loc else (None, None)
         location = _format_location(source, line)
+        label = _PARSER_LABELS.get(parser.__name__, parser.__name__)
         if strict:
             raise InvalidPrReferenceError(f"{location}: {exc}") from exc
         print(f"skipping invalid {label} at {location}: {exc}", file=sys.stderr)
@@ -128,10 +128,7 @@ def parse_repo_name(
     strict: bool = False,
 ) -> str | None:
     """Validate a repo name and return ``owner/name``, or skip with a diagnostic."""
-    source, line = loc if loc else (None, None)
-    result = _run_parser(
-        _split_repo, repo, source=source, line=line, strict=strict, label="repo name"
-    )
+    result = _run_parser(_split_repo, repo, loc=loc, strict=strict)
     return f"{result[0]}/{result[1]}" if result else None
 
 
@@ -141,17 +138,12 @@ def parse_pr_reference(
     *,
     loc: tuple[str, int] | None = None,
     strict: bool = False,
-) -> PRReference | None:
+) -> "PRReference | None":
     """Validate a ``repo`` + ``pr`` pair and return a typed value, or skip with a diagnostic."""
-    source, line = loc if loc else (None, None)
-    owner_name = _run_parser(
-        _split_repo, repo, source=source, line=line, strict=strict, label="repo name"
-    )
+    owner_name = _run_parser(_split_repo, repo, loc=loc, strict=strict)
     if owner_name is None:
         return None
-    number = _run_parser(
-        _parse_pr_number, pr, source=source, line=line, strict=strict, label="PR number"
-    )
+    number = _run_parser(_parse_pr_number, pr, loc=loc, strict=strict)
     if number is None:
         return None
     return PRReference(owner_name[0], owner_name[1], number)

--- a/pr_reference.py
+++ b/pr_reference.py
@@ -1,0 +1,150 @@
+"""Shared, strict PR reference parser/validator for PR automation scripts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+
+
+class InvalidPrReferenceError(ValueError):
+    """Raised when a PR reference cannot be parsed or contains unsafe input."""
+
+
+# GitHub owner/repo names are alphanumeric, hyphen, underscore, and dot.
+# Require first/last character to be alphanumeric to avoid option-like names.
+_OWNER_NAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$")
+# Reject whitespace and ASCII control characters anywhere in the raw string.
+_CONTROL_OR_SPACE_RE = re.compile(r"[\s\0-\x1f\x7f]")
+# Positive decimal integer (no sign, no leading zeros, no whitespace).
+_PR_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+def _check_component(component: str, kind: str) -> None:
+    if not component:
+        raise InvalidPrReferenceError(f"{kind} is empty")
+    if component[0] == "-":
+        raise InvalidPrReferenceError(
+            f"{kind} starts with an option-like '-': {component!r}"
+        )
+    if _CONTROL_OR_SPACE_RE.search(component):
+        raise InvalidPrReferenceError(
+            f"{kind} contains whitespace/control characters: {component!r}"
+        )
+    if not _OWNER_NAME_RE.match(component):
+        raise InvalidPrReferenceError(
+            f"{kind} contains invalid characters: {component!r}"
+        )
+
+
+def _split_repo(repo: str) -> tuple[str, str]:
+    repo = repo.strip()
+    if not repo:
+        raise InvalidPrReferenceError("repo reference is empty")
+    if _CONTROL_OR_SPACE_RE.search(repo):
+        raise InvalidPrReferenceError(
+            f"repo reference contains whitespace/control characters: {repo!r}"
+        )
+    slash_count = repo.count("/")
+    if slash_count != 1:
+        raise InvalidPrReferenceError(
+            f"repo must be exactly owner/name (got {slash_count} '/'): {repo!r}"
+        )
+    owner, name = repo.split("/", 1)
+    _check_component(owner, "owner")
+    _check_component(name, "repo name")
+    return owner, name
+
+
+def _parse_pr_number(pr: str) -> int:
+    pr = pr.strip()
+    if not pr:
+        raise InvalidPrReferenceError("PR number is empty")
+    if _CONTROL_OR_SPACE_RE.search(pr):
+        raise InvalidPrReferenceError(
+            f"PR number contains whitespace/control characters: {pr!r}"
+        )
+    if pr[0] == "-":
+        raise InvalidPrReferenceError(
+            f"PR number starts with an option-like '-': {pr!r}"
+        )
+    if not _PR_NUMBER_RE.match(pr):
+        raise InvalidPrReferenceError(
+            f"PR number must be a positive decimal integer: {pr!r}"
+        )
+    return int(pr)
+
+
+@dataclass(frozen=True, slots=True)
+class PRReference:
+    owner: str
+    name: str
+    number: int
+
+    @property
+    def repo(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    @property
+    def full(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+    @classmethod
+    def from_parts(cls, repo: str, pr: str) -> "PRReference":
+        owner, name = _split_repo(repo)
+        number = _parse_pr_number(pr)
+        return cls(owner, name, number)
+
+    @classmethod
+    def from_string(cls, ref: str) -> "PRReference":
+        ref = ref.strip()
+        if not ref:
+            raise InvalidPrReferenceError("PR reference is empty")
+        if "#" not in ref:
+            raise InvalidPrReferenceError(
+                f"PR reference must be owner/name#number: {ref!r}"
+            )
+        repo, _, pr = ref.partition("#")
+        return cls.from_parts(repo, pr)
+
+
+def _format_location(source: str | None, line: int | None) -> str:
+    return f"{source or '<unknown>'}:{line or '?'}"
+
+
+def parse_repo_name(
+    repo: str,
+    *,
+    source: str | None = None,
+    line: int | None = None,
+    strict: bool = False,
+) -> str | None:
+    """Validate a repo name and return ``owner/name``, or skip with a diagnostic."""
+    try:
+        owner, name = _split_repo(repo)
+        return f"{owner}/{name}"
+    except InvalidPrReferenceError as exc:
+        location = _format_location(source, line)
+        if strict:
+            raise InvalidPrReferenceError(f"{location}: {exc}") from exc
+        print(f"skipping invalid repo name at {location}: {exc}", file=sys.stderr)
+        return None
+
+
+def parse_pr_reference(
+    repo: str,
+    pr: str,
+    *,
+    source: str | None = None,
+    line: int | None = None,
+    strict: bool = False,
+) -> PRReference | None:
+    """Validate a ``repo`` + ``pr`` pair and return a typed value, or skip with a diagnostic."""
+    try:
+        return PRReference.from_parts(repo, pr)
+    except InvalidPrReferenceError as exc:
+        location = _format_location(source, line)
+        if strict:
+            raise InvalidPrReferenceError(f"{location}: {exc}") from exc
+        print(f"skipping invalid PR reference at {location}: {exc}", file=sys.stderr)
+        return None

--- a/run_merges.py
+++ b/run_merges.py
@@ -1,76 +1,67 @@
-from concurrent.futures import ThreadPoolExecutor
 import json
-import os
 import subprocess
+import sys
 import time
-from functools import lru_cache
+from concurrent.futures import ThreadPoolExecutor
 
-
-def _parse_env_line(line, env_dict):
-    line = line.strip()
-    if not line:
-        return
-    if line.startswith("#"):
-        return
-    if line.startswith("export "):
-        line = line[7:].strip()
-    # ⚡ Bolt Optimization: Use partition() over split() to avoid intermediate list allocation overhead
-    key, sep, val = line.partition("=")
-    if not sep:
-        return
-    env_dict[key] = val.strip("'\"")
-
-
-@lru_cache(maxsize=None)
-def _get_parsed_env_vars():
-    # ⚡ Bolt Optimization: Cache only the parsed variables from the file to prevent redundant IO reads, while keeping it safe from mutable dictionary cache poisoning
-    parsed_vars = {}
-    try:
-        with open("../email-security-pipeline/GH_TOKEN.env", "r") as f:
-            for line in f:
-                _parse_env_line(line, parsed_vars)
-    except FileNotFoundError:
-        pass
-    return parsed_vars
-
-
-def _load_gh_token_env():
-    env = os.environ.copy()
-    env.update(_get_parsed_env_vars())
-    return env
+from gh_token_env import load_gh_token_env
+from pr_reference import PRReference
 
 
 def run_gh(cmd_list):
-    env = _load_gh_token_env()
-    result = subprocess.run(cmd_list, capture_output=True, text=True, env=env)
+    """Call ``gh`` and return parsed JSON, or a string, or None on failure/timeout."""
+    env = load_gh_token_env()
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"gh command timed out: {cmd_list[0] if cmd_list else cmd_list}",
+            file=sys.stderr,
+        )
+        return None
     if result.returncode != 0:
         return None
     try:
         return json.loads(result.stdout)
-    except:
+    except json.JSONDecodeError:
         return result.stdout
 
 
 def get_diff(repo, pr):
+    """Fetch the textual diff for a PR."""
     res = run_gh(["gh", "pr", "diff", str(pr), "-R", str(repo)])
     return res if isinstance(res, str) else ""
 
 
 def _fetch_pr_data(item):
     repo, pr, title = item
+    ref = PRReference.from_parts(repo, pr)
     info = run_gh(
-        ["gh", "pr", "view", str(pr), "-R", str(repo), "--json", "mergeStateStatus"]
+        [
+            "gh",
+            "pr",
+            "view",
+            str(ref.number),
+            "-R",
+            ref.repo,
+            "--json",
+            "mergeStateStatus",
+        ]
     )
     diff = ""
     if info and info.get("mergeStateStatus") not in ["DIRTY", "CONFLICTING"]:
-        diff = get_diff(repo, pr)
-    return repo, pr, title, info, diff
+        diff = get_diff(ref.repo, str(ref.number))
+    return ref.repo, str(ref.number), title, info, diff
 
 
 def _fetch_all_pr_data_parallel(queue_items):
-    # ⚡ Bolt Optimization: Parallelize N+1 read-only API calls using map() to significantly speed up PR data fetching
-    # This mitigates network latency and execution time by querying github concurrently
-    # ⚡ Bolt Optimization: Dynamic thread concurrency to eliminate batching latency
     with ThreadPoolExecutor(max_workers=min(len(queue_items) or 1, 32)) as executor:
         return list(executor.map(_fetch_pr_data, queue_items))
 
@@ -180,7 +171,7 @@ queue = [
 
 results = {"merged": [], "escalated": [], "conflicting": []}
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     for repo, pr, title, info, diff in _fetch_all_pr_data_parallel(queue):
         print(f"\nProcessing {repo}#{pr}: {title}")
 
@@ -209,13 +200,11 @@ if __name__ == '__main__':
             escalate = True
             reasons.append("Dangerous GitHub Actions workflow detected.")
         if ".gitignore" in diff_lower and "+" in diff_lower and "!" in diff_lower:
-            # Simplistic check for gitignore weakening
             pass
         if ".env.example" in diff_lower and "- " in diff_lower:
             escalate = True
             reasons.append("Weakened .env.example.")
 
-        # ⚡ Bolt Optimization: Cache title.lower() to prevent redundant C-level string allocations during multiple sequential "in" checks
         title_lower = title.lower()
         for sensitive in ("auth", "payment", "migration", "sql"):
             if sensitive in title_lower:
@@ -228,21 +217,34 @@ if __name__ == '__main__':
             results["escalated"].append((repo, pr, title, reasons))
             continue
 
-        print(f"Gate 2 passed. Merging...")
-        env = _load_gh_token_env()
+        print("Gate 2 passed. Merging...")
+        ref = PRReference.from_parts(repo, pr)
+        env = load_gh_token_env()
         res = subprocess.run(
-            ["gh", "pr", "merge", str(pr), "-R", str(repo), "--squash", "--delete-branch"],
+            [
+                "gh",
+                "pr",
+                "merge",
+                str(ref.number),
+                "-R",
+                ref.repo,
+                "--squash",
+                "--delete-branch",
+            ],
             capture_output=True,
             text=True,
             env=env,
+            timeout=120,
+            check=False,
         )
         if res.returncode == 0:
             print(f"Successfully merged {repo}#{pr}")
             results["merged"].append((repo, pr, title))
         else:
-            print(f"Merge failed: {res.stderr}")
+            error_text = res.stderr.strip() or res.stdout.strip() or "unknown error"
+            print(f"Merge failed: {error_text}")
             results["escalated"].append(
-                (repo, pr, title, ["Merge command failed", res.stderr])
+                (repo, pr, title, ["Merge command failed", error_text])
             )
             continue
 

--- a/tests/test_categorize_ready.py
+++ b/tests/test_categorize_ready.py
@@ -14,7 +14,7 @@ class TestCategorizeReady(unittest.TestCase):
             "categorize_ready.py",
             {
                 "run_gh",
-                "_load_gh_token_env",
+                "load_gh_token_env",
                 "fetch_pr_info",
                 "get_category_from_title",
             },

--- a/tests/test_detect_duplicates.py
+++ b/tests/test_detect_duplicates.py
@@ -180,6 +180,46 @@ class TestDetectDuplicates(unittest.TestCase):
         mock_run_gh.assert_not_called()
 
     @patch("detect_duplicates.run_gh")
+    def test_group_prs_by_files_uses_graphql_variables(self, mock_run_gh):
+        """Test that the query uses declared variables and separate -f/-F fields."""
+        mock_run_gh.return_value = {
+            "data": {
+                "pr0": {
+                    "pullRequest": {
+                        "number": 1,
+                        "title": "PR 1",
+                        "files": {"nodes": [{"path": "file1.py"}]},
+                    }
+                }
+            }
+        }
+
+        _group_prs_by_files(["repoA/projectA#1"])
+
+        mock_run_gh.assert_called_once()
+        args, _ = mock_run_gh.call_args
+        cmd = args[0]
+        self.assertIsInstance(cmd, list)
+        self.assertEqual(cmd[0], "gh")
+        self.assertEqual(cmd[1], "api")
+        self.assertEqual(cmd[2], "graphql")
+        self.assertIn("-f", cmd)
+        self.assertIn("query=", " ".join(cmd))
+        self.assertIn("owner0=repoA", cmd)
+        self.assertIn("name0=projectA", cmd)
+        self.assertIn("-F", cmd)
+        self.assertIn("pr0=1", cmd)
+
+    @patch("detect_duplicates.run_gh")
+    def test_group_prs_by_files_skips_invalid_reference(self, mock_run_gh):
+        """Invalid PR references are skipped rather than aborting batch processing."""
+        mock_run_gh.return_value = None
+        file_groups = _group_prs_by_files(["bad-reference", "repoA/projectA#1"])
+        # Only one valid PR should be queried.
+        self.assertEqual(mock_run_gh.call_count, 1)
+        self.assertEqual(len(file_groups), 0)
+
+    @patch("detect_duplicates.run_gh")
     def test_group_prs_by_files_api_failure(self, mock_run_gh):
         """Test when graphql query returns None (e.g., API error)."""
         mock_run_gh.return_value = None
@@ -207,7 +247,6 @@ class TestDetectDuplicates(unittest.TestCase):
         self.assertIn(key, result)
         self.assertEqual(len(result[key]), 1)
         self.assertEqual(result[key][0]["number"], 1)
-
 
     @patch("detect_duplicates._extract_duplicates_from_groups")
     @patch("detect_duplicates._group_prs_by_files")

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -116,10 +116,85 @@ class TestGhTokenEnv(unittest.TestCase):
             ):
                 self.assertEqual(resolve_gh_token_env_file(), env_file)
 
+    def test_explicit_env_file_missing_does_not_fall_through(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing.env"
+            with patch.dict(
+                os.environ, {"GH_TOKEN_ENV_FILE": str(missing)}, clear=True
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    resolve_gh_token_env_file()
+
     def test_missing_message_mentions_runbook(self):
         with patch("gh_token_env.resolve_gh_token_env_file", return_value=None):
             message = missing_gh_token_message()
         self.assertIn("github-pat-rotation-runbook", message)
+
+    def test_load_from_file_only_injects_gh_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "GH_TOKEN.env"
+            _write_secure_env_file(
+                env_file, "GH_TOKEN=file_token\nOTHER_VAR=do_not_inject\n"
+            )
+            with patch.dict(
+                os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
+            ):
+                os.environ.pop("GH_TOKEN", None)
+                merged = load_gh_token_env()
+        self.assertEqual(merged["GH_TOKEN"], "file_token")
+        self.assertNotIn("OTHER_VAR", merged)
+
+    def test_load_gh_token_env_does_not_mutate_global_environ(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "GH_TOKEN.env"
+            _write_secure_env_file(env_file, "GH_TOKEN=file_token\n")
+            with patch.dict(
+                os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
+            ):
+                original = os.environ.copy()
+                load_gh_token_env()
+                self.assertEqual(os.environ, original)
+
+    def test_legacy_path_is_script_relative(self):
+        import gh_token_env as gte
+
+        legacy = gte._LEGACY_RELATIVE_ENV
+        self.assertTrue(legacy.is_absolute())
+        # The legacy file is a sibling of the repo containing gh_token_env.py.
+        self.assertIn("email-security-pipeline", str(legacy))
+
+    def test_resolve_gh_token_env_file_finds_legacy_from_different_cwd(self):
+        import gh_token_env as gte
+
+        with tempfile.TemporaryDirectory() as tmp:
+            legacy_dir = Path(tmp) / "email-security-pipeline"
+            legacy_dir.mkdir()
+            legacy_file = legacy_dir / "GH_TOKEN.env"
+            _write_secure_env_file(legacy_file, "GH_TOKEN=legacy_token\n")
+
+            # Simulate the repo being a sibling of the legacy dir.
+            fake_repo = Path(tmp) / "personal-config"
+            fake_repo.mkdir()
+            with patch.object(gte, "_LEGACY_RELATIVE_ENV", legacy_file):
+                with patch("os.getcwd", return_value=str(tmp)):
+                    found = resolve_gh_token_env_file()
+            self.assertEqual(found, legacy_file)
+
+    def test_cache_reset_isolation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first.env"
+            _write_secure_env_file(first, "GH_TOKEN=first\n")
+            second = Path(tmp) / "second.env"
+            _write_secure_env_file(second, "GH_TOKEN=second\n")
+
+            with patch.dict(os.environ, {"GH_TOKEN_ENV_FILE": str(first)}, clear=True):
+                os.environ.pop("GH_TOKEN", None)
+                self.assertEqual(load_gh_token_env()["GH_TOKEN"], "first")
+
+            clear_gh_token_cache()
+            with patch.dict(os.environ, {"GH_TOKEN_ENV_FILE": str(second)}, clear=True):
+                os.environ.pop("GH_TOKEN", None)
+                self.assertEqual(load_gh_token_env()["GH_TOKEN"], "second")
 
 
 if __name__ == "__main__":

--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -25,6 +25,30 @@ class TestGhTokenEnv(unittest.TestCase):
     def setUp(self):
         clear_gh_token_cache()
 
+    def _load_from_file(
+        self,
+        content: str,
+        env_vars: dict | None = None,
+        pop_gh_token: bool = True,
+    ) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+        """Load GH_TOKEN from a secure temp env file.
+
+        Returns ``(merged_env, original_env, env_after_load)`` so callers can
+        verify that ``load_gh_token_env`` does not mutate ``os.environ``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "GH_TOKEN.env"
+            _write_secure_env_file(env_file, content)
+            patched = dict(env_vars) if env_vars else {}
+            patched["GH_TOKEN_ENV_FILE"] = str(env_file)
+            with patch.dict(os.environ, patched, clear=True):
+                if pop_gh_token:
+                    os.environ.pop("GH_TOKEN", None)
+                original = os.environ.copy()
+                merged = load_gh_token_env()
+                after = os.environ.copy()
+                return merged, original, after
+
     def test_parse_env_line_basic(self):
         env: dict[str, str] = {}
         parse_env_line("FOO=bar", env)
@@ -97,14 +121,7 @@ class TestGhTokenEnv(unittest.TestCase):
         self.assertEqual(merged["GH_TOKEN"], "env_token")
 
     def test_load_from_file_when_env_unset(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            env_file = Path(tmp) / "GH_TOKEN.env"
-            _write_secure_env_file(env_file, "export GH_TOKEN=file_token\n")
-            with patch.dict(
-                os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
-            ):
-                os.environ.pop("GH_TOKEN", None)
-                merged = load_gh_token_env()
+        merged, _, _ = self._load_from_file("export GH_TOKEN=file_token\n")
         self.assertEqual(merged["GH_TOKEN"], "file_token")
 
     def test_resolve_gh_token_env_file_override(self):
@@ -131,29 +148,15 @@ class TestGhTokenEnv(unittest.TestCase):
         self.assertIn("github-pat-rotation-runbook", message)
 
     def test_load_from_file_only_injects_gh_token(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            env_file = Path(tmp) / "GH_TOKEN.env"
-            _write_secure_env_file(
-                env_file, "GH_TOKEN=file_token\nOTHER_VAR=do_not_inject\n"
-            )
-            with patch.dict(
-                os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
-            ):
-                os.environ.pop("GH_TOKEN", None)
-                merged = load_gh_token_env()
+        merged, _, _ = self._load_from_file(
+            "GH_TOKEN=file_token\nOTHER_VAR=do_not_inject\n"
+        )
         self.assertEqual(merged["GH_TOKEN"], "file_token")
         self.assertNotIn("OTHER_VAR", merged)
 
     def test_load_gh_token_env_does_not_mutate_global_environ(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            env_file = Path(tmp) / "GH_TOKEN.env"
-            _write_secure_env_file(env_file, "GH_TOKEN=file_token\n")
-            with patch.dict(
-                os.environ, {"GH_TOKEN_ENV_FILE": str(env_file)}, clear=True
-            ):
-                original = os.environ.copy()
-                load_gh_token_env()
-                self.assertEqual(os.environ, original)
+        _, original, after = self._load_from_file("GH_TOKEN=file_token\n")
+        self.assertEqual(after, original)
 
     def test_legacy_path_is_script_relative(self):
         import gh_token_env as gte

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -12,7 +12,6 @@ from parse_inventory import (
     _is_checks_failing,
     _is_pr_stale,
     _load_inventory_lines,
-    _parse_env_line,
     _parse_repo_name,
     _write_triage_report,
     parse_inventory_lines,
@@ -37,60 +36,33 @@ class TestParseInventory(unittest.TestCase):
             "updatedAt": updated_at,
         }
 
-    def test_parse_env_line_basic(self):
-        env = {}
-        _parse_env_line("FOO=bar", env)
-        self.assertEqual(env, {"FOO": "bar"})
-
-    def test_parse_env_line_with_export(self):
-        env = {}
-        _parse_env_line("export FOO=bar", env)
-        self.assertEqual(env, {"FOO": "bar"})
-
-    def test_parse_env_line_with_quotes(self):
-        env = {}
-        _parse_env_line('export FOO="bar"', env)
-        self.assertEqual(env, {"FOO": "bar"})
-
-        env = {}
-        _parse_env_line("export FOO='bar'", env)
-        self.assertEqual(env, {"FOO": "bar"})
-
-    def test_parse_env_line_comments_and_empty(self):
-        env = {"FOO": "bar"}
-        _parse_env_line("# export BAZ=qux", env)
-        self.assertEqual(env, {"FOO": "bar"})
-
-        _parse_env_line("   ", env)
-        self.assertEqual(env, {"FOO": "bar"})
-
     def test_parse_inventory_lines(self):
         # Flat-table format matching tasks/pr-inventory.md (no ## section headers)
         lines = [
             "| Repo | PR | Author (API) | Branch (head) | Category | CI rollup | Conflicts | Age (created→) | Notes |\n",
             "| ---------------------------------------- | --- | ------------ | ----------- | ------- | --------- | --------- | -------------- | ----- |\n",
-            "| repoA | 123 | some_user[bot] | branch | cat | C | none | 2026-05-03 | |\n",
-            "| repoA | 456 | human | branch | cat | FAIL | none | 2026-05-03 | has-hints |\n",
-            "| repoA | 789 | human | branch | cat | C | none | 2026-05-03 | |\n",
-            "| repoB | 101 | another[bot] | branch | cat | C | none | 2026-05-03 | |\n",
+            "| owner/repoA | 123 | some_user[bot] | branch | cat | C | none | 2026-05-03 | |\n",
+            "| owner/repoA | 456 | human | branch | cat | FAIL | none | 2026-05-03 | has-hints |\n",
+            "| owner/repoA | 789 | human | branch | cat | C | none | 2026-05-03 | |\n",
+            "| owner/repoB | 101 | another[bot] | branch | cat | C | none | 2026-05-03 | |\n",
         ]
         repos = parse_inventory_lines(lines)
 
-        self.assertIn("repoA", repos)
-        self.assertIn("repoB", repos)
+        self.assertIn("owner/repoA", repos)
+        self.assertIn("owner/repoB", repos)
 
         # repoA: 123 (bot) and 456 (human with hints), not 789 (human, no hints)
-        self.assertEqual(len(repos["repoA"]), 2)
-        self.assertEqual(repos["repoA"][0]["pr"], "123")
-        self.assertEqual(repos["repoA"][0]["checks"], "C")
+        self.assertEqual(len(repos["owner/repoA"]), 2)
+        self.assertEqual(repos["owner/repoA"][0]["pr"], "123")
+        self.assertEqual(repos["owner/repoA"][0]["checks"], "C")
 
-        self.assertEqual(repos["repoA"][1]["pr"], "456")
-        self.assertEqual(repos["repoA"][1]["checks"], "FAIL")
+        self.assertEqual(repos["owner/repoA"][1]["pr"], "456")
+        self.assertEqual(repos["owner/repoA"][1]["checks"], "FAIL")
 
         # repoB: 101 (bot)
-        self.assertEqual(len(repos["repoB"]), 1)
-        self.assertEqual(repos["repoB"][0]["pr"], "101")
-        self.assertEqual(repos["repoB"][0]["checks"], "C")
+        self.assertEqual(len(repos["owner/repoB"]), 1)
+        self.assertEqual(repos["owner/repoB"][0]["pr"], "101")
+        self.assertEqual(repos["owner/repoB"][0]["checks"], "C")
 
     def test_parse_inventory_lines_missing_repo(self):
         # Flat-table row with empty repo column and no section header: should be skipped
@@ -103,39 +75,46 @@ class TestParseInventory(unittest.TestCase):
     def test_parse_inventory_lines_malformed(self):
         # Section-header establishes repo; row with too few columns is silently skipped
         lines = [
-            "## repoA\n",
-            "| repoA | 123 | bot[bot] | \n",  # Too few columns
+            "## owner/repoA\n",
+            "| owner/repoA | 123 | bot[bot] | \n",  # Too few columns
         ]
         repos = parse_inventory_lines(lines)
-        self.assertEqual(repos["repoA"], [])
+        self.assertEqual(repos["owner/repoA"], [])
 
     # --- _parse_repo_name ---
 
     def test_parse_repo_name_valid(self):
-        self.assertEqual(_parse_repo_name("## repo-name"), "repo-name")
+        self.assertEqual(_parse_repo_name("## owner/repo-name"), "owner/repo-name")
 
     def test_parse_repo_name_with_extra_spaces(self):
-        self.assertEqual(_parse_repo_name("##    repo-name   "), "repo-name")
+        self.assertEqual(
+            _parse_repo_name("##    owner/repo-name   "), "owner/repo-name"
+        )
 
     def test_parse_repo_name_link_format(self):
         self.assertEqual(
-            _parse_repo_name("### [repo-name](https://github.com/org/repo-name)"),
-            "repo-name",
+            _parse_repo_name("### [owner/repo-name](https://github.com/org/repo-name)"),
+            "owner/repo-name",
         )
 
     def test_parse_repo_name_link_format_with_spaces(self):
-        self.assertEqual(_parse_repo_name("### [  repo-name  ](url)"), "repo-name")
+        self.assertEqual(
+            _parse_repo_name("### [  owner/repo-name  ](url)"), "owner/repo-name"
+        )
 
     def test_parse_repo_name_invalid_link_format(self):
         self.assertIsNone(_parse_repo_name("### no-link"))
 
     def test_parse_repo_name_invalid_prefix(self):
-        self.assertIsNone(_parse_repo_name("# repo-name"))
-        self.assertIsNone(_parse_repo_name("repo-name"))
+        self.assertIsNone(_parse_repo_name("# owner/repo-name"))
+        self.assertIsNone(_parse_repo_name("owner/repo-name"))
 
     def test_parse_repo_name_empty(self):
         self.assertIsNone(_parse_repo_name(""))
         self.assertIsNone(_parse_repo_name("   "))
+
+    def test_parse_repo_name_invalid_repo(self):
+        self.assertIsNone(_parse_repo_name("## invalid-name"))
 
     # --- _load_inventory_lines ---
 
@@ -204,7 +183,7 @@ class TestParseInventory(unittest.TestCase):
 
     # --- run_gh ---
 
-    @patch("parse_inventory._load_gh_token_env", return_value={})
+    @patch("parse_inventory.load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
     def test_run_gh_success(self, mock_run, _mock_env):
         mock_result = MagicMock()
@@ -217,7 +196,7 @@ class TestParseInventory(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["files"][0]["filename"], "foo.py")
 
-    @patch("parse_inventory._load_gh_token_env", return_value={})
+    @patch("parse_inventory.load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
     def test_run_gh_nonzero(self, mock_run, _mock_env):
         mock_result = MagicMock()
@@ -226,7 +205,7 @@ class TestParseInventory(unittest.TestCase):
         mock_run.return_value = mock_result
         self.assertIsNone(run_gh("repoA", 123))
 
-    @patch("parse_inventory._load_gh_token_env", return_value={})
+    @patch("parse_inventory.load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
     def test_run_gh_invalid_json(self, mock_run, _mock_env):
         mock_result = MagicMock()
@@ -235,7 +214,7 @@ class TestParseInventory(unittest.TestCase):
         mock_run.return_value = mock_result
         self.assertIsNone(run_gh("repoA", 123))
 
-    @patch("parse_inventory._load_gh_token_env", return_value={})
+    @patch("parse_inventory.load_gh_token_env", return_value={})
     @patch("parse_inventory.subprocess.run")
     def test_run_gh_returncode_not_zero(self, mock_run, _mock_env):
         mock_result = MagicMock()

--- a/tests/test_pr_reference.py
+++ b/tests/test_pr_reference.py
@@ -86,7 +86,7 @@ class TestPRReference(unittest.TestCase):
         old_stderr = sys.stderr
         sys.stderr = captured
         try:
-            result = parse_repo_name("bad-name", source="tasks/test.md", line=3)
+            result = parse_repo_name("bad-name", loc=("tasks/test.md", 3))
         finally:
             sys.stderr = old_stderr
         self.assertIsNone(result)

--- a/tests/test_pr_reference.py
+++ b/tests/test_pr_reference.py
@@ -1,0 +1,109 @@
+import io
+import sys
+import unittest
+
+sys.path.insert(0, "/".join(__file__.split("/")[:-2]))
+
+from pr_reference import (
+    InvalidPrReferenceError,
+    PRReference,
+    parse_pr_reference,
+    parse_repo_name,
+)
+
+
+class TestPRReference(unittest.TestCase):
+    def test_from_parts(self):
+        ref = PRReference.from_parts("  abhimehro/personal-config  ", "  123  ")
+        self.assertEqual(ref.owner, "abhimehro")
+        self.assertEqual(ref.name, "personal-config")
+        self.assertEqual(ref.number, 123)
+        self.assertEqual(ref.repo, "abhimehro/personal-config")
+        self.assertEqual(ref.full, "abhimehro/personal-config#123")
+
+    def test_from_string(self):
+        ref = PRReference.from_string("owner/repo#42")
+        self.assertEqual(ref.repo, "owner/repo")
+        self.assertEqual(ref.number, 42)
+
+    def test_repo_missing_slash(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner", "1")
+
+    def test_repo_extra_slashes(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo/extra", "1")
+
+    def test_repo_leading_hyphen(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("-owner/repo", "1")
+
+    def test_repo_name_leading_hyphen(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/-repo", "1")
+
+    def test_repo_whitespace(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner /repo", "1")
+
+    def test_repo_control_character(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/re\x00po", "1")
+
+    def test_pr_zero(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "0")
+
+    def test_pr_negative(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "-1")
+
+    def test_pr_non_decimal(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "abc")
+
+    def test_pr_leading_zero(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "0123")
+
+    def test_pr_leading_hyphen(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "-123")
+
+    def test_pr_shell_metacharacters(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo", "123; touch /tmp/pwned")
+
+    def test_repo_shell_metacharacters(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            PRReference.from_parts("owner/repo$(touch /tmp/pwned)", "1")
+
+    def test_parse_repo_name_valid(self):
+        self.assertEqual(parse_repo_name("owner/repo"), "owner/repo")
+
+    def test_parse_repo_name_non_strict_skips_invalid(self):
+        captured = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = captured
+        try:
+            result = parse_repo_name("bad-name", source="tasks/test.md", line=3)
+        finally:
+            sys.stderr = old_stderr
+        self.assertIsNone(result)
+        self.assertIn("skipping invalid repo name", captured.getvalue())
+        self.assertIn("tasks/test.md:3", captured.getvalue())
+
+    def test_parse_repo_name_strict_raises(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            parse_repo_name("bad-name", strict=True)
+
+    def test_parse_pr_reference_non_strict(self):
+        self.assertIsNone(parse_pr_reference("owner", "abc"))
+
+    def test_parse_pr_reference_strict(self):
+        with self.assertRaises(InvalidPrReferenceError):
+            parse_pr_reference("owner", "abc", strict=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_merges.py
+++ b/tests/test_run_merges.py
@@ -1,113 +1,70 @@
-import os
-import unittest
-from unittest.mock import patch, MagicMock, mock_open
-import json
-from importlib import import_module
-from pathlib import Path
 import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-# Add the project root to sys.path so we can import run_merges
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import run_merges
-from run_merges import (
-    _parse_env_line,
-    _get_parsed_env_vars,
-    _load_gh_token_env,
-    run_gh,
-    get_diff,
-    _fetch_pr_data,
-)
+from run_merges import _fetch_all_pr_data_parallel, _fetch_pr_data, get_diff, run_gh
+
 
 class TestRunMerges(unittest.TestCase):
-    def setUp(self):
-        # Clear the lru_cache before each test
-        _get_parsed_env_vars.cache_clear()
+    def test_run_gh_success_json(self):
+        with (
+            patch("run_merges.load_gh_token_env", return_value={}) as _mock_env,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = '{"key": "value"}'
+            mock_run.return_value = mock_result
 
-    def test_parse_env_line(self):
-        env_dict = {}
-        _parse_env_line("FOO=bar", env_dict)
-        self.assertEqual(env_dict["FOO"], "bar")
+            result = run_gh(["gh", "test"])
+            self.assertEqual(result, {"key": "value"})
+            args, kwargs = mock_run.call_args
+            self.assertIsInstance(args[0], list)
+            self.assertEqual(args[0][0], "gh")
+            self.assertFalse(kwargs.get("shell", False))
+            self.assertIsNotNone(kwargs.get("timeout"))
 
-        _parse_env_line("export BAZ=qux", env_dict)
-        self.assertEqual(env_dict["BAZ"], "qux")
+    def test_run_gh_success_string(self):
+        with (
+            patch("run_merges.load_gh_token_env", return_value={}) as _mock_env,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "plain text output"
+            mock_run.return_value = mock_result
 
-        _parse_env_line("# comment", env_dict)
-        self.assertNotIn("#", env_dict)
+            result = run_gh(["gh", "test"])
+            self.assertEqual(result, "plain text output")
 
-        _parse_env_line("export QUUX='hello'", env_dict)
-        self.assertEqual(env_dict["QUUX"], "hello")
+    def test_run_gh_failure(self):
+        with (
+            patch("run_merges.load_gh_token_env", return_value={}) as _mock_env,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_result = MagicMock()
+            mock_result.returncode = 1
+            mock_run.return_value = mock_result
 
-        _parse_env_line("INVALID_LINE", env_dict)
-        self.assertNotIn("INVALID_LINE", env_dict)
-
-    @patch("builtins.open", new_callable=mock_open, read_data="FOO=bar\nexport BAZ=qux\n# comment")
-    def test_get_parsed_env_vars(self, mock_file):
-        parsed = _get_parsed_env_vars()
-        self.assertEqual(parsed, {"FOO": "bar", "BAZ": "qux"})
-        mock_file.assert_called_once_with("../email-security-pipeline/GH_TOKEN.env", "r")
-
-    @patch("builtins.open", side_effect=FileNotFoundError)
-    def test_get_parsed_env_vars_file_not_found(self, mock_file):
-        parsed = _get_parsed_env_vars()
-        self.assertEqual(parsed, {})
-        mock_file.assert_called_once_with("../email-security-pipeline/GH_TOKEN.env", "r")
-
-    @patch("run_merges._get_parsed_env_vars")
-    @patch.dict(os.environ, {"EXISTING": "val"}, clear=True)
-    def test_load_gh_token_env(self, mock_get_parsed):
-        mock_get_parsed.return_value = {"NEW_VAR": "new_val"}
-        env = _load_gh_token_env()
-        self.assertEqual(env.get("EXISTING"), "val")
-        self.assertEqual(env.get("NEW_VAR"), "new_val")
-
-    @patch("subprocess.run")
-    @patch("run_merges._load_gh_token_env")
-    def test_run_gh_success_json(self, mock_load_env, mock_run):
-        mock_load_env.return_value = {"TEST_ENV": "1"}
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = '{"key": "value"}'
-        mock_run.return_value = mock_result
-
-        result = run_gh(["gh", "test"])
-        self.assertEqual(result, {"key": "value"})
-        mock_run.assert_called_once_with(["gh", "test"], capture_output=True, text=True, env={"TEST_ENV": "1"})
-
-    @patch("subprocess.run")
-    @patch("run_merges._load_gh_token_env")
-    def test_run_gh_success_string(self, mock_load_env, mock_run):
-        mock_load_env.return_value = {}
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = 'plain text output'
-        mock_run.return_value = mock_result
-
-        result = run_gh(["gh", "test"])
-        self.assertEqual(result, "plain text output")
-
-    @patch("subprocess.run")
-    @patch("run_merges._load_gh_token_env")
-    def test_run_gh_failure(self, mock_load_env, mock_run):
-        mock_load_env.return_value = {}
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        mock_run.return_value = mock_result
-
-        result = run_gh(["gh", "test"])
-        self.assertIsNone(result)
+            result = run_gh(["gh", "test"])
+            self.assertIsNone(result)
 
     @patch("run_merges.run_gh")
     def test_get_diff_success(self, mock_run_gh):
         mock_run_gh.return_value = "diff output"
-        res = get_diff("repo", "123")
+        res = get_diff("owner/repo", "123")
         self.assertEqual(res, "diff output")
-        mock_run_gh.assert_called_once_with(["gh", "pr", "diff", "123", "-R", "repo"])
+        mock_run_gh.assert_called_once_with(
+            ["gh", "pr", "diff", "123", "-R", "owner/repo"]
+        )
 
     @patch("run_merges.run_gh")
     def test_get_diff_not_string(self, mock_run_gh):
         mock_run_gh.return_value = {"some": "json"}
-        res = get_diff("repo", "123")
+        res = get_diff("owner/repo", "123")
         self.assertEqual(res, "")
 
     @patch("run_merges.get_diff")
@@ -116,23 +73,34 @@ class TestRunMerges(unittest.TestCase):
         mock_run_gh.return_value = {"mergeStateStatus": "CLEAN"}
         mock_get_diff.return_value = "some diff"
 
-        repo, pr, title, info, diff = _fetch_pr_data(("myrepo", "1", "title"))
+        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
 
-        self.assertEqual(repo, "myrepo")
+        self.assertEqual(repo, "owner/myrepo")
         self.assertEqual(pr, "1")
         self.assertEqual(title, "title")
         self.assertEqual(info, {"mergeStateStatus": "CLEAN"})
         self.assertEqual(diff, "some diff")
 
-        mock_run_gh.assert_called_once_with(["gh", "pr", "view", "1", "-R", "myrepo", "--json", "mergeStateStatus"])
-        mock_get_diff.assert_called_once_with("myrepo", "1")
+        mock_run_gh.assert_called_once_with(
+            [
+                "gh",
+                "pr",
+                "view",
+                "1",
+                "-R",
+                "owner/myrepo",
+                "--json",
+                "mergeStateStatus",
+            ]
+        )
+        mock_get_diff.assert_called_once_with("owner/myrepo", "1")
 
     @patch("run_merges.get_diff")
     @patch("run_merges.run_gh")
     def test_fetch_pr_data_dirty(self, mock_run_gh, mock_get_diff):
         mock_run_gh.return_value = {"mergeStateStatus": "DIRTY"}
 
-        repo, pr, title, info, diff = _fetch_pr_data(("myrepo", "1", "title"))
+        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
 
         self.assertEqual(info, {"mergeStateStatus": "DIRTY"})
         self.assertEqual(diff, "")
@@ -143,11 +111,24 @@ class TestRunMerges(unittest.TestCase):
     def test_fetch_pr_data_no_info(self, mock_run_gh, mock_get_diff):
         mock_run_gh.return_value = None
 
-        repo, pr, title, info, diff = _fetch_pr_data(("myrepo", "1", "title"))
+        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
 
         self.assertIsNone(info)
         self.assertEqual(diff, "")
         mock_get_diff.assert_not_called()
+
+    def test_fetch_pr_data_invalid_reference(self):
+        with self.assertRaises(ValueError):
+            _fetch_pr_data(("myrepo", "1", "title"))
+
+    @patch("run_merges._fetch_pr_data")
+    def test_fetch_all_pr_data_parallel(self, mock_fetch):
+        mock_fetch.side_effect = lambda item: (item[0], item[1], item[2], None, "")
+        result = _fetch_all_pr_data_parallel(
+            [("owner/a", "1", "t1"), ("owner/b", "2", "t2")]
+        )
+        self.assertEqual(len(result), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vulnerability_fix.py
+++ b/tests/test_vulnerability_fix.py
@@ -2,8 +2,14 @@
 
 The four PR automation scripts (`categorize_ready.py`, `detect_duplicates.py`,
 `run_merges.py`, `parse_inventory.py`) historically used ``subprocess.run(cmd_str,
-shell=True)``. PR #788 ("🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78)
-in subprocess calls") replaced that with list-args and a manual `.env` parser.
+shell=True)``. PR #788 replaced that with list-args and a manual `.env` parser.
+
+This change hardens further by:
+
+* Centralising PR-reference parsing/validation in `pr_reference.py`.
+* Centralising the `GH_TOKEN` env loader in `gh_token_env.py`.
+* Ensuring every `subprocess.run` call uses list args, omits ``shell=True``,
+  and uses a bounded timeout.
 
 These tests assert the post-#788 API contract so a future refactor cannot
 silently reintroduce the vulnerability:
@@ -12,15 +18,7 @@ silently reintroduce the vulnerability:
    NOT pass ``shell=True``.
 2. ``argv[0]`` MUST be the literal binary name ``"gh"`` so the subprocess
    executes the GitHub CLI directly without shell metachar interpretation.
-3. ``_load_gh_token_env`` MUST be pure Python file IO and MUST NOT shell out.
-
-Originally proposed by automation in PR #816; that PR became unmergeable
-(228-file diff, conflicts after the Lesson-0 cascade). The test file is
-salvaged here, adapted to match main's actual ``run_gh`` signatures.
-
-The scripts execute automation logic at module import time, so we extract
-the function source into a fresh, side-effect-free module via ``ast`` rather
-than importing the full script.
+3. ``load_gh_token_env`` MUST be pure Python file IO and MUST NOT shell out.
 """
 
 import ast
@@ -35,9 +33,8 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def _load_function_only(script_filename, function_names):
     """Return a module containing only the named top-level functions / imports.
 
-    This avoids running the script's module-level automation logic (which
-    reads `tasks/pr-inventory.md`, calls `gh`, writes files, etc.) and lets
-    us unit-test the security-relevant function definitions in isolation.
+    This avoids running the script's module-level automation logic and lets us
+    unit-test the security-relevant function definitions in isolation.
     """
     src_path = os.path.join(REPO_ROOT, script_filename)
     with open(src_path, "r", encoding="utf-8") as fh:
@@ -67,6 +64,10 @@ def _assert_safe(test_case, mock_run):
     test_case.assertFalse(
         kwargs.get("shell", False),
         "subprocess.run must not be called with shell=True",
+    )
+    test_case.assertIsNotNone(
+        kwargs.get("timeout"),
+        "subprocess.run must specify a bounded timeout",
     )
 
 
@@ -131,7 +132,7 @@ class TestRunGhListArgs(unittest.TestCase):
 
 
 class TestEnvLoaderShellSafety(unittest.TestCase):
-    """Defense in depth: ``_load_gh_token_env`` must be pure Python file IO.
+    """Defense in depth: ``load_gh_token_env`` must be pure Python file IO.
 
     If a future refactor accidentally re-introduces a
     ``subprocess.Popen(... shell=True)`` to source the env file, this test will
@@ -141,15 +142,15 @@ class TestEnvLoaderShellSafety(unittest.TestCase):
     @patch("subprocess.run")
     @patch("subprocess.Popen")
     def test_env_loader_does_not_shell_out(self, mock_popen, mock_run):
-        mod = _load_function_only("categorize_ready.py", {"_load_gh_token_env"})
-        mod._load_gh_token_env()
+        mod = _load_function_only("categorize_ready.py", {"load_gh_token_env"})
+        mod.load_gh_token_env()
         self.assertFalse(
             mock_run.called,
-            "_load_gh_token_env must not invoke subprocess.run",
+            "load_gh_token_env must not invoke subprocess.run",
         )
         self.assertFalse(
             mock_popen.called,
-            "_load_gh_token_env must not invoke subprocess.Popen",
+            "load_gh_token_env must not invoke subprocess.Popen",
         )
 
 


### PR DESCRIPTION
Closes [ABHI-1548](https://linear.app/abhis-space/issue/ABHI-1548).

## What
Hardens the four PR automation scripts against command injection and related input-handling weaknesses by introducing a shared PR-reference validator, converting the GraphQL query to use declared variables, consolidating credential loading, and adding a required CI security gate.

## Why
PR #788 removed the original `subprocess.run(..., shell=True)` calls. This change completes the defense-in-depth work requested in ABHI-1548: a single typed parser for `owner/name#number`, a static GraphQL document with variables, a single auditable `GH_TOKEN` loader with a stable legacy path, bounded `subprocess.run` timeouts, and a deterministic AST regression test backstopped by static analysis.

## How
- **New `pr_reference.py`**: parses `owner/name#number` once, rejects whitespace/control chars, extra `/` segments, leading `-`, empty components, and non-positive/non-decimal PR numbers. Batch callers get a filename/line-number diagnostic and skip invalid rows; a `strict=True` mode is available for fail-fast.
- **`detect_duplicates.py`**: builds a static GraphQL query with `$ownerN`, `$nameN`, `$prN` variables and passes each value through `gh api graphql` `-f`/`-F` fields, so untrusted repo/PR strings can never alter query syntax.
- **Token loader consolidation**: all four scripts now import `gh_token_env.load_gh_token_env`. `gh_token_env.py` resolves the legacy `GH_TOKEN.env` path relative to `Path(__file__).resolve().parent`, only injects `GH_TOKEN` into the child environment, warns on legacy use, and fails closed on an explicitly configured `GH_TOKEN_ENV_FILE` that is missing or insecure.
- **Subprocess wrappers**: every `gh` call uses an argument list, omits `shell`, sets `timeout=120`, captures output, and avoids printing `GH_TOKEN` or the full environment in errors.
- **CI gate**: added `CWE-78 Security Gate` job to `.github/workflows/code-quality.yml` running `ruff --select S602,S605` and `bandit -t B602,B605`, plus `tests.test_vulnerability_fix`.
- **Sentinel**: audit scope, commands, results, and accepted exclusions recorded in `.jules/sentinel.md`.

## Testing
- `make lint-errors` — passed
- `make test` — 43/46 shell tests passed, 3 skipped
- `make test-python` / `python3 -m unittest discover -s tests -p 'test_*.py'` — 452 tests passed
- `uvx ruff check --select S602,S605 .` — passed
- `uvx bandit -r . -t B602,B605 -ll` — no issues
- `trunk check <changed files>` — no new issues

## Security
This PR closes the original CWE-78 path by ensuring every production `subprocess` call uses a list with `shell=False` and a bounded timeout, and that no helper converts the list back into a shell string. The shared validator and GraphQL variables also remove injection/breakage risks from malformed repo/PR strings.

---

## Checklist
- [x] `make lint-errors` passes locally
- [x] `trunk check` on changed files reports no new issues
- [x] No secrets, tokens, or `.env` files included
- [x] `.jules/sentinel.md` updated
- [x] Branch name follows the convention in CONTRIBUTING.md

Link to Devin session: https://app.devin.ai/sessions/774390441ecd47b29342b4355b5f547f
Requested by: @abhimehro