### PR TITLE
🧪 [Testing] Add tests for extract_domains.py write_lists

### DIFF
--- a/submission.sh
+++ b/submission.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-git log -1 --stat

--- a/submission.sh
+++ b/submission.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+git log -1 --stat

--- a/tests/test_extract_domains.py
+++ b/tests/test_extract_domains.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 
 # Add the project root to sys.path so we can import the script
 project_root = Path(__file__).resolve().parent.parent
@@ -18,6 +18,7 @@ from adguard.scripts.extract_domains import (
     extract_domains_from_file,
     process_allowlist_files,
     process_denylist_files,
+    write_lists,
 )
 
 
@@ -290,6 +291,35 @@ class TestProcessDenylistFiles(unittest.TestCase):
             result = process_denylist_files(temp_dir)
             self.assertEqual(result, set())
             mock_extract.assert_called_once()
+
+
+class TestWriteLists(unittest.TestCase):
+    @patch("builtins.print")
+    def test_happy_path(self, mock_print):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            denylist = {"bad.com", "worse.com"}
+            allowlist = {"good.com"}
+            write_lists(temp_dir, denylist, allowlist)
+
+            with open(os.path.join(temp_dir, "Consolidated-Denylist.txt"), "r") as f:
+                self.assertEqual(f.read(), "bad.com\nworse.com\n")
+            with open(os.path.join(temp_dir, "Consolidated-Allowlist.txt"), "r") as f:
+                self.assertEqual(f.read(), "@@good.com\n")
+
+    @patch("adguard.scripts.extract_domains.os.path.exists")
+    def test_base_dir_not_exists(self, mock_exists):
+        mock_exists.return_value = False
+        # Should not raise exception
+        write_lists("/fake/dir", {"bad.com"}, {"good.com"})
+        mock_exists.assert_called_once_with("/fake/dir")
+
+    @patch("adguard.scripts.extract_domains.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_open_exception(self, mock_file, mock_exists):
+        mock_exists.return_value = True
+        mock_file.side_effect = PermissionError("Permission denied")
+        with self.assertRaises(PermissionError):
+            write_lists("/fake/dir", {"bad.com"}, {"good.com"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Missing test coverage for `adguard/scripts/extract_domains.py` `write_lists` function, including exception handling.
📊 **Coverage:** Added tests for the happy path (file writing), missing base directory (`os.path.exists` check), and `open()` exceptions (e.g. `PermissionError`).
✨ **Result:** Enhanced test suite reliability by ensuring `write_lists` handles edge cases gracefully.

---
*PR created automatically by Jules for task [16470085670732424504](https://jules.google.com/task/16470085670732424504) started by @abhimehro*