### PR TITLE
🧪 [testing improvement] Add missing tests for run_merges.py run_gh timeout and OSError exception

### DIFF
--- a/run_merges.py
+++ b/run_merges.py
@@ -20,9 +20,9 @@ def run_gh(cmd_list):
             timeout=120,
             check=False,
         )
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError) as e:
         print(
-            f"gh command timed out: {cmd_list[0] if cmd_list else cmd_list}",
+            f"gh command failed or timed out ({type(e).__name__}): {cmd_list[0] if cmd_list else cmd_list}",
             file=sys.stderr,
         )
         return None

--- a/tests/test_run_merges.py
+++ b/tests/test_run_merges.py
@@ -57,6 +57,23 @@ class TestRunMerges(unittest.TestCase):
             result = run_gh(["gh", "test"])
             self.assertIsNone(result)
 
+    def test_run_gh_timeout(self):
+        import subprocess
+        with (
+            patch("run_merges.load_gh_token_env", return_value={}),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["gh", "test"], timeout=120))
+        ):
+            result = run_gh(["gh", "test"])
+            self.assertIsNone(result)
+
+    def test_run_gh_oserror(self):
+        with (
+            patch("run_merges.load_gh_token_env", return_value={}),
+            patch("subprocess.run", side_effect=OSError("Command not found"))
+        ):
+            result = run_gh(["gh", "test"])
+            self.assertIsNone(result)
+
     @patch("run_merges.run_gh")
     def test_get_diff_success(self, mock_run_gh):
         mock_run_gh.return_value = "diff output"


### PR DESCRIPTION
🎯 **What:** Caught `OSError` in `run_gh` and added tests for `TimeoutExpired` and `OSError` exceptions.
📊 **Coverage:** Tested timeout and missing executable cases for gh commands.
✨ **Result:** Increased test reliability and prevents unhandled exceptions when calling github cli.

---
*PR created automatically by Jules for task [2084828096928483813](https://jules.google.com/task/2084828096928483813) started by @abhimehro*