### PR TITLE
a11y(media): skip-link + main landmark (salvages #1840/#1835)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -475,3 +475,6 @@ screen readers to skip announcing the actual value, breaking accessibility.
 **Action:** Always verify that `aria-labelledby` attributes point to all
 relevant text and value IDs within composite components so that screen readers
 announce the full context.
+## 2026-07-31 - Skip-to-content links for Python generated HTML
+**Learning:** Python scripts that generate static HTML for directory listings omit essential keyboard accessibility features like skip-to-content links, making navigation tedious for keyboard and screen reader users.
+**Action:** Always include a visually hidden, focusable skip link (`<a href="#main-content" class="skip-link">Skip to main content</a>`) at the top of the `<body>` and ensure the main content is wrapped in `<main id="main-content">`.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -220,6 +220,8 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             <title>Media Library - {safe_path}</title>
             <style>
                 body {{ font-family: Arial, sans-serif; margin: 5%; }}
+                .skip-link {{ position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }}
+                .skip-link:focus {{ top: 0; }}
                 nav ul {{ list-style-type: none; padding: 0; margin: 0; }}
                 nav li {{ margin: 0; padding: 0; }}
                 .file {{ display: block; padding: 10px; text-decoration: none; color: #333; }}
@@ -229,9 +231,13 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             </style>
         </head>
         <body>
-            <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
-            <nav aria-label="Directory listing">
-                <ul>
+            <a href="#main-content" class="skip-link">Skip to main content</a>
+            <header>
+                <h1><span aria-hidden="true">📁</span> Media Library: /{safe_path}</h1>
+            </header>
+            <main id="main-content">
+                <nav aria-label="Directory listing">
+                    <ul>
         """]
 
         # Add parent directory link if not root
@@ -278,6 +284,7 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
         html_parts.append("""
                 </ul>
             </nav>
+            </main>
         </body>
         </html>
         """)

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -220,8 +220,8 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
             <title>Media Library - {safe_path}</title>
             <style>
                 body {{ font-family: Arial, sans-serif; margin: 5%; }}
-                .skip-link {{ position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }}
-                .skip-link:focus {{ top: 0; }}
+                .skip-link {{ position: absolute; top: 0; left: 0; transform: translateY(-150%); background: #000; color: #fff; padding: 8px; z-index: 100; text-decoration: none; transition: transform 0.2s; }}
+                .skip-link:focus, .skip-link:focus-visible {{ transform: translateY(0); }}
                 nav ul {{ list-style-type: none; padding: 0; margin: 0; }}
                 nav li {{ margin: 0; padding: 0; }}
                 .file {{ display: block; padding: 10px; text-decoration: none; color: #333; }}


### PR DESCRIPTION
## Summary
Salvages CONFLICTING Palette twins [#1840](https://github.com/abhimehro/personal-config/pull/1840) / [#1835](https://github.com/abhimehro/personal-config/pull/1835) onto fresh `main`.

- Prefer #1840 HTML (`<header>` + `<main id=\"main-content\">` + skip-link CSS)
- Append-only `.jules/palette.md` journal entry (Lesson 0y) — do not checkout journal from PR

## ELIR
**PURPOSE:** Restore keyboard/screen-reader skip navigation on archived Infuse media listing HTML generator.
**SECURITY:** Cosmetic a11y only; no trust-boundary change. Archived script path.
**FAILS IF:** HTML template anchors drift on `main`.
**VERIFY:** `python3 -m py_compile media-streaming/archive/scripts/infuse-media-server.py`; confirm `skip-link` / `main-content` present.
**MAINTAIN:** Journal must stay append-only.

## Tier
T3 — routine salvage

Autonomous merge: **never** (Phase 2 S1).