### PR TITLE
🎨 Palette: Add native HTML meter to total warnings card

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -530,3 +530,8 @@ with potentially missing data, always conditionally render a dedicated
 to communicate the absence of data clearly and beautifully.
 
 >>>>>>> Stashed changes
+
+## 2026-08-19 - Native HTML Meter for Data Visualization
+
+**Learning:** Generating HTML dashboards with native HTML5 `<meter>` elements provides semantic, accessible data visualization for scalar values. Missing these on certain metric cards creates inconsistency and poor UX.
+**Action:** Ensure all similar metric cards use the native HTML5 `<meter>` element with appropriate attributes (`min`, `max`, `low`, `high`, `optimum`, and `aria-label`) for accessible and consistent visual representation of scalar metrics.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -483,7 +483,10 @@ EOF
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
             </li>
             <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
-                <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
+                <div class="metric-value" id="total-warnings-value">
+                    ${total_warnings}
+                    <meter value="${total_warnings}" min="0" max="10" low="1" high="4" optimum="0" aria-label="Total Warnings: ${total_warnings}"></meter>
+                </div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
             </li>
 EOF


### PR DESCRIPTION
* 💡 What: Added a native HTML5 `<meter>` element to the "Total Warnings" metric card in the generated analytics dashboard.
* 🎯 Why: To provide a consistent, accessible visual representation of scalar measurements across all metric cards and improve user comprehension of the warnings metric relative to defined thresholds.
* 📸 Before/After: See attached screenshot of the dashboard rendering properly.
* ♿ Accessibility: Uses the native HTML5 `<meter>` element and includes an appropriate `aria-label` attribute (`aria-label="Total Warnings: ${total_warnings}"`) for screen readers.

---
*PR created automatically by Jules for task [792338167732674989](https://jules.google.com/task/792338167732674989) started by @abhimehro*