### PR TITLE
chore(repo-health): repair agent-shell docs and maintenance schedule drift

### DIFF
--- a/.devin/rules/agent-shell.md
+++ b/.devin/rules/agent-shell.md
@@ -4,10 +4,11 @@
 
 - OS shell is bash/sh on Ubuntu
 - No Fish
-- Prefer plain POSIX commands in blueprint /
+- Prefer plain POSIX commands in blueprint / setup scripts
 
 ## Local workstation
 
 - Login shell is Fish
-- Use or for agent commands
-- See
+- Use `agent-zsh -c '…'` or `agent-bash -c '…'` for agent commands
+- See `AGENTS.md` (Agent shell section) and
+  `docs/AGENT_SHELL_CONFIG_MATRIX.md`

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,7 +1,19 @@
 ---
-name: Custom issue template
-about: Describe this issue template's purpose here.
+name: General
+about: Catch-all for questions, docs, or chores that are not a bug or feature
 title: ""
 labels: ""
 assignees: ""
 ---
+
+## Summary
+
+<!-- What do you need? -->
+
+## Context
+
+<!-- Links, commands, or files involved. -->
+
+## Desired outcome
+
+<!-- What does “done” look like? -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,11 +586,12 @@ databases to start. The dev workflow is: edit scripts, lint, and run tests.
 | Shell tests only           | `make test`                                      | Fastest full suite; 47 `tests/test_*.sh`, 3 expected macOS-only skips (fish, BSD sed, 1Password socket)                                                                                                           |
 | Smoke tests (pre-commit)   | `make test-quick`                                | 3 fast cross-platform tests; ~5s; defined in Makefile `test-quick` target                                                                                                                                        |
 | All tests (shell + Python) | `make test-all`                                  | Runs shell tests in parallel, then Python tests. Platform-specific shell tests emit `SKIP:` and exit 77 on Linux/CI.                                                                                             |
-| Single Python module       | `python3 -m unittest tests.test_path_validation` | Mostly stdlib; some tests (e.g. `test_repository_automation_common.py`) need `pip install pyyaml`                                                                                                                |
-| Python tests only          | `make test-python`                               | Mostly stdlib; install `pyyaml` (`pip install pyyaml`) for the full suite                                                                                                                                        |
+| Single Python module       | `python3 -m unittest tests.test_path_validation` | Mostly stdlib; some tests (e.g. `test_repository_automation_common.py`) need `pip install -r requirements.txt` (`pyyaml==6.0.3`)                                                                                |
+| Python tests only          | `make test-python`                               | Mostly stdlib; install via `python3 -m pip install -r requirements.txt` (`pyyaml==6.0.3`) for the full suite                                                                                                    |
 | Lint (all)                 | `make lint`                                      | Trunk downloads its own tool versions on first run                                                                                                                                                               |
 | Lint (correctness gate)    | `make lint-errors`                               | SC2155/SC2145 only; exits non-zero on violations. Fast regression gate.                                                                                                                                          |
 | Format                     | `make lint-fix`                                  | Auto-fixes where supported                                                                                                                                                                                       |
+| Auth hygiene (optional)    | `make verify-credentials`                        | Runs `scripts/verify-repo-auth-hygiene.sh` (trufflehog `--only-verified` + password grep)                                                                                                                        |
 
 ### Non-obvious caveats
 
@@ -601,8 +602,8 @@ databases to start. The dev workflow is: edit scripts, lint, and run tests.
   downloads shellcheck, shfmt, ruff, black, prettier, etc. into `.trunk/`.
   Subsequent runs are fast. The update script installs the Trunk launcher, but
   tool downloads happen lazily.
