### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection / SSRF in PR triage scripts

### DIFF
--- a/scratch_inventory.py
+++ b/scratch_inventory.py
@@ -4,12 +4,19 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
 from gh_token_env import load_gh_token_env
+from pr_reference import parse_repo_name
 from spreadsheet_safety import escape_spreadsheet_formula
 
 
 def _fetch_repo_prs(repo):
     repo_prs = []
     env = load_gh_token_env()
+
+    # SECURITY: Validate the repo name to prevent command injection / SSRF.
+    if not parse_repo_name(repo):
+        print(f"Skipping invalid repo reference: {repo}")
+        return []
+
     try:
         res = subprocess.run(
             [

--- a/scratch_triage.py
+++ b/scratch_triage.py
@@ -4,6 +4,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
 from gh_token_env import load_gh_token_env
+from pr_reference import parse_repo_name
 
 repos = [
     "abhimehro/personal-config",
@@ -16,6 +17,12 @@ repos = [
 
 
 def run_cmd(cmd):
+    # SECURITY: Prevent command injection in PR triage scripts (CWE-78)
+    if not isinstance(cmd, list):
+        raise ValueError("run_cmd requires a list of arguments, not a string")
+    if cmd[0] != "gh":
+        raise ValueError("run_cmd may only execute the 'gh' CLI")
+
     env = load_gh_token_env()
     try:
         res = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=120)
@@ -111,6 +118,12 @@ def group_prs(all_prs, triage_md):
 
 def _fetch_repo_prs(repo):
     repo_prs = []
+
+    # SECURITY: Validate the repo name to prevent command injection / SSRF.
+    if not parse_repo_name(repo):
+        print(f"Skipping invalid repo reference: {repo}")
+        return []
+
     success, stdout, _ = run_cmd(
         [
             "gh",


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The `_fetch_repo_prs` function in `scratch_inventory.py` and `scratch_triage.py` takes a repository name string and directly passes it to `subprocess.run` invoking the `gh` CLI tool. While `shell=True` was not used, passing an invalid or malicious string could still result in argument injection or Server-Side Request Forgery depending on how the `gh` tool parses the `--repo` flag inputs. In `scratch_triage.py`, `run_cmd` lacked safety validations.
* 🎯 Impact: If a malicious repository string is provided, it could lead to unauthorized API requests (SSRF) or argument injection, which compromises the integrity of the automation scripts.
* 🔧 Fix: Integrated `parse_repo_name` from `pr_reference.py` to securely validate repository names before fetching data. Hardened the `run_cmd` wrapper in `scratch_triage.py` to ensure only the `gh` CLI can be executed and only as a list.
* ✅ Verification: Verified by running `make test-all` and ensuring all tests pass without regressions, along with manual review of the script changes.

---
*PR created automatically by Jules for task [14196950593631364451](https://jules.google.com/task/14196950593631364451) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/personal-config/pull/1980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->