### PR TITLE
🎨 Palette: Add skip-link and semantic HTML to Media Server

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -468,3 +468,6 @@ on the `<dl>` itself if complex alignment is needed.
 
 **Learning:** When using `aria-labelledby` on a composite UI element (such as a metric card) that contains both a textual label and a dynamically generated value, the attribute must reference the IDs of both the label and the value (e.g., `aria-labelledby="label-id value-id"`). Referencing only the label causes screen readers to skip announcing the actual value, breaking accessibility.
 **Action:** Always verify that `aria-labelledby` attributes point to all relevant text and value IDs within composite components so that screen readers announce the full context.
+## 2026-07-31 - Skip-to-content links for Python generated HTML
+**Learning:** Python scripts that generate static HTML for directory listings omit essential keyboard accessibility features like skip-to-content links, making navigation tedious for keyboard and screen reader users.
+**Action:** Always include a visually hidden, focusable skip link (`<a href="#main-content" class="skip-link">Skip to main content</a>`) at the top of the `<body>` and ensure the main content is wrapped in `<main id="main-content">`.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -220,6 +220,8 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             <title>Media Library - {safe_path}</title>
             <style>
                 body {{ font-family: Arial, sans-serif; margin: 5%; }}
+                .skip-link {{ position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }}
+                .skip-link:focus {{ top: 0; }}
                 nav ul {{ list-style-type: none; padding: 0; margin: 0; }}
                 nav li {{ margin: 0; padding: 0; }}
                 .file {{ display: block; padding: 10px; text-decoration: none; color: #333; }}
@@ -229,9 +231,13 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
-            <nav aria-label="Directory listing">
-                <ul>
+            <a href="#main-content" class="skip-link">Skip to main content</a>
+            <header>
+                <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            </header>
+            <main id="main-content">
+                <nav aria-label="Directory listing">
+                    <ul>
         """]
 
         # Add parent directory link if not root
@@ -278,6 +284,7 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
         html_parts.append("""
                 </ul>
             </nav>
+            </main>
         </body>
         </html>
         """)


### PR DESCRIPTION
* 💡 What: Added a skip-to-content link and wrapped main content in <header> and <main> tags for the Infuse Media Server directory listing.
* 🎯 Why: Screen reader and keyboard users need a way to bypass the header and immediately focus on the directory listing.
* 📸 Before/After: N/A
* ♿ Accessibility: Improves keyboard navigation and provides proper structural semantics.

---
*PR created automatically by Jules for task [3913973850401244338](https://jules.google.com/task/3913973850401244338) started by @abhimehro*