### PR TITLE
🎨 Palette: Add visual gauge for Total Warnings metric

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -530,3 +530,7 @@ with potentially missing data, always conditionally render a dedicated
 to communicate the absence of data clearly and beautifully.
 
 >>>>>>> Stashed changes
+## $(date +%Y-%m-%d) - Native HTML Meter for Scalar Data Visualizations
+
+**Learning:** Shell scripts that generate static HTML reports often neglect data visualization, opting to display scalar measurements (like performance scores, disk usage, or warning counts) as plain text within metric cards. This approach is visually dull and misses an opportunity for accessible, semantic data representation.
+**Action:** Always use the native HTML5 `<meter>` element to provide semantic, accessible visual gauges for scalar data in generated HTML reports. Ensure you include appropriate `aria-label`, `min`, `max`, `low`, `high`, and `optimum` attributes to provide full context to screen readers and clear visual feedback to users.

--- a/maintenance/bin/analytics_dashboard.sh
+++ b/maintenance/bin/analytics_dashboard.sh
@@ -483,7 +483,10 @@ EOF
                 <div class="metric-label" id="disk-usage-label">Disk Usage</div>
             </li>
             <li class="metric-card $([ "${total_warnings:-0}" -gt 3 ] && echo "warning" || echo "success")" aria-labelledby="total-warnings-label total-warnings-value">
-                <div class="metric-value" id="total-warnings-value">${total_warnings}</div>
+                <div class="metric-value" id="total-warnings-value">
+                    ${total_warnings}
+                    <meter value="${total_warnings}" min="0" max="10" low="2" high="4" optimum="0" aria-label="Total Warnings: ${total_warnings}"></meter>
+                </div>
                 <div class="metric-label" id="total-warnings-label">Total Warnings</div>
             </li>
 EOF


### PR DESCRIPTION
* 💡 What: Added a native HTML `<meter>` element to the "Total Warnings" metric card in the generated analytics dashboard.
* 🎯 Why: To provide a visual gauge for warning counts rather than just plain text, making it easier for users to understand system health at a glance.
* 📸 Before/After: Before: Plain text number for warnings. After: A semantic gauge bar accompanying the number.
* ♿ Accessibility: Improved screen reader context by using the semantic HTML5 `<meter>` element with appropriate `min`, `max`, `low`, `high`, `optimum`, and `aria-label` attributes.

---
*PR created automatically by Jules for task [3961742590475511456](https://jules.google.com/task/3961742590475511456) started by @abhimehro*