### PR TITLE
🧹 code health: simplify synthetic data generation benchmark

### DIFF
--- a/tests/benchmarks/benchmark_extract_domains.py
+++ b/tests/benchmarks/benchmark_extract_domains.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import tempfile
@@ -50,9 +51,8 @@ def run_benchmark(name, setups, context):
     print(f"Time saved: {old_time - new_time:.4f} seconds")
 
 
-def main():
-    num_rules = 500000
-    iterations = 50
+@contextlib.contextmanager
+def setup_benchmark_data(num_rules):
     print(f"Generating synthetic JSON data for benchmark ({num_rules} rules)...")
     test_data = generate_test_data(num_rules)
 
@@ -62,6 +62,16 @@ def main():
         temp_filepath = f.name
 
     try:
+        yield temp_filepath
+    finally:
+        os.unlink(temp_filepath)
+
+
+def main():
+    num_rules = 500000
+    iterations = 50
+
+    with setup_benchmark_data(num_rules) as temp_filepath:
         # Full end-to-end setups (including JSON parsing)
         setup_e2e_old = f"""
 import json
@@ -142,9 +152,6 @@ def extract(filepath):
             (setup_e2e_allow_old, setup_e2e_allow_new),
             context,
         )
-
-    finally:
-        os.unlink(temp_filepath)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Extracted synthetic data generation and cleanup into a `@contextlib.contextmanager` called `setup_benchmark_data(num_rules)` in `tests/benchmarks/benchmark_extract_domains.py`.
💡 **Why:** Removes the manual `try...finally` block in `main()`, simplifying the script structure, improving readability, and making it easier to maintain or extend in the future.
✅ **Verification:** Verified that the benchmark still runs correctly end-to-end without errors and that the full test suite passes.
✨ **Result:** `main()` is smaller, easier to read, and safely handles file cleanup automatically via `with setup_benchmark_data(num_rules):`

---
*PR created automatically by Jules for task [5670123750731797313](https://jules.google.com/task/5670123750731797313) started by @abhimehro*