### PR TITLE
chore: exclude devin-handoff from lint-errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:  ## Run all linters (requires Trunk; runs: trunk check --all)
 lint-errors:  ## Fail on SC2155/SC2145 correctness violations (run without Trunk; regression gate)
 	@echo "Checking for SC2155 (declare+assign) and SC2145 (arg mixing) violations..."
 	@bash -c 'set -euo pipefail; \
-		output=$$(find . \( -path "./.git" -o -path "./.trunk" -o -path "./.cursor" -o -path "./configs/.config/mole" -o -path "./mole.*" -o -path "*/archive" -o -path "./node_modules" \) -prune -o \
+		output=$$(find . \( -path "./.git" -o -path "./.trunk" -o -path "./.cursor" -o -path "./configs/.config/mole" -o -path "./mole.*" -o -path "*/archive" -o -path "./node_modules" -o -path "./devin-handoff" \) -prune -o \
 			-name "*.sh" -type f -exec shellcheck --include=SC2155,SC2145 --format=gcc {} \; || { \
 				echo "❌ shellcheck failed to run correctly (missing, usage error, or parse error)"; \
 				exit 1; \


### PR DESCRIPTION
Excluded `devin-handoff` from `make lint-errors` find path to fix `SC2155` violations from submodule code.

---
*PR created automatically by Jules for task [5517181312139736333](https://jules.google.com/task/5517181312139736333) started by @abhimehro*