### PR TITLE
perf(parse): inventory split bound + dotenv bulk-read (salvages #1857)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -846,3 +846,8 @@ static and used repeatedly inside functions or loops.
 ## 2024-05-18 - Replacing file iteration with splitlines() for memory efficiency
 **Learning:** The previous plan attempted to optimize file parsing by changing lazy iteration (`for line in handle:`) to loading the entire file into memory and splitting it into a list (`for line in handle.read().splitlines():`). While potentially faster for very small text files by avoiding the overhead of multiple I/O loops, it degraded memory efficiency because it required loading the entire file into memory at once. It also destroyed newline formatting. We learned that the standard `for line in handle:` is generally more memory-efficient and safer to use unless memory overhead is strictly not a concern and raw read speed is critical.
 **Action:** When considering file reading performance optimizations, always weigh raw read speed against memory consumption and memory overhead. Prioritize lazy iteration (`for line in handle:`) for unknown file sizes or whenever memory optimization is prioritized over micro-optimizations in speed.
+
+## 2026-07-31 - Bound splits + bulk-read small dotenv files
+**Learning:** Unbounded `.split("|")` and per-line I/O on small `.env` files add avoidable allocations in tight parse loops.
+**Action:** Use `.split("|", n)` when only the first n fields are needed, and `handle.read().splitlines()` for small in-memory config files.
+

--- a/gh_token_env.py
+++ b/gh_token_env.py
@@ -60,8 +60,10 @@ def _validate_env_fd(fd: int, path: Path) -> None:
 
 def _parse_env_lines(handle, parsed: dict[str, str]) -> None:
     """Read a dotenv-style file handle into ``parsed``."""
-    for line in handle:
-        parse_env_line(line, parsed)
+    content = handle.read()
+    if content:
+        for line in content.splitlines():
+            parse_env_line(line, parsed)
 
 
 def _read_env_file(path: Path) -> dict[str, str]:

--- a/parse_inventory.py
+++ b/parse_inventory.py
@@ -85,7 +85,7 @@ def _ensure_repo_bucket(repo_name, repos):
 
 
 def _parse_row_record(line, current_repo, line_number):
-    parts = line.split("|")
+    parts = line.split("|", 10)
     if len(parts) <= 9:
         return None
     repo_col, pr_id, author, checks, hints = _extract_pr_row_fields(parts)


### PR DESCRIPTION
## Summary
Re-salvages DIRTY [#1857](https://github.com/abhimehro/personal-config/pull/1857) onto current `main`.

- `parse_inventory.py`: `line.split("|", 10)` bound
- `gh_token_env.py`: bulk-read dotenv handle then splitlines
- `.jules/bolt.md`: append-only journal entry (Lesson 0y)

## ELIR
PURPOSE: Restore micro-opts that conflicted after concurrent merges.
SECURITY: No auth/secrets changes; parsing only.
FAILS IF: Inventory rows needing >10 pipe-delimited fields (unlikely).
VERIFY: `python3 -m py_compile parse_inventory.py gh_token_env.py`
MAINTAIN: Prefer this draft over #1857; close #1857 after merge.

Autonomous merge: **none** (S1).