### PR TITLE
🎨 Palette: Add skip-to-content link and main landmark

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -468,3 +468,6 @@ on the `<dl>` itself if complex alignment is needed.
 
 **Learning:** When using `aria-labelledby` on a composite UI element (such as a metric card) that contains both a textual label and a dynamically generated value, the attribute must reference the IDs of both the label and the value (e.g., `aria-labelledby="label-id value-id"`). Referencing only the label causes screen readers to skip announcing the actual value, breaking accessibility.
 **Action:** Always verify that `aria-labelledby` attributes point to all relevant text and value IDs within composite components so that screen readers announce the full context.
+## $(date +%Y-%m-%d) - Main Landmark and Skip Links in Media Server
+**Learning:** Python scripts generating static HTML for media streaming tools missed fundamental screen reader landmarks (like `<main>`) and keyboard bypass features (like skip-to-content).
+**Action:** When dynamically generating standalone HTML views, always include a hidden skip link targeting the primary content container.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -220,6 +220,8 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             <title>Media Library - {safe_path}</title>
             <style>
                 body {{ font-family: Arial, sans-serif; margin: 5%; }}
+                .skip-link {{ position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }}
+                .skip-link:focus {{ top: 0; }}
                 nav ul {{ list-style-type: none; padding: 0; margin: 0; }}
                 nav li {{ margin: 0; padding: 0; }}
                 .file {{ display: block; padding: 10px; text-decoration: none; color: #333; }}
@@ -229,9 +231,11 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
-            <nav aria-label="Directory listing">
-                <ul>
+            <a href="#main-content" class="skip-link">Skip to main content</a>
+            <main id="main-content">
+                <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+                <nav aria-label="Directory listing">
+                    <ul>
         """]
 
         # Add parent directory link if not root
@@ -278,6 +282,7 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
         html_parts.append("""
                 </ul>
             </nav>
+            </main>
         </body>
         </html>
         """)


### PR DESCRIPTION
* 💡 What: Added a visually hidden skip-to-content link and wrapped the primary content in a `<main>` landmark in the generated HTML for the Media Server.
* 🎯 Why: Follows best practices from .jules/palette.md to improve keyboard accessibility by allowing users to bypass the header directly to main content.
* 📸 Before/After: Added skip link element dynamically to HTML response.
* ♿ Accessibility: Addresses the lack of skip links and main landmark in static HTML reports.

---
*PR created automatically by Jules for task [2890855642025781665](https://jules.google.com/task/2890855642025781665) started by @abhimehro*