### PR TITLE
fix(a11y): HTML meter for performance metrics (salvages #1893)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -492,3 +492,7 @@ Added `empty-state` class on empty directory listing `<li>` without removing ski
 ## 2026-08-02 - Improved empty states and a11y focus rings
 **Learning:** Shell-generated HTML reports often neglect a11y focus states for `.skip-link` and lack robust visual distinction for empty states (e.g. no recommendations).
 **Action:** Always verify keyboard accessibility (`:focus` with clear outline) and add icons/soft backgrounds for empty states to make them visibly distinct.
+
+## 2026-08-04 - Native HTML Meter for Data Visualization
+**Learning:** Presenting system metrics (like CPU load or disk usage) as raw text in HTML reports misses an opportunity for accessible data visualization.
+**Action:** Use the native HTML5 `<meter>` element to provide a semantic, accessible, and visually appealing representation of scalar measurements within known ranges, ensuring appropriate `aria-label`, `min`, `max`, `low`, and `high` attributes are set.

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -643,9 +643,9 @@ EOF
 	[[ $disk_usage -gt 90 ]] && disk_status="critical"
 
 	cat >>"$report_file" <<EOF
-            <tr><th scope="row">CPU Load</th><td>$cpu_load</td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">CPU Load</th><td><meter aria-label="CPU Load" min="0" max="8" low="2" high="4" optimum="1" value="$cpu_load">$cpu_load</meter></td><td class="$cpu_status">$(echo $cpu_status | tr '[:lower:]' '[:upper:]')</td></tr>
             <tr><th scope="row">Memory Free Pages</th><td>$memory_usage</td><td class="good">GOOD</td></tr>
-            <tr><th scope="row">Disk Usage</th><td>${disk_usage}%</td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
+            <tr><th scope="row">Disk Usage</th><td><meter aria-label="Disk Usage" min="0" max="100" low="70" high="90" optimum="50" value="${disk_usage}">${disk_usage}%</meter></td><td class="$disk_status">$(echo "$disk_status" | tr '[:lower:]' '[:upper:]')</td></tr>
         </table>
     </section>
     


### PR DESCRIPTION
## Summary
Salvages unique UX from CONFLICTING [#1893](https://github.com/abhimehro/personal-config/pull/1893): semantic `<meter>` for CPU load and disk usage in `performance_optimizer.sh`, plus append-only Palette journal entry.

## ELIR
- **Purpose:** Accessible scalar visualization for maintenance HTML reports.
- **Security:** No trust-boundary change; HTML report generation only.
- **Fails if:** `cpu_load`/`disk_usage` are non-numeric (pre-existing assumption).
- **Verify:** `bash -n maintenance/bin/performance_optimizer.sh`; inspect generated report row markup.
- **Maintain:** Keep journal append-only; do not checkout PR `.jules/palette.md` wholesale.

## Test plan
- [x] Diff limited to meter markup + journal append
- [ ] Human: spot-check report HTML in browser

S1: draft only — do not auto-merge.