### PR TITLE
🎨 Palette: Add `<meter>` to Total Warnings metric

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -530,3 +530,8 @@ with potentially missing data, always conditionally render a dedicated
 to communicate the absence of data clearly and beautifully.
 
 >>>>>>> Stashed changes
+
+## 2026-08-17 - Add <meter> element for numeric counts
+
+**Learning:** When generating HTML reports with numeric metrics like total warnings, using a native `<meter>` element is visually more informative than displaying a plain text number. It also improves accessibility by using proper semantic `aria-label`, `min`, `max`, `low`, `high`, and `optimum` tags.
+**Action:** Use a native HTML5 `<meter>` element when visualizing numeric scalar data, like total warnings counts, in generated HTML reports.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -483,7 +483,10 @@ EOF
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
             </li>
             <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
-                <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
+                <div class="metric-value" id="total-warnings-value">
+                    ${total_warnings}
+                    <meter value="${total_warnings}" min="0" max="10" low="3" high="7" optimum="0" aria-label="Total Warnings: ${total_warnings}"></meter>
+                </div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
             </li>
 EOF


### PR DESCRIPTION
* 💡 What: Added an HTML5 `<meter>` element to the "Total Warnings" metric in the generated System Maintenance Dashboard (`maintenance/bin/analytics_dashboard.sh`).
* 🎯 Why: Previously, the total warnings count was displayed as a plain text number without visual bounds. Adding a `<meter>` element gives users instant visual feedback on how severe the warning count is relative to expected limits, matching the UX of the other metrics on the dashboard.
* 📸 Before/After: [Screenshots included via Playwright validation]
* ♿ Accessibility: Improved accessibility by using a semantic `<meter>` element with an `aria-label`, as well as bounded limits (`min`, `max`, `low`, `high`, `optimum`).

---
*PR created automatically by Jules for task [14401936892782023868](https://jules.google.com/task/14401936892782023868) started by @abhimehro*