### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Option Injection (CWE-88) in report-daemons-watchdog.sh

### DIFF
--- a/scripts/report-daemons-watchdog.sh
+++ b/scripts/report-daemons-watchdog.sh
@@ -16,7 +16,7 @@ log "start mode=observe-only uid=$(id -u)"
 
 found=0
 for name in ReportCrash ReportCrashService ReportMemoryException; do
-    pids="$(pgrep -x "$name" 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)"
+    pids="$(pgrep -x -- "$name" 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)"
     if [[ -n "$pids" ]]; then
         log "process=$name pids=$pids action=leave-alone"
         found=1
@@ -69,7 +69,7 @@ etime_to_seconds() {
 check_stuck() {
     local name="$1"
     local pid etime_raw cpu etime_sec role uid
-    for pid in $(pgrep -x "$name" 2>/dev/null); do
+    for pid in $(pgrep -x -- "$name" 2>/dev/null); do
         # etime = [[dd-]hh:]mm:ss on macOS; %cpu = instantaneous usage
         read -r etime_raw cpu uid <<<"$(ps -p "$pid" -o etime=,%cpu=,uid= 2>/dev/null)"
         [[ -n "${etime_raw:-}" && -n "${cpu:-}" ]] || continue


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: Option injection (CWE-88 variant) in `pgrep` where a process name starting with `-` could be interpreted as a flag.
* 🎯 Impact: Allows arbitrary flag injection to `pgrep`.
* 🔧 Fix: Added `--` delimiter before `$name` in `pgrep -x "$name"`.
* ✅ Verification: Verified script runs properly and logic is consistent with standard defenses.

---
*PR created automatically by Jules for task [14086110631975771875](https://jules.google.com/task/14086110631975771875) started by @abhimehro*