### PR TITLE
🎨 Palette: Add semantic <meter> to performance metrics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -490,3 +490,7 @@ top of the `<body>` and ensure the main content is wrapped in
 
 Added `empty-state` class on empty directory listing `<li>` without removing
 skip-link / landmark a11y from main.
+
+## 2026-08-04 - Native HTML Meter for Data Visualization
+**Learning:** Presenting system metrics (like CPU load or disk usage) as raw text in HTML reports misses an opportunity for accessible data visualization.
+**Action:** Use the native HTML5 `<meter>` element to provide a semantic, accessible, and visually appealing representation of scalar measurements within known ranges, ensuring appropriate `aria-label`, `min`, `max`, `low`, and `high` attributes are set.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -643,9 +643,9 @@ EOF
 	[[ $disk_usage -gt 90 ]] && disk_status="critical"
 
 	cat >>"$report_file" <<EOF
-            <tr><th scope="row">CPU Load</th><td>$cpu_load</td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">CPU Load</th><td><meter aria-label="CPU Load" min="0" max="8" low="2" high="4" optimum="1" value="$cpu_load">$cpu_load</meter></td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
             <tr><th scope="row">Memory Free Pages</th><td>$memory_usage</td><td class="good">GOOD</td></tr>
-            <tr><th scope="row">Disk Usage</th><td>${disk_usage}%</td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">Disk Usage</th><td><meter aria-label="Disk Usage" min="0" max="100" low="70" high="90" optimum="50" value="${disk_usage}">${disk_usage}%</meter></td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
         </table>
     </section>
     


### PR DESCRIPTION
* 💡 What: Replaced raw text output for CPU Load and Disk Usage with semantic HTML5 `<meter>` elements in the performance optimization report.
* 🎯 Why: Presenting system metrics as raw text misses an opportunity for accessible data visualization. A `<meter>` element provides immediate visual context of usage levels within safe/warning thresholds.
* 📸 Before/After: Before, values were just text (e.g., "55%"). After, they are rendered as native browser meter bars showing proportionality and threshold states.
* ♿ Accessibility: The `<meter>` element is natively accessible, automatically exposing its `min`, `max`, `low`, `high`, `optimum`, and `value` to screen readers, along with an explicit `aria-label` for clear context.

---
*PR created automatically by Jules for task [16489469546279554523](https://jules.google.com/task/16489469546279554523) started by @abhimehro*