### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection (CWE-78) via eval in shopt restorations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -816,3 +816,8 @@ arguments when using `pgrep` or `pkill`.
 **Vulnerability:** `get_prs_summarize.py` invoked `gh` via `subprocess.check_output` without a timeout or the standardized `gh_token_env` loader, risking indefinite hangs on network requests (DoS) and potential inconsistent execution environments.
 **Learning:** Even in read-only data formatting scripts, all network-bound subprocess calls should have strict timeouts and utilize consistent authentication loading mechanisms to avoid stalling or failing silently.
 **Prevention:** Always use `subprocess.run` with a `timeout` argument and explicitly pass `env=load_gh_token_env()` when calling external APIs, rather than relying on `subprocess.check_output` with inherited environments.
+## 2026-08-15 - Command Injection Risk via eval in shopt restorations
+
+**Vulnerability:** Command Injection (CWE-78 variant). The scripts used `eval "$_nullglob_state"` to restore saved shell options. If a variable is compromised, `eval` would execute the payload as an arbitrary command.
+**Learning:** You do not need to use `eval` to execute saved safe shell commands like `shopt -s nullglob`. Direct unquoted execution `$_nullglob_state` correctly splits the string by spaces, safely calling `shopt` without evaluating shell metacharacters.
+**Prevention:** Avoid `eval` to execute stored commands or state restorations. Use direct unquoted execution when the command is simple and its arguments only rely on word-splitting.

--- a/configs/.config/mole/lib/clean/apps.sh
+++ b/configs/.config/mole/lib/clean/apps.sh
@@ -403,7 +403,7 @@ clean_orphaned_app_data() {
 					fi
 				done
 			done
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
+			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
 		fi
 	done
 	stop_section_spinner
@@ -855,7 +855,7 @@ clean_orphaned_container_stubs() {
 		done
 	done
 
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	if [[ $_ng_state == "shopt -"[su]" "* ]]; then $_ng_state; fi
 
 	if [[ $removed_count -gt 0 ]]; then
 		if [[ $DRY_RUN == "true" ]]; then

--- a/configs/.config/mole/lib/clean/user.sh
+++ b/configs/.config/mole/lib/clean/user.sh
@@ -787,8 +787,8 @@ cache_top_level_entry_count_capped() {
 		fi
 	done
 
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
+	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then $_dotglob_state; fi
 
 	[[ $count =~ ^[0-9]+$ ]] || count=0
 	printf '%s\n' "$count"
@@ -807,14 +807,14 @@ directory_has_entries() {
 	local item
 	for item in "$dir"/*; do
 		if [[ -e $item ]]; then
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
+			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then $_dotglob_state; fi
 			return 0
 		fi
 	done
 
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
+	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then $_dotglob_state; fi
 	return 1
 }
 
@@ -882,7 +882,7 @@ clean_app_caches() {
 		[[ -d "$container_dir/Data/Library/Caches" ]] || continue
 		process_container_cache "$container_dir"
 	done
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	if [[ $_ng_state == "shopt -"[su]" "* ]]; then $_ng_state; fi
 	stop_section_spinner
 
 	if [[ $found_any == "true" ]]; then
@@ -957,8 +957,8 @@ process_container_cache() {
 			[[ -e $item ]] || continue
 			safe_remove "$item" true || true
 		done
-		if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-		if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+		if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
+		if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then $_dotglob_state; fi
 	fi
 }
 
@@ -1088,8 +1088,8 @@ clean_group_container_caches() {
 					fi
 				done
 			fi
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
+			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then $_dotglob_state; fi
 
 			if [[ $candidate_changed == "true" ]]; then
 				total_size=$((total_size + candidate_size_kb))
@@ -1098,7 +1098,7 @@ clean_group_container_caches() {
 			fi
 		done
 	done
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
+	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then $_nullglob_state; fi
 
 	stop_section_spinner
 
@@ -1795,7 +1795,7 @@ clean_application_support_logs() {
 	if [[ $pipefail_was_set == "true" ]]; then
 		set -o pipefail
 	fi
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	if [[ $_ng_state == "shopt -"[su]" "* ]]; then $_ng_state; fi
 	stop_section_spinner
 	if [[ $found_any == "true" ]]; then
 		local size_human


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection (CWE-78) risk via `eval` used to restore `shopt` state variables in `user.sh` and `apps.sh`.
🎯 Impact: Allows arbitrary command execution if a variable is compromised.
🔧 Fix: Removed `eval` and replaced it with direct, unquoted variable execution which safely relies on bash word-splitting for the exact `shopt` arguments.
✅ Verification: Ran `make test-all` and verified the `eval` statements were successfully eliminated.

---
*PR created automatically by Jules for task [11456516281703044887](https://jules.google.com/task/11456516281703044887) started by @abhimehro*