### PR TITLE
fix(security): harden shell option restoration

### DIFF
--- a/configs/.config/mole/lib/clean/apps.sh
+++ b/configs/.config/mole/lib/clean/apps.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 
 readonly ORPHAN_AGE_THRESHOLD=${ORPHAN_AGE_THRESHOLD:-${MOLE_ORPHAN_AGE_DAYS:-30}}
 readonly CLAUDE_VM_ORPHAN_AGE_THRESHOLD=${MOLE_CLAUDE_VM_ORPHAN_AGE_DAYS:-7}
+
+_restore_shopt_state() {
+	local state="$1"
+	local expected_option="$2"
+	local -a parts=()
+	read -r -a parts <<<"$state"
+	if [[ ${#parts[@]} -eq 3 && ${parts[0]} == "shopt" && ( ${parts[1]} == "-s" || ${parts[1]} == "-u" ) && ${parts[2]} == "$expected_option" ]]; then
+		shopt "${parts[1]}" "${parts[2]}"
+	fi
+}
 # Args: $1=target_dir, $2=label
 clean_ds_store_tree() {
 	local target="$1"
@@ -403,7 +413,7 @@ clean_orphaned_app_data() {
 					fi
 				done
 			done
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
+			_restore_shopt_state "$_nullglob_state" nullglob
 		fi
 	done
 	stop_section_spinner
@@ -855,7 +865,7 @@ clean_orphaned_container_stubs() {
 		done
 	done
 
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	_restore_shopt_state "$_ng_state" nullglob
 
 	if [[ $removed_count -gt 0 ]]; then
 		if [[ $DRY_RUN == "true" ]]; then

--- a/configs/.config/mole/lib/clean/user.sh
+++ b/configs/.config/mole/lib/clean/user.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # User Data Cleanup Module
 set -euo pipefail
+
+_restore_shopt_state() {
+	local state="$1"
+	local expected_option="$2"
+	local -a parts=()
+	read -r -a parts <<<"$state"
+	if [[ ${#parts[@]} -eq 3 && ${parts[0]} == "shopt" && ( ${parts[1]} == "-s" || ${parts[1]} == "-u" ) && ${parts[2]} == "$expected_option" ]]; then
+		shopt "${parts[1]}" "${parts[2]}"
+	fi
+}
 clean_user_essentials() {
 	start_section_spinner "Scanning caches..."
 	safe_clean ~/Library/Caches/* "User app cache"
@@ -787,8 +797,8 @@ cache_top_level_entry_count_capped() {
 		fi
 	done
 
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+	_restore_shopt_state "$_nullglob_state" nullglob
+	_restore_shopt_state "$_dotglob_state" dotglob
 
 	[[ $count =~ ^[0-9]+$ ]] || count=0
 	printf '%s\n' "$count"
@@ -807,14 +817,14 @@ directory_has_entries() {
 	local item
 	for item in "$dir"/*; do
 		if [[ -e $item ]]; then
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+			_restore_shopt_state "$_nullglob_state" nullglob
+			_restore_shopt_state "$_dotglob_state" dotglob
 			return 0
 		fi
 	done
 
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-	if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+	_restore_shopt_state "$_nullglob_state" nullglob
+	_restore_shopt_state "$_dotglob_state" dotglob
 	return 1
 }
 
@@ -882,7 +892,7 @@ clean_app_caches() {
 		[[ -d "$container_dir/Data/Library/Caches" ]] || continue
 		process_container_cache "$container_dir"
 	done
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	_restore_shopt_state "$_ng_state" nullglob
 	stop_section_spinner
 
 	if [[ $found_any == "true" ]]; then
@@ -957,8 +967,8 @@ process_container_cache() {
 			[[ -e $item ]] || continue
 			safe_remove "$item" true || true
 		done
-		if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-		if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+		_restore_shopt_state "$_nullglob_state" nullglob
+		_restore_shopt_state "$_dotglob_state" dotglob
 	fi
 }
 
@@ -1088,8 +1098,8 @@ clean_group_container_caches() {
 					fi
 				done
 			fi
-			if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
-			if [[ $_dotglob_state == "shopt -"[su]" "* ]]; then eval "$_dotglob_state"; fi
+			_restore_shopt_state "$_nullglob_state" nullglob
+			_restore_shopt_state "$_dotglob_state" dotglob
 
 			if [[ $candidate_changed == "true" ]]; then
 				total_size=$((total_size + candidate_size_kb))
@@ -1098,7 +1108,7 @@ clean_group_container_caches() {
 			fi
 		done
 	done
-	if [[ $_nullglob_state == "shopt -"[su]" "* ]]; then eval "$_nullglob_state"; fi
+	_restore_shopt_state "$_nullglob_state" nullglob
 
 	stop_section_spinner
 
@@ -1795,7 +1805,7 @@ clean_application_support_logs() {
 	if [[ $pipefail_was_set == "true" ]]; then
 		set -o pipefail
 	fi
-	if [[ $_ng_state == "shopt -"[su]" "* ]]; then eval "$_ng_state"; fi
+	_restore_shopt_state "$_ng_state" nullglob
 	stop_section_spinner
 	if [[ $found_any == "true" ]]; then
 		local size_human

--- a/scripts/report-daemons-watchdog.sh
+++ b/scripts/report-daemons-watchdog.sh
@@ -16,7 +16,7 @@ log "start mode=observe-only uid=$(id -u)"
 
 found=0
 for name in ReportCrash ReportCrashService ReportMemoryException; do
-	pids="$(pgrep -x "$name" 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)"
+	pids="$(pgrep -x -- "$name" 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)"
 	if [[ -n $pids ]]; then
 		log "process=$name pids=$pids action=leave-alone"
 		found=1
@@ -69,7 +69,7 @@ etime_to_seconds() {
 check_stuck() {
 	local name="$1"
 	local pid etime_raw cpu etime_sec role uid
-	for pid in $(pgrep -x "$name" 2>/dev/null); do
+	for pid in $(pgrep -x -- "$name" 2>/dev/null); do
 		# etime = [[dd-]hh:]mm:ss on macOS; %cpu = instantaneous usage
 		read -r etime_raw cpu uid <<<"$(ps -p "$pid" -o etime=,%cpu=,uid= 2>/dev/null)"
 		[[ -n ${etime_raw:-} && -n ${cpu:-} ]] || continue

--- a/tests/test_shell_hardening.sh
+++ b/tests/test_shell_hardening.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCHDOG="$REPO_ROOT/scripts/report-daemons-watchdog.sh"
+APPS_MODULE="$REPO_ROOT/configs/.config/mole/lib/clean/apps.sh"
+USER_MODULE="$REPO_ROOT/configs/.config/mole/lib/clean/user.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/personal-config-shell-hardening.XXXXXX")"
+TEST_HOME="$TEST_ROOT/home"
+MOCK_ENV="$TEST_ROOT/mock-env.sh"
+PGREP_LOG="$TEST_ROOT/pgrep.log"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+mkdir -p "$TEST_HOME"
+
+cat >"$MOCK_ENV" <<'MOCK'
+pgrep() {
+  printf 'pgrep' >>"$PGREP_LOG"
+  local argument
+  for argument in "$@"; do
+    printf ' <%s>' "$argument" >>"$PGREP_LOG"
+  done
+  printf '\n' >>"$PGREP_LOG"
+  return 1
+}
+MOCK
+
+assert_contains() {
+  local expected="$1"
+  local file="$2"
+  grep -Fqx -- "$expected" "$file" || {
+    printf 'expected line not found: %s\n' "$expected" >&2
+    cat "$file" >&2
+    exit 1
+  }
+}
+
+assert_shopt_state_restoration() {
+  local module="$1"
+  local marker="$TEST_ROOT/should-not-exist"
+  HOME="$TEST_HOME" bash -c '
+    set -euo pipefail
+    source "$1"
+    shopt -u nullglob dotglob
+    _restore_shopt_state "shopt -s nullglob" nullglob
+    shopt -q nullglob
+    _restore_shopt_state "shopt -s dotglob" dotglob
+    shopt -q dotglob
+    _restore_shopt_state "shopt -u nullglob" nullglob
+    ! shopt -q nullglob
+    _restore_shopt_state "shopt -u dotglob" dotglob
+    ! shopt -q dotglob
+    _restore_shopt_state "shopt -s nullglob; touch $2" nullglob
+    [[ ! -e $2 ]]
+    _restore_shopt_state "shopt -s extglob" nullglob
+    ! shopt -q nullglob
+  ' bash "$module" "$marker"
+}
+
+assert_shopt_state_restoration "$APPS_MODULE"
+assert_shopt_state_restoration "$USER_MODULE"
+
+PGREP_LOG="$PGREP_LOG" HOME="$TEST_HOME" BASH_ENV="$MOCK_ENV" bash -c '
+  source "$1"
+  check_stuck --leading-dash-process
+' bash "$WATCHDOG"
+
+assert_contains 'pgrep <-x> <--> <ReportCrash>' "$PGREP_LOG"
+assert_contains 'pgrep <-x> <--> <ReportCrashService>' "$PGREP_LOG"
+assert_contains 'pgrep <-x> <--> <ReportMemoryException>' "$PGREP_LOG"
+assert_contains 'pgrep <-x> <--> <--leading-dash-process>' "$PGREP_LOG"
+
+printf 'PASS: shell hardening regressions\n'


### PR DESCRIPTION
## Scope

This draft combines the two explicitly approved, narrowly scoped shell-hardening changes that overlap the remaining work from #1989, #2000, and #2007. It leaves all original PRs open and does not supersede or close them.

- `scripts/report-daemons-watchdog.sh` now invokes `pgrep -x -- "$name"` at both call sites, including the alert-only stuck-process loop.
- The `apps.sh` and `user.sh` cleanup modules replace `eval`-based `shopt` restoration with a validated array parser. It accepts only `shopt -s|-u <the expected nullglob|dotglob option>` and calls the builtin directly. Malformed or injected strings are ignored.

## Regression coverage

`tests/test_shell_hardening.sh` uses a temporary `HOME` and a mocked `pgrep` implementation. It verifies exact `-x --` argument ordering, including a leading-dash process value, verifies restoration of both enabled and disabled `nullglob` and `dotglob` states, and proves injected restoration input does not execute.

## Verification

- `tests/test_shell_hardening.sh` passed.
- `bash -n` passed for all changed shell scripts and the test.
- `make test-quick` passed.
- `make test` ran the complete shell suite. The new regression passed; two unrelated existing failures remained in `test_controld_manager.sh` and `test_media_server_env_vars.sh`, with three documented platform skips.

This remains a draft pending human security review.
