### PR TITLE
🛡️ Sentinel: Fix TruffleHog false positives on 40-character test function names

### DIFF
--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -78,7 +78,7 @@ class TestGenerateReport(unittest.TestCase):
         with self.assertRaises(AttributeError):
             generate_report.format_lists([], [123], [])
 
-    def test_format_lists_invalid_escalated_data(self):
+    def test_format_lists_invalid_escalated_data_raises(self):
         # Invalid elements in escalated_data trigger AttributeError
         with self.assertRaises(AttributeError):
             generate_report.format_lists([], [], [123])

--- a/tests/test_http_response_splitting.py
+++ b/tests/test_http_response_splitting.py
@@ -307,7 +307,7 @@ class TestHTTPResponseSplitting(unittest.TestCase):
             "Path-based bypass attempt should be blocked",
         )
 
-    def test_query_string_bypass_attempt_blocked(self):
+    def test_query_string_bypass_attempt_is_blocked(self):
         """Test that query string attacks are blocked (e.g., http://evil.com?ref=http://example.com)."""
         self._test_origin_rejection(
             "http://evil.com?ref=http://example.com",

--- a/tests/test_parse_inventory.py
+++ b/tests/test_parse_inventory.py
@@ -102,7 +102,7 @@ class TestParseInventory(unittest.TestCase):
             _parse_repo_name("### [  owner/repo-name  ](url)"), "owner/repo-name"
         )
 
-    def test_parse_repo_name_invalid_link_format(self):
+    def test_parse_repo_name_with_invalid_link_format(self):
         self.assertIsNone(_parse_repo_name("### no-link"))
 
     def test_parse_repo_name_invalid_prefix(self):
@@ -118,7 +118,7 @@ class TestParseInventory(unittest.TestCase):
 
     # --- _load_inventory_lines ---
 
-    def test_load_inventory_lines_file_not_found(self):
+    def test_load_inventory_lines_when_file_not_found(self):
         lines = _load_inventory_lines("nonexistent_file_xyz_123.txt")
         self.assertEqual(list(lines), [])
 
@@ -153,7 +153,7 @@ class TestParseInventory(unittest.TestCase):
 
     # --- _get_pr_category ---
 
-    def test_get_pr_category_superseded_no_files(self):
+    def test_get_pr_category_superseded_with_no_files(self):
         info = self._build_info("CLEAN", self._recent_iso(), with_files=False)
         self.assertEqual(_get_pr_category(info, "C", now=None), "SUPERSEDED")
 

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -96,7 +96,7 @@ class TestApplyWorkflowUpdates(unittest.TestCase):
         self.assertNotIn("v7.0.1.0.1", result)
         self.assertEqual(result.count("actions/upload-artifact@v7.0.1"), 3)
 
-    def test_distinct_replacements_still_applied(self):
+    def test_distinct_replacements_are_still_applied(self):
         text = "uses: actions/checkout@v3\n" "uses: actions/upload-artifact@v4\n"
         replacements = [
             {"old": "uses: actions/checkout@v3", "new": "uses: actions/checkout@v4"},
@@ -290,7 +290,7 @@ class TestRunPerformanceOptimizer(unittest.TestCase):
 
 class TestExecuteConfiguredCommands(unittest.TestCase):
     @patch("repository_automation_tasks.run_shell_command")
-    def test_execute_configured_commands_success(self, mock_run_shell_command):
+    def test_execute_configured_commands_are_successful(self, mock_run_shell_command):
         mock_run_shell_command.side_effect = lambda cmd, timeout: {
             "exit_code": 0,
             "stdout": f"ran {cmd}",


### PR DESCRIPTION
* 🚨 Severity: LOW
* 💡 Vulnerability: TruffleHog Lob API key detector falsely flags 40-character strings starting with `test_`.
* 🎯 Impact: CI/CD credential checks fail due to test function names being exactly 40 characters.
* 🔧 Fix: Rename the 7 affected test functions to have lengths other than 40 characters.
* ✅ Verification: `make verify-credentials` passes cleanly and `make test-all` passes.

---
*PR created automatically by Jules for task [3523391936168985797](https://jules.google.com/task/3523391936168985797) started by @abhimehro*