### PR TITLE
🎨 Palette: Add `<meter>` for rain probability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -530,3 +530,8 @@ with potentially missing data, always conditionally render a dedicated
 to communicate the absence of data clearly and beautifully.
 
 >>>>>>> Stashed changes
+
+## 2026-08-27 - Use <meter> for numeric scalar metrics
+
+**Learning:** Displaying raw percentages or numerical counts in text (e.g., "Rain: 30%") lacks visual context and requires users to parse the text to gauge its relative impact, degrading accessibility.
+**Action:** When generating HTML reports with numeric scalar metrics (like counts, scores, or percentages), use native HTML5 `<meter>` elements with appropriate `min`, `max`, `low`, `high`, `optimum`, and `aria-label` attributes to provide semantic and visual context.

--- a/scripts/morning-brief/morning-brief.py
+++ b/scripts/morning-brief/morning-brief.py
@@ -1376,7 +1376,7 @@ def render_greeting_section(weather: WeatherSnapshot, greeting_paragraph: str) -
         f"<div><strong>Baton Rouge Weather:</strong> "
         f"{sanitize_text(weather.high_temp)}°F High / "
         f"{sanitize_text(weather.current_temp)}°F Current "
-        f"(Rain: {sanitize_text(weather.rain_probability)}%)</div>"
+        f'(Rain: <meter aria-label="Rain Probability" min="0" max="100" low="30" high="70" optimum="0" value="{sanitize_text(weather.rain_probability)}">{sanitize_text(weather.rain_probability)}%</meter>)</div>'
     )
     return html_section("🌅 Good Morning, Abhi", body)
 


### PR DESCRIPTION
* 💡 What: Use semantic `<meter>` element for rain probability metric.
* 🎯 Why: Improves accessibility and provides visual context for the rain probability metric.
* 📸 Before/After: Replaced text representation with `<meter>` element.
* ♿ Accessibility: Adds ARIA labels and semantic structure for screen readers.

---
*PR created automatically by Jules for task [11360188604900639527](https://jules.google.com/task/11360188604900639527) started by @abhimehro*