-- **`requirements.txt`**: The root `requirements.txt` contains `pyyaml`, which
-  is needed by the full test suite (e.g.,
+- **`requirements.txt`**: The root `requirements.txt` pins `pyyaml==6.0.3`,
+  which is needed by the full test suite (e.g.,
   `tests/test_repository_automation_common.py` exercises
   `.github/scripts/repository_automation_common.py`). The Devin environment
   blueprint installs this dependency automatically; otherwise run
@@ -662,37 +663,16 @@ command shell.
 
 ### Local command pattern
 
-## main...origin/main
+```bash
+agent-zsh -c '<command>'    # primary
+agent-bash -c '<command>'   # fallback
+agent-term-doctor           # diagnostics
+agent-session               # doctor then interactive agent-zsh
+```
 
-?? .agents/ ?? .claude/ ?? .cursor/ ?? .github/github-app.yml ?? .trunk/ ??
-.vscode/ ?? .windsurf/
-
-## main...origin/main
-
-## ?? .agents/ ?? .claude/ ?? .cursor/ ?? .github/github-app.yml ?? .trunk/ ?? .vscode/ ?? .windsurf/ === agent-term-doctor === log: /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184640Z-29691.log PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read login shell parent_comm=/bin/sh PASS agent-zsh workspace cd ok PASS agent-zsh unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered + pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git --no-pager returns output (0927973 fix: neutralize middle-dot in langs card alt text) stdin_tty=no stdout_tty=no stderr_tty=no
-
-INTERPRETATION
-
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
-
----
-
-## summary warnings=1 failures=0 status=warn exit=1 latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log === agent-term-doctor === log: /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184641Z-29878.log PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read login shell parent_comm=/bin/bash NOTE parent looks POSIX (/bin/bash) PASS agent-zsh workspace cd ok PASS agent-zsh unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered + pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git --no-pager returns output (0927973 fix: neutralize middle-dot in langs card alt text) stdin_tty=no stdout_tty=no stderr_tty=no
-
-INTERPRETATION
-
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
-
----
-
-summary warnings=1 failures=0 status=warn exit=1
-latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log
+Launchers live in-repo under `configs/bin/agent-*` (synced to `~/bin` on the
+Mac). Profiles: `configs/.config/agent-shell/`. Prefer non-interactive-safe env:
+`PYTHONUNBUFFERED=1`, `PAGER=cat`, `GIT_PAGER=cat`.
 
 ### Host-specific notes
 
@@ -702,7 +682,7 @@ latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log
 | Cursor CLI              | + this file              | No — prefix commands                     |
 | Mistral Vibe            | + this file              | No — prefix commands                     |
 | Claude Code             | + repo docs              | No — prefix commands                     |
-| Codex                   |                          | No — prefix commands                     |
+| Codex                   | + repo docs              | No — prefix commands                     |
 | Devin cloud             | (Ubuntu bash)            | N/A (no Fish on VM)                      |
 | Antigravity/Gemini      | + repo                   | No — prefix commands                     |
 | Raycast Script Commands | shebang on each script   | N/A if shebang is bash/zsh               |
@@ -714,5 +694,6 @@ latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log
   configured
 - Do **not** change the macOS login shell away from Fish
 - Prefer absolute or PATH-resolved over assuming Fish abbreviations
-- Full matrix:
-- Launcher details:
+- Full matrix: [`docs/AGENT_SHELL_CONFIG_MATRIX.md`](docs/AGENT_SHELL_CONFIG_MATRIX.md)
+- Launcher details: [`configs/.config/agent-shell/README.md`](configs/.config/agent-shell/README.md)
+- Raycast: [`docs/RAYCAST_AGENT_SHELL.md`](docs/RAYCAST_AGENT_SHELL.md)

--- a/configs/.config/agent-shell/README.md
+++ b/configs/.config/agent-shell/README.md
@@ -107,4 +107,5 @@ For AI chats that execute shell tools, prefer asking: â€œrun via `agent-zsh -c`â
 
 ## Full host matrix
 
-See for Cursor, Vibe, Claude, Codex, Devin, Antigravity, and Raycast.
+See [`docs/AGENT_SHELL_CONFIG_MATRIX.md`](../../../docs/AGENT_SHELL_CONFIG_MATRIX.md)
+for Cursor, Vibe, Claude, Codex, Devin, Antigravity, and Raycast.

--- a/docs/AGENT_SHELL_CONFIG_MATRIX.md
+++ b/docs/AGENT_SHELL_CONFIG_MATRIX.md
@@ -1,6 +1,6 @@
 # Agent shell configuration matrix
 
-Last updated: 2026-08-04
+Last updated: 2026-08-13
 
 This doc explains **what is shared**, **what is separate**, and **where to
 configure** each agent host so local Fish never breaks POSIX agent commands.
@@ -10,173 +10,125 @@ configure** each agent host so local Fish never breaks POSIX agent commands.
 | Layer                                                                    | What it controls                                    | Shared across tools?                            | Fish risk                                            |
 | :----------------------------------------------------------------------- | :-------------------------------------------------- | :---------------------------------------------- | :--------------------------------------------------- |
 | macOS login shell                                                        | Interactive human terminal (Fish)                   | OS-wide                                         | N/A (intentional)                                    |
-| +                                                                        | Clean POSIX env for agents                          | **Shared primitive** used by all local tools    | None if used                                         |
+| `agent-zsh` / `agent-bash`                                               | Clean POSIX env for agents                          | **Shared primitive** used by all local tools    | None if used                                         |
 | IDE terminal profile (Cursor/VS Code/Windsurf)                           | Integrated terminal + often agent/automation shells | Per IDE user settings (not synced to cloud VMs) | High if default is Fish                              |
-| Local CLI agents (Vibe, Claude Code, Codex, Cursor CLI, Antigravity CLI) | How the agent spawns shell tools on this Mac        | Per-product config + repo /                     | High unless prefixed or IDE/default shell overridden |
-| Cloud agents (Devin, cloud sandboxes)                                    | Remote Linux VM shell                               | **Separate** ( / VM image)                      | Low (no Fish)                                        |
+| Local CLI agents (Vibe, Claude Code, Codex, Cursor CLI, Antigravity CLI) | How the agent spawns shell tools on this Mac        | Per-product config + repo `AGENTS.md` / rules   | High unless prefixed or IDE/default shell overridden |
+| Cloud agents (Devin, cloud sandboxes)                                    | Remote Linux VM shell                               | **Separate** (blueprint / VM image)             | Low (no Fish)                                        |
 | Raycast Script Commands / AI Terminal                                    | Explicit shebang or Terminal extension command      | Per script / per invocation                     | Low if shebang is bash/zsh                           |
 
-**Key rule:** nothing auto-inherits unless the **host tool** is configured to
-launch it, or the agent is instructed to prefix commands.
+**Key rule:** nothing auto-inherits `agent-zsh` unless the **host tool** is
+configured to launch it, or the agent is instructed to prefix commands.
 
 ## Shared local primitive (configure once)
 
-## === agent-term-doctor === log: /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184634Z-28786.log PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read login shell parent_comm=/bin/sh PASS agent-zsh workspace cd ok PASS agent-zsh unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered + pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git --no-pager returns output (0927973 fix: neutralize middle-dot in langs card alt text) stdin_tty=no stdout_tty=no stderr_tty=no
+In-repo sources:
 
-INTERPRETATION
+- Launchers: `configs/bin/agent-{zsh,bash,session,term-doctor,shell-selftest}`
+- Profiles: `configs/.config/agent-shell/` (`zshrc`, `zshenv`, `bashrc`)
+- Overview: `configs/.config/agent-shell/README.md`
 
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
+Typical install on the Mac: symlink or copy launchers onto `PATH` (for example
+`~/bin`), then:
 
----
+```bash
+agent-zsh -c 'git status -sb'
+agent-bash -c 'git status -sb'
+agent-term-doctor
+```
 
-## summary warnings=1 failures=0 status=warn exit=1 latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log === agent-term-doctor === log: /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184635Z-28978.log PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read login shell parent_comm=/bin/bash NOTE parent looks POSIX (/bin/bash) PASS agent-zsh workspace cd ok PASS agent-zsh unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered + pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git --no-pager returns output (0927973 fix: neutralize middle-dot in langs card alt text) stdin_tty=no stdout_tty=no stderr_tty=no
+Doctor logs (local only; do not commit):
 
-INTERPRETATION
-
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
-
----
-
-summary warnings=1 failures=0 status=warn exit=1
-latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log
-
-Managed copy (for version control / sync):
+```text
+~/.local/state/agent-term-doctor/session-<utc>-<pid>.log
+~/.local/state/agent-term-doctor/latest.log
+```
 
 ## Per-host configuration
 
 ### 1. Cursor IDE (local)
 
-- **User settings:**
-- **Workspace settings:**
-- Set:
-  - =
-  - ->
-  - profiles for , ,
-- **Does not sync** to Devin/cloud VMs.
-- Cursor CLI () is separate from IDE terminal profiles. CLI still needs /
-  explicit .
+- **User settings:** `~/Library/Application Support/Cursor/User/settings.json`
+- **Workspace settings:** `.vscode/settings.json`
+- Set `terminal.integrated.defaultProfile.osx` / automation profile to
+  `agent-zsh` when you want the IDE agent terminal on the POSIX launcher
+- **Does not sync** to Devin/cloud VMs
+- Cursor CLI (`agent`) is separate from IDE terminal profiles — still needs
+  `agent-zsh -c` / explicit instructions
 
 ### 2. Cursor CLI
 
-- Config: (permissions, attribution, sandbox)
+- Config: `~/.cursor/cli-config.json` (permissions, attribution, sandbox)
 - Shell behavior: follows process environment + instructions in repo
-- Action: keep allowlist broad enough for / , and document prefix in
+- Action: document prefix in `AGENTS.md` / `.cursor/rules/agent-shell.mdc`
 
 ### 3. Mistral Vibe
 
-- Config:
+- Config: `~/.vibe/config.toml`, `~/.vibe/AGENTS.md`
 - Runs tools **locally**; bash tool often starts under login shell context
-- Action:
-  - Prefer commands via
-  - Keep interactive shells denylisted (already present)
-  - Optional: add / to bash allowlist prefixes
-- Vibe config is **local-only**; not shared with Devin.
+- Action: prefer commands via `agent-zsh -c`; keep interactive shells denylisted
+- Vibe config is **local-only**; not shared with Devin
 
 ### 4. Claude Code
 
-- Global: ,
-- Repo: /
-- Action: shell policy in + repo
-- Hooks remain product-specific (1Password validate, LiveReview)
+- Global: `~/.claude/settings.json`
+- Repo: `AGENTS.md` / `CLAUDE.md`
+- Action: shell policy in repo docs; hooks remain product-specific
 
 ### 5. Codex
 
-- Global: ,
-- Action: same shell policy section in
+- Global: `~/.codex/config.toml`
+- Action: same shell policy section in `AGENTS.md`
 - MCP/server config is separate from shell launcher
 
 ### 6. Devin (cloud)
 
-- Repo: (initialize + maintenance on **Ubuntu**)
-- Local companion: , hooks, rules
-- Remote shell is system / — **no Fish**, no unless you install it in
-- Action: keep blueprint POSIX-only; add knowledge notes for local vs cloud
-  differences
-- **Does not use** Cursor
+- Repo: `.devin/` (initialize + maintenance on **Ubuntu**)
+- Local companion: `.devin/rules/agent-shell.md`, hooks, rules
+- Remote shell is system bash/sh — **no Fish**, no `~/bin/agent-zsh` unless you
+  install it in the VM
+- Action: keep blueprint POSIX-only; document local vs cloud differences
 
 ### 7. Antigravity / Gemini
 
-- Local state: ,
-- Repo hints: , /
-- CLI settings: (editor, permissions; not macOS login shell)
+- Local IDE settings under Application Support (separate from Cursor)
+- Repo hints: `AGENTS.md`, agent rules
 - Action: document in repo agent guides; cloud/IDE sides still differ
 
 ### 8. Raycast
 
-- **Script Commands:** interpreter comes from the script shebang (, , ). They do
-  **not** use Fish unless shebang says so.
-- **AI Terminal ():** runs commands in a shell on this Mac. Prefer:
-  - from AI instructions, or
-  - a Script Command wrapper that calls
-- **AI Extensions custom instructions:** Settings -> extension -> Ask tool ->
-  Custom Instructions
-- Raycast does not read Cursor terminal profiles.
+- **Script Commands:** interpreter comes from the script shebang (`bash`,
+  `zsh`, `osascript`). They do **not** use Fish unless the shebang says so.
+- **AI Terminal:** runs commands in a shell on this Mac. Prefer
+  `agent-zsh -c '…'` from AI instructions, or a Script Command wrapper.
+- Details: [`docs/RAYCAST_AGENT_SHELL.md`](RAYCAST_AGENT_SHELL.md)
 
 ## Sync vs separate
 
-| Artifact               | Cursor IDE               | Local CLIs    | Devin cloud              | Raycast                |
-| :--------------------- | :----------------------- | :------------ | :----------------------- | :--------------------- |
-| launchers              | optional default profile | prefix / PATH | install in VM if desired | shebang or wrapper     |
-| shell policy           | yes (repo)               | yes           | yes (guidance)           | yes (if AI reads repo) |
-| IDE terminal profile   | yes                      | no            | no                       | no                     |
-|                        | no                       | no            | yes                      | no                     |
-|                        | no                       | Vibe only     | no                       | no                     |
-| Script Command shebang | no                       | no            | no                       | yes                    |
+| Artifact                 | Cursor IDE               | Local CLIs    | Devin cloud              | Raycast                |
+| :----------------------- | :----------------------- | :------------ | :----------------------- | :--------------------- |
+| `agent-zsh` launchers    | optional default profile | prefix / PATH | install in VM if desired | shebang or wrapper     |
+| shell policy in repo     | yes                      | yes           | yes (guidance)           | yes (if AI reads repo) |
+| IDE terminal profile     | yes                      | no            | no                       | no                     |
+| `.devin` blueprint       | no                       | no            | yes                      | no                     |
+| Vibe config              | no                       | Vibe only     | no                       | no                     |
+| Script Command shebang   | no                       | no            | no                       | yes                    |
 
 ## Recommended operator checklist
 
 1. Keep login shell = Fish
-2. Keep on PATH ()
-3. Cursor default + automation profile =
-4. Repo mandates
+2. Keep `agent-zsh` / `agent-bash` on `PATH` (for example `~/bin`)
+3. Optionally set Cursor default + automation profile to `agent-zsh`
+4. Repo mandates prefix via `AGENTS.md` / `.cursor/rules/agent-shell.mdc`
 5. Vibe/Claude/Codex instructions mirror the same rule
 6. Devin blueprint stays Ubuntu/bash
-7. Raycast scripts use or (or call )
-8. Run === agent-term-doctor === log:
-   /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184638Z-29292.log
-   PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash
-   -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read
-   login shell parent_comm=/bin/sh PASS agent-zsh workspace cd ok PASS agent-zsh
-   unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh
-   stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered +
-   pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted
-   PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst
-   reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git
-   --no-pager returns output (0927973 fix: neutralize middle-dot in langs card
-   alt text) stdin_tty=no stdout_tty=no stderr_tty=no
-
----
-
-INTERPRETATION
-
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
-
----
-
-summary warnings=1 failures=0 status=warn exit=1
-latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log after changes
+7. Raycast scripts use bash/zsh shebang (or call `agent-zsh`)
+8. Run `agent-term-doctor` after launcher or profile changes
 
 ## Quick verification
 
-## agent-zsh self-test shell=zsh ZDOTDIR=/Users/speedybee/.config/agent-shell PWD=/Users/speedybee/dev/abhimehro AGENT_WORKSPACE=/Users/speedybee/dev/abhimehro PYTHONUNBUFFERED=1 PAGER=cat git=ok python3=ok stdout-mark agent-bash self-test shell=bash BASH_ENV=/Users/speedybee/.config/agent-shell/bashrc PWD=/Users/speedybee/dev/abhimehro AGENT_WORKSPACE=/Users/speedybee/dev/abhimehro PYTHONUNBUFFERED=1 PAGER=cat git=ok python3=ok stdout-mark === agent-term-doctor === log: /Users/speedybee/.local/state/agent-term-doctor/session-20260804T184639Z-29473.log PASS found agent-zsh -> /Users/speedybee/bin/agent-zsh PASS found agent-bash -> /Users/speedybee/bin/agent-bash login_shell=unknown WARN could not read login shell parent_comm=/bin/sh PASS agent-zsh workspace cd ok PASS agent-zsh unbuffered + pager hardened PASS agent-zsh stdout captured PASS agent-zsh stderr emitted PASS agent-bash workspace cd ok PASS agent-bash unbuffered + pager hardened PASS agent-bash stdout captured PASS agent-bash stderr emitted PASS agent-bash rc loaded on -c burst agent-zsh 12/12 PASS agent-zsh burst reliable burst agent-bash 12/12 PASS agent-bash burst reliable PASS git --no-pager returns output (0927973 fix: neutralize middle-dot in langs card alt text) stdin_tty=no stdout_tty=no stderr_tty=no
-
-INTERPRETATION
-
-- PASS launchers + swallowed output later => suspect agent terminal tool/PTY,
-  not shell rc
-- Agents do NOT auto-switch from Fish; point them at agent-zsh or agent-bash
-- Prefer: agent-zsh -c ... fallback: agent-bash -c ...
-
----
-
-summary warnings=1 failures=0 status=warn exit=1
-latest=/Users/speedybee/.local/state/agent-term-doctor/latest.log
+```bash
+command -v agent-zsh agent-bash
+agent-shell-selftest
+agent-term-doctor
+agent-zsh -c 'pwd; git --no-pager rev-parse --is-inside-work-tree'
+```

--- a/docs/RAYCAST_AGENT_SHELL.md
+++ b/docs/RAYCAST_AGENT_SHELL.md
@@ -2,20 +2,34 @@
 
 ## Script Commands
 
-- Interpreter = shebang (use or )
-- Directory: (add via Settings → Script Commands)
+- Interpreter = shebang (use `#!/bin/bash` or `#!/bin/zsh`, not Fish)
+- Directory: add your Script Commands folder via Settings → Extensions → Script
+  Commands
 - Does not read Cursor terminal profiles
 
-## AI Terminal ()
+Suggested wrappers (if present in your Raycast scripts folder):
+
+- `agent-zsh-run.sh`
+- `agent-term-doctor.sh`
+- `agent-session.sh`
+
+## AI Terminal
 
 Raycast AI can run shell commands on this Mac. To avoid Fish:
 
-1. Prefix:
-2. Or use Script Command **Run in Agent Zsh**
+1. Prefix commands with `agent-zsh -c '…'`
+2. Or use a Script Command that invokes `agent-zsh`
 
 ## Suggested AI Extension custom instruction
 
 Settings → AI Extensions → Terminal → Custom Instructions:
+
+```text
+Prefer agent-zsh -c '<command>' for shell tools.
+Fallback: agent-bash -c '<command>'.
+Do not change the macOS login shell away from Fish.
+Do not emit raw Fish syntax.
+```
 
 ## Permissions
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -30,9 +30,10 @@ npm install -g pyright bash-language-server \
 1. Clone the `personal-config` repo:
 
 ```bash
-mkdir -p ~/Documents/dev
-cd ~/Documents/dev
+mkdir -p ~/dev
+cd ~/dev
 git clone git@github.com:<user>/personal-config.git
+cd ~/dev/personal-config
 ```
 
 2. Symlink or copy fish config:
@@ -230,10 +231,6 @@ windows:
         color: Green
         layout:
           cwd: /Users/speedybee/dev/personal-config
-      - title: dev-root
-        color: Blue
-        layout:
-          cwd: /Users/speedybee/Documents/dev
       - title: downloads
         color: Cyan
         layout:

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -8,8 +8,9 @@ clean, updated, and healthy with minimal manual intervention.
 **Current Status**: ✅ **Fully Operational**
 
 - **Scripts**: All working and tested with actionable notifications
-- **Automation**: 9 launch agents active (exit code 0)
-- **Last Update**: January 2026
+- **Automation**: 9 launch agents installed by `maintenance/install.sh`
+  (`com.abhimehrotra.maint.*` labels)
+- **Last Update**: August 2026
 - **Dependencies**: terminal-notifier (for interactive notifications)
 
 ## ⚡ Raycast Quick Actions
@@ -69,7 +70,11 @@ Under memory pressure, pausing or killing Apple diagnostic agents
 - Daily Nag Remover: 10:00 AM - Suppresses persistent screen capture alerts
 - Weekly Maintenance: Monday 9:00 AM - Comprehensive weekly tasks
 - Monthly Maintenance: 1st of month 6:00 AM - Deep system maintenance
-- ProtonDrive Backup: 3:15 AM - One-way home backup to ProtonDrive
+- Google Drive Backup (Light): 3:15 AM Tue–Sun — home backup light mode
+- Google Drive Backup (Full): Monday 4:00 AM — fuller Google Drive backup
+- ProtonDrive Backup: **archived** (`bin/archive/protondrive_backup.sh`); not
+  installed by `install.sh` (use `macos/com.abhimehrotra.protondrive-backup.plist`
+  only if you intentionally re-enable it)
 
 ### 🏥 Health Monitoring
 
@@ -206,31 +211,34 @@ UPDATE_MAS_APPS=1          # Auto-update Mac App Store apps
 
 ### Active Schedules
 
-1. **Daily Health Check** (`com.abhimehrotra.maintenance.healthcheck`)
+Labels below match what `maintenance/install.sh` writes
+(`com.abhimehrotra.maint.*`). Checked-in files under `maintenance/launchd/` may
+still use older `…maintenance.*` names — treat `install.sh` as authoritative.
+
+1. **Daily Health Check** (`com.abhimehrotra.maint.healthcheck`)
    - Time: 8:30 AM daily
    - Script: `health_check.sh`
    - Purpose: System health monitoring
    - Notifications: ✅ Click to view logs
 
-2. **Daily Brew Maintenance** (`com.abhimehrotra.maintenance.brew`)
+2. **Daily Brew Maintenance** (`com.abhimehrotra.maint.brew`)
    - Time: 10:00 AM daily
    - Script: `brew_maintenance.sh`
    - Purpose: Homebrew packages + comprehensive cask updates
    - Notifications: ✅ Click to view logs
 
-3. **Daily Nag Remover**
-   (`com.abhimehrotra.maintenance.screencapture-nag-remover`)
+3. **Daily Nag Remover** (`com.abhimehrotra.maint.screencapture-nag-remover`)
    - Time: 10:00 AM daily
    - Script: `screencapture_nag_remover.sh`
    - Purpose: Suppresses persistent macOS screen capture alerts
    - Note: Requires Full Disk Access for `/bin/bash`
 
-4. **Daily Service Monitor** (`com.abhimehrotra.maintenance.servicemonitor`)
+4. **Daily Service Monitor** (`com.abhimehrotra.maint.servicemonitor`)
    - Time: 8:35 AM daily
    - Script: `service_monitor.sh`
    - Purpose: Disables unused background services (without killing widgets)
 
-5. **Daily System Cleanup** (`com.abhimehrotra.maintenance.systemcleanup`)
+5. **Daily System Cleanup** (`com.abhimehrotra.maint.systemcleanup`)
    - Time: 9:00 AM daily (9:30 AM on Mondays to avoid collision)
    - Script: `system_cleanup.sh`
    - Purpose: System maintenance
@@ -248,11 +256,18 @@ UPDATE_MAS_APPS=1          # Auto-update Mac App Store apps
    - Purpose: system cleanup, editor cleanup, deep cleaner
    - Notifications: ✅ Click to view error summary
 
-8. **ProtonDrive Backup** (`com.abhimehrotra.maintenance.protondrivebackup`)
-   - Time: 3:15 AM daily
-   - Script: `bin/archive/protondrive_backup.sh` (archived path; install must
-     place or symlink it where the plist expects)
-   - Purpose: One-way home backup to ProtonDrive
+8. **Google Drive Backup (Light)** (`com.abhimehrotra.maint.googledrivebackup.light`)
+   - Time: 3:15 AM Tue–Sun
+   - Purpose: Light-mode Google Drive home backup
+
+9. **Google Drive Backup (Full)** (`com.abhimehrotra.maint.googledrivebackup.full`)
+   - Time: Monday 4:00 AM
+   - Purpose: Fuller Google Drive backup
+
+10. **ProtonDrive Backup** (archived — not installed by `install.sh`)
+    - Optional: `macos/com.abhimehrotra.protondrive-backup.plist`
+    - Script: `bin/archive/protondrive_backup.sh`
+    - Historical: `maintenance/launchd/com.abhimehrotra.maintenance.protondrivebackup.plist`
 
 ## 📊 Monitoring & Logs
 
@@ -323,14 +338,14 @@ terminal-notifier -title "Test" -message "Click me" \
 launchctl list | grep com.abhimehrotra
 
 # Reload if needed
-launchctl kickstart -k gui/$(id -u)/com.abhimehrotra.maintenance.healthcheck
+launchctl kickstart -k gui/$(id -u)/com.abhimehrotra.maint.healthcheck
 ```
 
 **Script Permissions**
 
 ```bash
 # Fix permissions
-chmod +x ~/Documents/dev/personal-config/maintenance/bin/*.sh
+chmod +x ~/dev/personal-config/maintenance/bin/*.sh
 ```
 
 **Log Directory Missing**
@@ -338,7 +353,7 @@ chmod +x ~/Documents/dev/personal-config/maintenance/bin/*.sh
 ```bash
 # Create log directories
 mkdir -p ~/Library/Logs/maintenance
-mkdir -p ~/Documents/dev/personal-config/maintenance/tmp
+mkdir -p ~/dev/personal-config/maintenance/tmp
 ```
 
 ## 🔄 Updates & Maintenance
@@ -368,4 +383,4 @@ Schedules & Settings**
 
 ---
 
-_Last Updated: January 2026 - System Status: Fully Operational_
+_Last Updated: August 2026 - Align docs with `install.sh` labels; ProtonDrive archived_

--- a/maintenance/SCHEDULE_SUMMARY.md
+++ b/maintenance/SCHEDULE_SUMMARY.md
@@ -1,7 +1,8 @@
 # 📅 Maintenance Automation Schedule - FINAL
 
-**Updated:** October 10, 2025\
-**Status:** ✅ All timings now match your pre-configured calendar events
+**Updated:** 2026-08-13 (aligned with `maintenance/install.sh`)
+
+**Status:** ✅ Schedule matches install-time LaunchAgents (`com.abhimehrotra.maint.*`)
 
 ## 🕐 Complete Schedule Overview
 
@@ -11,21 +12,27 @@
 | **9:00 AM**  | 🧹 System Cleanup       | Daily        | `system_cleanup.sh`              | Cache cleanup, temp files, logs                   |
 | **9:00 AM**  | 📅 Weekly Maintenance   | Monday       | `run_all_maintenance.sh weekly`  | quick cleanup, node, Google Drive, optimizers     |
 | **6:00 AM**  | 📆 Monthly Maintenance  | 1st of month | `run_all_maintenance.sh monthly` | system/editor cleanup, deep cleaner               |
-| **3:15 AM**  | ☁️ ProtonDrive Backup   | Daily        | `bin/archive/protondrive_backup.sh` | One-way home backup to ProtonDrive             |
+| **3:15 AM**  | ☁️ Google Drive (Light) | Tue–Sun      | (install.sh googledrive light)   | Light Google Drive home backup                    |
+| **4:00 AM**  | ☁️ Google Drive (Full)  | Monday       | (install.sh googledrive full)    | Fuller Google Drive backup                        |
 | **10:00 AM** | 🍺 Homebrew Maintenance | Daily        | `brew_maintenance.sh`            | Package updates, cask maintenance                 |
+
+> ProtonDrive one-way backup is **archived**
+> (`maintenance/bin/archive/protondrive_backup.sh`) and is not installed by
+> `maintenance/install.sh`.
 
 ## 🔗 Launch Agent Mapping
 
 ### Daily Agents
 
-- `com.abhimehrotra.maintenance.protondrivebackup.plist` → **3:15 AM daily**
-- `com.abhimehrotra.maintenance.healthcheck.plist` → **8:30 AM daily**
-- `com.abhimehrotra.maintenance.systemcleanup.plist` → **9:00 AM daily**
-- `com.abhimehrotra.maintenance.brew.plist` → **10:00 AM daily**
+- `com.abhimehrotra.maint.googledrivebackup.light.plist` → **3:15 AM Tue–Sun**
+- `com.abhimehrotra.maint.healthcheck.plist` → **8:30 AM daily**
+- `com.abhimehrotra.maint.systemcleanup.plist` → **9:00 AM daily**
+- `com.abhimehrotra.maint.brew.plist` → **10:00 AM daily**
 
 ### Weekly Agent
 
 - `com.abhimehrotra.maint.weekly.plist` → **9:00 AM Monday**
+- `com.abhimehrotra.maint.googledrivebackup.full.plist` → **4:00 AM Monday**
 
 ### Monthly Agent
 


### PR DESCRIPTION
## What

Weekly repo-health housekeeping: repair corrupted agent-shell docs and align maintenance schedule docs with `install.sh`.

## Why

Since 2026-08-10, `AGENTS.md` / agent-shell matrix / Raycast docs contained pasted `agent-term-doctor` logs and stripped backticks, which misguides coding agents. Maintenance docs still presented ProtonDrive as live and used outdated `com.abhimehrotra.maintenance.*` labels after #1931/#1932.

## How

- Rewrote agent-shell sections with pointers to clean matrix / Raycast / launcher README
- Aligned `maintenance/README.md` + `SCHEDULE_SUMMARY.md` to `install.sh` (`maint.*`, Google Drive light/full; ProtonDrive archived)
- Fixed `docs/SETUP.md` clone path to `~/dev`; documented `pyyaml==6.0.3`; replaced placeholder issue template; noted `make verify-credentials`
- Did **not** mutate Control D / Windscribe / live DNS launchd

## Testing

- Doc/path verification via `rg` + file existence checks (docs-only change)
- Confirmed workflow catalog still 18 YAML files matching `.github/workflows/README.md`
- Confirmed 47 `tests/test_*.sh` (AGENTS count still correct)

## Security

No security impact. Docs-only; no secrets, auth, or production network changes.

---

## Checklist

- [x] Documentation updated if behaviour changed
- [x] No secrets, tokens, or `.env` files included
- [ ] `make test-quick` passes locally (docs-only; skipped in cloud)
- [ ] `make lint` reports no new errors (docs-only)
- [x] Branch name follows the convention in CONTRIBUTING.md

### ELIR

PURPOSE: Restore trustworthy agent/maintenance docs after Aug 10 paste corruption and post-#1931 schedule drift.
SECURITY: Docs only; no live DNS/launchd mutation.
FAILS IF: Checked-in `maintenance/launchd/*` names are still treated as install truth without reading `install.sh`.
VERIFY: Skim AGENTS agent-shell section + maintenance schedule labels vs `install.sh`.
MAINTAIN: Never paste `agent-term-doctor` stdout into markdown.