### PR TITLE
perf(run_merges): GraphQL batch mergeStateStatus (salvages #1820)

### DIFF
--- a/run_merges.py
+++ b/run_merges.py
@@ -40,30 +40,49 @@ def get_diff(repo, pr):
     return res if isinstance(res, str) else ""
 
 
-def _fetch_pr_data(item):
+def _fetch_pr_diff_only(item, info):
     repo, pr, title = item
     ref = PRReference.from_parts(repo, pr)
-    info = run_gh(
-        [
-            "gh",
-            "pr",
-            "view",
-            str(ref.number),
-            "-R",
-            ref.repo,
-            "--json",
-            "mergeStateStatus",
-        ]
-    )
     diff = ""
     if info and info.get("mergeStateStatus") not in ["DIRTY", "CONFLICTING"]:
         diff = get_diff(ref.repo, str(ref.number))
     return ref.repo, str(ref.number), title, info, diff
 
 
+def _build_graphql_query(queue_items):
+    parts = []
+    for i, item in enumerate(queue_items):
+        owner, name = item[0].split("/")
+        parts.append(
+            f'pr{i}: repository(owner: "{owner}", name: "{name}") {{ pullRequest(number: {item[1]}) {{ mergeStateStatus }} }}'
+        )
+    return "query { " + " ".join(parts) + " }"
+
+
+def _parse_graphql_response(res, queue_items):
+    data = res.get("data", {}) if isinstance(res, dict) else {}
+    info_map = {}
+    for i, item in enumerate(queue_items):
+        pr_node = data.get(f"pr{i}", {}) or {}
+        info_map[item] = pr_node.get("pullRequest")
+    return info_map
+
+
+def _fetch_all_pr_info_graphql(queue_items):
+    if not queue_items:
+        return {}
+    query = _build_graphql_query(queue_items)
+    res = run_gh(["gh", "api", "graphql", "-f", f"query={query}"])
+    return _parse_graphql_response(res, queue_items)
+
+
 def _fetch_all_pr_data_parallel(queue_items):
+    info_map = _fetch_all_pr_info_graphql(queue_items)
     with ThreadPoolExecutor(max_workers=min(len(queue_items) or 1, 32)) as executor:
-        return list(executor.map(_fetch_pr_data, queue_items))
+        futures = []
+        for item in queue_items:
+            futures.append(executor.submit(_fetch_pr_diff_only, item, info_map.get(item)))
+        return [f.result() for f in futures]
 
 
 queue = [

--- a/tests/test_run_merges.py
+++ b/tests/test_run_merges.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from run_merges import _fetch_all_pr_data_parallel, _fetch_pr_data, get_diff, run_gh
+from run_merges import _fetch_all_pr_data_parallel, _fetch_pr_diff_only, get_diff, run_gh
 
 
 class TestRunMerges(unittest.TestCase):
@@ -69,65 +69,52 @@ class TestRunMerges(unittest.TestCase):
 
     @patch("run_merges.get_diff")
     @patch("run_merges.run_gh")
-    def test_fetch_pr_data_clean(self, mock_run_gh, mock_get_diff):
-        mock_run_gh.return_value = {"mergeStateStatus": "CLEAN"}
-        mock_get_diff.return_value = "some diff"
+    def test_fetch_all_pr_data_parallel(self, mock_run_gh, mock_get_diff):
+        mock_run_gh.return_value = {
+            "data": {
+                "pr0": {"pullRequest": {"mergeStateStatus": "CLEAN"}},
+                "pr1": {"pullRequest": {"mergeStateStatus": "DIRTY"}},
+            }
+        }
+        mock_get_diff.side_effect = lambda repo, pr: "diff " + pr
 
-        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
+        items = [("owner/repo1", "1", "title1"), ("owner/repo2", "2", "title2")]
+        result = _fetch_all_pr_data_parallel(items)
 
-        self.assertEqual(repo, "owner/myrepo")
-        self.assertEqual(pr, "1")
-        self.assertEqual(title, "title")
-        self.assertEqual(info, {"mergeStateStatus": "CLEAN"})
-        self.assertEqual(diff, "some diff")
+        self.assertEqual(len(result), 2)
 
-        mock_run_gh.assert_called_once_with(
-            [
-                "gh",
-                "pr",
-                "view",
-                "1",
-                "-R",
-                "owner/myrepo",
-                "--json",
-                "mergeStateStatus",
-            ]
-        )
-        mock_get_diff.assert_called_once_with("owner/myrepo", "1")
+        # PR 1 (CLEAN)
+        self.assertEqual(result[0][0], "owner/repo1")
+        self.assertEqual(result[0][1], "1")
+        self.assertEqual(result[0][3], {"mergeStateStatus": "CLEAN"})
+        self.assertEqual(result[0][4], "diff 1")
 
-    @patch("run_merges.get_diff")
+        # PR 2 (DIRTY)
+        self.assertEqual(result[1][3], {"mergeStateStatus": "DIRTY"})
+        self.assertEqual(result[1][4], "")
+
+        # Verify GraphQL call
+        self.assertEqual(mock_run_gh.call_count, 1)
+        args, _ = mock_run_gh.call_args
+        self.assertIn("graphql", args[0])
+
+        # Verify diff fetch call count
+        self.assertEqual(mock_get_diff.call_count, 1)
+
     @patch("run_merges.run_gh")
-    def test_fetch_pr_data_dirty(self, mock_run_gh, mock_get_diff):
-        mock_run_gh.return_value = {"mergeStateStatus": "DIRTY"}
-
-        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
-
-        self.assertEqual(info, {"mergeStateStatus": "DIRTY"})
-        self.assertEqual(diff, "")
-        mock_get_diff.assert_not_called()
-
-    @patch("run_merges.get_diff")
-    @patch("run_merges.run_gh")
-    def test_fetch_pr_data_no_info(self, mock_run_gh, mock_get_diff):
+    def test_fetch_all_pr_data_parallel_graphql_failure(self, mock_run_gh):
         mock_run_gh.return_value = None
 
-        repo, pr, title, info, diff = _fetch_pr_data(("owner/myrepo", "1", "title"))
+        items = [("owner/repo1", "1", "title1")]
+        result = _fetch_all_pr_data_parallel(items)
 
-        self.assertIsNone(info)
-        self.assertEqual(diff, "")
-        mock_get_diff.assert_not_called()
+        self.assertEqual(len(result), 1)
+        self.assertIsNone(result[0][3])
+        self.assertEqual(result[0][4], "")
 
-    def test_fetch_pr_data_invalid_reference(self):
+    def test_fetch_all_pr_data_parallel_invalid_reference(self):
         with self.assertRaises(ValueError):
-            _fetch_pr_data(("myrepo", "1", "title"))
-
-    @patch("run_merges._fetch_pr_data")
-    def test_fetch_all_pr_data_parallel(self, mock_fetch):
-        mock_fetch.side_effect = lambda item: (item[0], item[1], item[2], None, "")
-        result = _fetch_all_pr_data_parallel(
-            [("owner/a", "1", "t1"), ("owner/b", "2", "t2")]
-        )
-        self.assertEqual(len(result), 2)
+            _fetch_all_pr_data_parallel([("myrepo", "1", "title")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Salvages the unique GraphQL batching residual from CONFLICTING [#1820](https://github.com/abhimehro/personal-config/pull/1820) onto current `main`, **excluding** junk artifacts (`trunk` binary, `trunk_output*.txt`) that triggered Phase 1 REQUEST_CHANGES.

## Changes
- `run_merges.py`: batch `mergeStateStatus` via one GraphQL query, then parallelize diffs only
- `tests/test_run_merges.py`: adapted coverage for GraphQL path + failure path

## Not included
- `trunk` / `trunk_output.txt` / `trunk_output2.txt` (junk)
- `greetings.yml` (already pinned via #1828)

## Verification
```bash
python3 -m py_compile run_merges.py
python3 -m unittest tests.test_run_merges -v
```
All 8 tests OK locally.

## ELIR
- **PURPOSE:** Cut N+1 `gh pr view` calls when scanning the merge queue.
- **SECURITY:** GraphQL query interpolates owner/name/number from the trusted local queue list (same trust boundary as prior subprocess args). No new secrets.
- **FAILS IF:** `gh api graphql` shape changes or queue items use unexpected repo strings.
- **VERIFY:** Run unit tests above; optional dry-run of `run_merges.py` against a small queue.
- **MAINTAIN:** Keep GraphQL field selection in sync with `mergeStateStatus` consumers.

Phase 2 never auto-merges — human review required (S1).