### PR TITLE
🎨 Palette: Add keyboard focus ring to skip links and improve empty state design

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -482,3 +482,6 @@ announce the full context.
 ## 2026-08-01 — empty-state class (salvage #1859)
 
 Added `empty-state` class on empty directory listing `<li>` without removing skip-link / landmark a11y from main.
+## 2026-08-02 - Improved empty states and a11y focus rings
+**Learning:** Shell-generated HTML reports often neglect a11y focus states for `.skip-link` and lack robust visual distinction for empty states (e.g. no recommendations).
+**Action:** Always verify keyboard accessibility (`:focus` with clear outline) and add icons/soft backgrounds for empty states to make them visibly distinct.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -411,7 +411,7 @@ generate_dashboard() {
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
         .skip-link { position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }
-        .skip-link:focus { top: 0; }
+        .skip-link:focus { top: 0; outline: 3px solid #007bff; outline-offset: 2px; }
         .container { max-width: 1200px; margin: 0 auto; background: white; border-radius: 10px; padding: 30px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
         .header { text-align: center; margin-bottom: 40px; }
         .header h1 { color: #333; margin-bottom: 10px; }

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -532,7 +532,7 @@ generate_performance_report() {
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .skip-link { position: absolute; top: -40px; left: 0; background: #000; color: white; padding: 8px; z-index: 100; text-decoration: none; transition: top 0.2s; }
-        .skip-link:focus { top: 0; }
+        .skip-link:focus { top: 0; outline: 3px solid #007bff; outline-offset: 2px; }
         .header { background-color: #f0f0f0; padding: 10px; border-radius: 5px; }
         .section { margin: 20px 0; padding: 15px; border: 1px solid #ccc; border-radius: 5px; }
         dl.metric-list { margin: 0; padding: 0; display: grid; grid-template-columns: auto 1fr; gap: 5px 8px; }
@@ -613,7 +613,7 @@ EOF
 	fi
 
 	if [[ $has_recs == false ]]; then
-		echo '            <li class="empty-state" style="color: #666; font-style: italic;">System is running smoothly. No specific recommendations at this time.</li>' >>"$report_file"
+		echo '            <li class="empty-state" style="color: #155724; background-color: #d4edda; border-color: #c3e6cb; padding: 15px; border-radius: 4px; display: flex; align-items: center; gap: 10px;"><span aria-hidden="true" style="font-size: 1.2em;">✅</span> <span>System is running smoothly. No specific recommendations at this time.</span></li>' >>"$report_file"
 	fi
 
 	cat >>"$report_file" <<EOF


### PR DESCRIPTION
* 💡 What: Added an explicit, high-contrast focus ring (`outline: 3px solid #007bff; outline-offset: 2px;`) to the visually-hidden `.skip-link` in HTML reports and improved the "no recommendations" empty state in the performance optimizer by adding an icon, a soft background, and better alignment.
* 🎯 Why: Screen reader and keyboard navigation users had no visual indication when they focused on the `.skip-link`, degrading the experience. The empty state for recommendations was plain and could easily be overlooked, so adding visual distinction makes it clearer that the system is operating optimally.
* 📸 Before/After: N/A (shell-generated HTML).
* ♿ Accessibility: The `.skip-link` now strictly meets WCAG SC 2.4.7 (Focus Visible) requirements by overriding standard browser defaults with a distinct, accessible blue outline.

---
*PR created automatically by Jules for task [16431285110985051917](https://jules.google.com/task/16431285110985051917) started by @abhimehro*