### PR TITLE
style(media): empty-state class on directory listing (salvages #1859)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -478,3 +478,7 @@ announce the full context.
 ## 2026-07-31 - Skip-to-content links for Python generated HTML
 **Learning:** Python scripts that generate static HTML for directory listings omit essential keyboard accessibility features like skip-to-content links, making navigation tedious for keyboard and screen reader users.
 **Action:** Always include a visually hidden, focusable skip link (`<a href="#main-content" class="skip-link">Skip to main content</a>`) at the top of the `<body>` and ensure the main content is wrapped in `<main id="main-content">`.
+
+## 2026-08-01 — empty-state class (salvage #1859)
+
+Added `empty-state` class on empty directory listing `<li>` without removing skip-link / landmark a11y from main.

--- a/media-streaming/archive/scripts/infuse-media-server.py
+++ b/media-streaming/archive/scripts/infuse-media-server.py
@@ -277,7 +277,7 @@ class MediaServerHandler(SimpleHTTPRequestHandler):
         ]
         if not items_html:
             items_html.append(
-                '<li><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>\n'
+                '<li class="empty-state"><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>\n'
             )
         html_parts.extend(items_html)
 

--- a/tests/test_infuse_media_server.py
+++ b/tests/test_infuse_media_server.py
@@ -168,7 +168,7 @@ class TestMediaServerHandler(unittest.TestCase):
         """
         html_empty = self.handler.generate_directory_listing([], "/empty_folder")
         self.assertIn(
-            '<li><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>',
+            '<li class="empty-state"><span class="file" style="color: #666;"><em>Directory is empty</em></span></li>',
             html_empty,
         )
 


### PR DESCRIPTION
## Summary
Salvages the valuable part of DIRTY [#1859](https://github.com/abhimehro/personal-config/pull/1859): add `empty-state` class to the empty directory listing item.

**Not taken from #1859:** removal of skip-link / `<header>` / `<main>` landmarks (a11y regression vs current `main`).

## ELIR
PURPOSE: Keep the CSS hook for empty-state styling without regressing accessibility.
SECURITY: Archive media listing HTML only; auth path untouched.
FAILS IF: Downstream CSS expected the exact prior markup without `empty-state`.
VERIFY: `python3 -m unittest tests.test_infuse_media_server`
MAINTAIN: Close #1859 as superseded by this draft after human merge.

Autonomous merge: **none** (S1).