### PR TITLE
perf(parse): inventory split bound + dotenv bulk-read (salvages #1824/#1823)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -843,3 +843,6 @@ static and used repeatedly inside functions or loops.
 ## 2026-12-08 - [Avoid slow manual string slicing with while loops]
 **Learning:** Using a manual `while True` loop to parse out multi-line string content by constantly calling `str.find` and managing pointers is extremely inefficient, byte-code intensive, and hard to read.
 **Action:** Replace manual string-parsing loops with a single `re.findall` call using a pre-compiled regular expression at the module level for a significant performance and readability boost.
+## 2026-07-31 - Bound splits + bulk-read small dotenv files
+**Learning:** Unbounded `.split("|")` and per-line I/O on small `.env` files add avoidable allocations in tight parse loops.
+**Action:** Use `.split("|", n)` when only the first n fields are needed, and `handle.read().splitlines()` for small in-memory config files.

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -60,8 +60,10 @@ def _validate_env_fd(fd: int, path: Path) -> None:
 
 def _parse_env_lines(handle, parsed: dict[str, str]) -> None:
     """Read a dotenv-style file handle into ``parsed``."""
-    for line in handle:
-        parse_env_line(line, parsed)
+    content = handle.read()
+    if content:
+        for line in content.splitlines():
+            parse_env_line(line, parsed)
 
 
 def _read_env_file(path: Path) -> dict[str, str]:

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -85,7 +85,7 @@ def _ensure_repo_bucket(repo_name, repos):
 
 
 def _parse_row_record(line, current_repo, line_number):
-    parts = line.split("|")
+    parts = line.split("|", 10)
     if len(parts) <= 9:
         return None
     repo_col, pr_id, author, checks, hints = _extract_pr_row_fields(parts)


### PR DESCRIPTION
## Summary
Combined salvage (Lesson 0ey) of CONFLICTING Bolt micro-opts:
- [#1824](https://github.com/abhimehro/personal-config/pull/1824) — `line.split(\"|\", 10)` in `parse_inventory.py`
- [#1823](https://github.com/abhimehro/personal-config/pull/1823) — bulk-read `.env` in `gh_token_env.py`

Journal append-only on `.jules/bolt.md`.

## ELIR
**PURPOSE:** Reduce unnecessary allocations in inventory parsing and dotenv reads.
**SECURITY:** No auth/token logic change; read path only. Does not alter `parse_env_line` semantics.
**FAILS IF:** Callers rely on unbounded split producing >11 parts with distinct meanings (they do not — code only uses first 10 fields).
**VERIFY:** `python3 -m py_compile parse_inventory.py gh_token_env.py`
**MAINTAIN:** Keep bolt journal append-only.

## Tier
T3 — routine salvage

Autonomous merge: **never** (Phase 2 S1).