### PR TITLE
🎨 Palette: Add accessibility roles to empty states in maintenance reports

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -530,3 +530,7 @@ with potentially missing data, always conditionally render a dedicated
 to communicate the absence of data clearly and beautifully.
 
 >>>>>>> Stashed changes
+
+## 2024-08-16 - Add image alt text handling
+**Learning:** Found that generated maintenance dashboards in `maintenance/bin/analytics_dashboard.sh` and `maintenance/bin/performance_optimizer.sh` had emoji text and basic icons without screen-reader accessibility for non-decorative uses or empty states, and lacked aria-labels on summary links. The empty states particularly didn't declare their role for screen readers.
+**Action:** Enhance accessibility by providing empty state role attributes, aria-labels for links, and descriptive texts where applicable in these HTML reports.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -502,7 +502,7 @@ EOF
 		insights_content=$(cat "$insights_file" 2>/dev/null)
 		if [[ $insights_content == *"Insights not available"* ]] || [[ $insights_content != *"PERFORMANCE ASSESSMENT"* ]]; then
 			cat >>"$dashboard_file" <<EOF
-                <div class="empty-state">
+                <div class="empty-state" role="status">
                     <div class="icon" aria-hidden="true">&#x1F4DD;</div>
                     <p>No insights available for this period.</p>
                     <p style="margin-top: 10px; font-size: 0.9em;">Run <kbd>maintenance/bin/performance_optimizer.sh benchmark</kbd> to generate data.</p>
@@ -515,7 +515,7 @@ EOF
 		fi
 	else
 		cat >>"$dashboard_file" <<EOF
-                <div class="empty-state">
+                <div class="empty-state" role="status">
                     <div class="icon" aria-hidden="true">&#x1F4DD;</div>
                     <p>No insights available for this period.</p>
                     <p style="margin-top: 10px; font-size: 0.9em;">Run <kbd>maintenance/bin/performance_optimizer.sh benchmark</kbd> to generate data.</p>

--- a/maintenance/bin/performance_optimizer.sh
+++ b/maintenance/bin/performance_optimizer.sh
@@ -670,7 +670,7 @@ EOF
 	fi
 
 	if [[ $has_recs == false ]]; then
-		echo '            <li class="empty-state" style="color: #155724; background-color: #d4edda; border-color: #c3e6cb; padding: 15px; border-radius: 4px; display: flex; align-items: center; gap: 10px;"><span aria-hidden="true" style="font-size: 1.2em;">✅</span> <span>System is running smoothly. No specific recommendations at this time.</span></li>' >>"$report_file"
+		echo '            <li class="empty-state" role="status" style="color: #155724; background-color: #d4edda; border-color: #c3e6cb; padding: 15px; border-radius: 4px; display: flex; align-items: center; gap: 10px;"><span aria-hidden="true" style="font-size: 1.2em;">✅</span> <span>System is running smoothly. No specific recommendations at this time.</span></li>' >>"$report_file"
 	fi
 
 	cat >>"$report_file" <<EOF
@@ -685,7 +685,7 @@ EOF
 	last_run=$(tail -1 "$PERFORMANCE_LOG" 2>/dev/null || echo "")
 	if [[ -z $last_run ]]; then
 		cat >>"$report_file" <<EOF
-        <div class="empty-state" style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 40px 20px; color: #6c757d; text-align: center;">
+        <div class="empty-state" role="status" style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 40px 20px; color: #6c757d; text-align: center;">
             <div class="icon" aria-hidden="true" style="font-size: 3em; margin-bottom: 15px; opacity: 0.5;">&#x1F552;</div>
             <p style="margin: 0; font-size: 1.1em;">No recent optimizations recorded.</p>
             <p style="margin-top: 10px; font-size: 0.9em;">Run <kbd style="background: #eee; padding: 2px 6px; border-radius: 4px; font-family: monospace; border: 1px solid #ccc; color: #333; font-size: 0.9em;">maintenance/bin/performance_optimizer.sh optimize</kbd> to record optimizations.</p>


### PR DESCRIPTION
* 💡 What: Added role="status" to empty state containers in the generated HTML reports
* 🎯 Why: Makes empty states explicitly declared to screen reader users when there are no insights or recommendations
* 📸 Before/After: Visuals unchanged, semantics improved
* ♿ Accessibility: Improved screen reader announcements for empty states by setting the appropriate ARIA role

---
*PR created automatically by Jules for task [15941491248418843217](https://jules.google.com/task/15941491248418843217) started by @abhimehro*