### PR TITLE
🎨 Palette: Improve screen reader accessibility for metric lists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -342,3 +342,6 @@ the emoji icon in `<span aria-hidden="true">` to hide it from screen readers.
 ## 2026-07-22 - Accessible Data Tables
 **Learning:** When creating data tables for performance reports, screen readers struggle to associate data cells with their row identifiers if they are marked as simple `<td>` elements.
 **Action:** Always use `<th scope="row">` for the first column in data-heavy tables to ensure proper row-level header associations for screen reader users.
+## $(date +%Y-%m-%d) - HTML Description Lists
+**Learning:** Using generic `<div>` tags directly inside a `<dl>` element creates invalid HTML markup, which can confuse screen readers and disrupt the reading flow of grouped key-value data. Standard HTML `<dl>` lists only allow `<dt>` and `<dd>` as direct children.
+**Action:** Always ensure `<dl>` elements strictly contain valid `<dt>` and `<dd>` elements, and use CSS grid or flexbox on the `<dl>` itself if complex alignment is needed.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -535,10 +535,9 @@ generate_performance_report() {
         .skip-link:focus { top: 0; }
         .header { background-color: #f0f0f0; padding: 10px; border-radius: 5px; }
         .section { margin: 20px 0; padding: 15px; border: 1px solid #ccc; border-radius: 5px; }
-        dl.metric-list { margin: 0; padding: 0; }
-        .metric { margin: 5px 0; display: flex; }
-        .metric dt { margin-right: 8px; }
-        .metric dd { margin: 0; }
+        dl.metric-list { margin: 0; padding: 0; display: grid; grid-template-columns: auto 1fr; gap: 5px 8px; }
+        .metric { font-weight: bold; }
+        dd { margin: 0; }
         .good { color: #057A55; }
         .warning { color: #B45309; }
         .critical { color: #DC2626; }
@@ -558,10 +557,10 @@ generate_performance_report() {
     <section class="section" aria-labelledby="sys-info-heading" role="region">
         <h2 id="sys-info-heading"><span aria-hidden="true">💻</span> System Information</h2>
         <dl class="metric-list">
-            <div class="metric"><dt><strong>System:</strong></dt><dd>$system_info</dd></div>
-            <div class="metric"><dt><strong>CPU:</strong></dt><dd>$cpu_info</dd></div>
-            <div class="metric"><dt><strong>Memory:</strong></dt><dd>${memory_info} GB</dd></div>
-            <div class="metric"><dt><strong>Disk:</strong></dt><dd>$disk_info</dd></div>
+            <dt class="metric"><strong>System:</strong></dt><dd>$system_info</dd>
+            <dt class="metric"><strong>CPU:</strong></dt><dd>$cpu_info</dd>
+            <dt class="metric"><strong>Memory:</strong></dt><dd>${memory_info} GB</dd>
+            <dt class="metric"><strong>Disk:</strong></dt><dd>$disk_info</dd>
         </dl>
     </section>
     


### PR DESCRIPTION
* 💡 What: Removed invalid `<div>` wrappers inside `<dl>` elements in `performance_optimizer.sh` and updated CSS.
* 🎯 Why: Using generic `<div>` tags directly inside a `<dl>` creates invalid HTML markup, which can confuse screen readers and disrupt the reading flow of grouped key-value data.
* 📸 Before/After: (Not applicable for bash script generating backend HTML)
* ♿ Accessibility: Ensures the `<dl>` element strictly contains valid `<dt>` and `<dd>` elements, providing a semantic and accessible experience for assistive technologies.

---
*PR created automatically by Jules for task [4937133120962022324](https://jules.google.com/task/4937133120962022324) started by @abhimehro*