### PR TITLE
🧹 [code health] Refactor overly long function 'group_prs'

### DIFF
--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -59,53 +59,48 @@ def _process_pr_group(matches, repo, rationale, groups):
         keep["status_action"] = "KEEP"
 
 
+GROUPING_RULES = [
+    # personal-config
+    (
+        "personal-config",
+        ["eval", "cwe-78"],
+        "Same CWE-78 eval injection theme; keep newest",
+    ),
+    ("personal-config", ["qa & agentic review"], "Duplicate QA reviews; keep newest"),
+    (
+        "personal-config",
+        ["markdown table"],
+        "Bolt perf optimizations for markdown tables; keep newest",
+    ),
+    ("personal-config", ["palette", "prompt"], "Palette UX prompts; keep newest"),
+    # email-security-pipeline
+    ("email-security-pipeline", ["empty state"], "Palette empty states; keep newest"),
+    (
+        "email-security-pipeline",
+        ["video frame"],
+        "Bolt video frame performance; keep newest",
+    ),
+    # series_correction
+    (
+        "series_correction_project_updated",
+        ["itertuples"],
+        "Bolt dataframe iteration perf; keep newest",
+    ),
+    (
+        "series_correction_project_updated",
+        ["iteration", "performance"],
+        "Iteration optimizations; handled by above/keep newest",
+    ),
+]
+
+
 def group_prs(all_prs, triage_md):
     # manual grouping logic based on patterns
     groups = []
 
-    def find_and_group(repo, title_keywords, rationale):
+    for repo, title_keywords, rationale in GROUPING_RULES:
         matches = _find_matching_prs(all_prs, repo, title_keywords)
         _process_pr_group(matches, repo, rationale, groups)
-
-    # personal-config
-    find_and_group(
-        "personal-config",
-        ["eval", "cwe-78"],
-        "Same CWE-78 eval injection theme; keep newest",
-    )
-    find_and_group(
-        "personal-config", ["qa & agentic review"], "Duplicate QA reviews; keep newest"
-    )
-    find_and_group(
-        "personal-config",
-        ["markdown table"],
-        "Bolt perf optimizations for markdown tables; keep newest",
-    )
-    find_and_group(
-        "personal-config", ["palette", "prompt"], "Palette UX prompts; keep newest"
-    )
-
-    # email-security-pipeline
-    find_and_group(
-        "email-security-pipeline", ["empty state"], "Palette empty states; keep newest"
-    )
-    find_and_group(
-        "email-security-pipeline",
-        ["video frame"],
-        "Bolt video frame performance; keep newest",
-    )
-
-    # series_correction
-    find_and_group(
-        "series_correction_project_updated",
-        ["itertuples"],
-        "Bolt dataframe iteration perf; keep newest",
-    )
-    find_and_group(
-        "series_correction_project_updated",
-        ["iteration", "performance"],
-        "Iteration optimizations; handled by above/keep newest",
-    )
 
     for g in groups:
         dups_str = ", ".join([f"**#{d['number']}**" for d in g["dups"]])


### PR DESCRIPTION
* 🎯 **What:** The code health issue addressed
  Refactored the `group_prs` function by extracting its internal, manually-called grouping logic (`find_and_group`) into a declarative, module-level constant (`GROUPING_RULES`). The function now cleanly iterates over this configuration to build PR groupings.

* 💡 **Why:** How this improves maintainability
  Extracting the list of matching patterns and rationales out of the function body drastically shortens `group_prs`, removes the inner closure overhead, eliminates repetitive boilerplate, and separates data configuration from business logic. It's now trivial to add, remove, or modify grouping patterns in a single list.

* ✅ **Verification:** How you confirmed the change is safe
  Ran the full `unittest` test suite (`python3 -m unittest discover -v`); all 450 tests passed successfully. The logic transformation is a functionally equivalent translation of hardcoded function calls to iterated tuple unpacking.

* ✨ **Result:** The improvement achieved
  The `group_prs` function body dropped from ~40 lines to under 10 lines of actual logic, making it vastly easier to read and test. Pattern configurations are cleanly organized.

---
*PR created automatically by Jules for task [16018549345672654928](https://jules.google.com/task/16018549345672654928) started by @abhimehro*