### PR TITLE
⚡ Bolt: O(1) hash map lookup for draft fixes in generate_report.py

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -30,8 +30,10 @@ The automated PR review agent successfully processed the backlog across 5 reposi
 
 def process_draft_fixes(results, draft_fixes):
     new_escalated = []
+    # ⚡ Bolt Optimization: Convert draft_fixes to a set for O(1) hash map lookup instead of O(n) list iteration inside the loop
+    draft_fixes_set = set(draft_fixes)
     for e in results.get("escalated", ()):
-        if f"{e[0]}#{e[1]}" in draft_fixes:
+        if f"{e[0]}#{e[1]}" in draft_fixes_set:
             results["merged"].append((e[0], e[1], e[2]))
         else:
             new_escalated.append(e)


### PR DESCRIPTION
* 💡 What: Converted the `draft_fixes` list to a set before iterating over escalated PRs in `process_draft_fixes` to allow O(1) lookups.
* 🎯 Why: To replace an O(n^2) operation (O(n) membership check inside an O(n) loop) with an O(n) operation using O(1) set membership lookups, directly addressing the backend performance rule: "Replace O(n^2) nested loop with O(n) hash map lookup".
* 📊 Impact: Significantly speeds up report generation when processing large volumes of escalated PRs and draft fixes by reducing membership check time.
* 🔬 Measurement: `make test-all` completes successfully, maintaining behavior while providing better computational complexity.

---
*PR created automatically by Jules for task [13877102648669483843](https://jules.google.com/task/13877102648669483843) started by @abhimehro*